### PR TITLE
Add another way to build Docker ivre/base image (using pip & PyPI)

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -82,6 +82,10 @@ that, from the `docker/` directory, run:
 
 This might take a long time.
 
+### Alternative builds for the base image ###
+
+#### Local archive ####
+
 It is also possible to build the `ivre/base` image without fetching
 the *tarball* from GitHub, by creating it locally and using the
 `base-local` directory instead of `base`. From the repository root,
@@ -89,7 +93,19 @@ run:
 
     $ git archive --format=tar --prefix=ivre/ HEAD -o docker/base-local/ivre.tar
     $ cd docker
+    $ docker pull debian:testing
     $ docker build -t ivre/base base-local
+
+#### Using pip ####
+
+Another way to create the `ivre/base` image is to use
+[pip](https://pypi.python.org/pypi/pip) and thus get IVRE from
+[PyPI](https://pypi.python.org), the Python Package Index. Please note
+that the version of IVRE on PyPI is not always up-to-date. From the
+`docker/` directory, run:
+
+    $ docker pull debian:testing
+    $ docker build -t ivre/base base-pip
 
 ## Running ##
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -19,11 +19,12 @@ The installation of [IVRE](README.md) itself can be done by:
   * using the `setup.py` (classical `./setup.py build; sudo ./setup.py
     install`) script.
 
-  * using the `pip` command: with on a Debian-based system for example,
-    install the packages `python-pip` and `python-dev` (needed to
-    build dependencies) and run `pip install ivre` (this will download
-    and install for you IVRE and its Python dependencies from
-    [PyPI](https://pypi.python.org), the Python Package Index).
+  * using [pip](https://pypi.python.org/pypi/pip): with on a
+    Debian-based system for example, install the packages `python-pip`
+    and `python-dev` (needed to build dependencies) and run `pip
+    install ivre` (this will download and install for you IVRE and its
+    Python dependencies from [PyPI](https://pypi.python.org), the
+    Python Package Index).
 
   * building an RPM package (you can use the provided `buildrpm`
     script, or use the `setup.py` script with your own options) and

--- a/docker/base-pip/Dockerfile
+++ b/docker/base-pip/Dockerfile
@@ -1,0 +1,29 @@
+# This file is part of IVRE.
+# Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+#
+# IVRE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IVRE is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+
+FROM debian:testing
+MAINTAINER Pierre LALET <pierre.lalet@cea.fr>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install pip, get IVRE, uninstall pip
+RUN apt-get -q update
+RUN apt-get -qy install python python-dev python-pip && \
+    pip install ivre && \
+    apt-get -qy autoremove python-dev python-pip
+
+# Config
+ADD ivre.conf /etc/ivre.conf

--- a/docker/base-pip/ivre.conf
+++ b/docker/base-pip/ivre.conf
@@ -1,0 +1,1 @@
+DB = "mongodb://ivredb/"

--- a/web/dokuwiki/doc/docker.txt
+++ b/web/dokuwiki/doc/docker.txt
@@ -54,11 +54,22 @@ $ for img in agent base client db web ; do
 > done</code>
 This might take a long time.
 
+==== Alternative builds for the base image ====
+
+=== Local archive ===
+
 It is also possible to build the ''%%ivre/base%%'' image without fetching the //tarball// from GitHub, by creating it locally and using the ''%%base-local%%'' directory instead of ''%%base%%''. From the repository root, run:
 
 <code>$ git archive --format=tar --prefix=ivre/ HEAD -o docker/base-local/ivre.tar
 $ cd docker
+$ docker pull debian:testing
 $ docker build -t ivre/base base-local</code>
+=== Using pip ===
+
+Another way to create the ''%%ivre/base%%'' image is to use [[https://pypi.python.org/pypi/pip|pip]] and thus get IVRE from [[https://pypi.python.org|PyPI]], the Python Package Index. Please note that the version of IVRE on PyPI is not always up-to-date. From the ''%%docker/%%'' directory, run:
+
+<code>$ docker pull debian:testing
+$ docker build -t ivre/base base-pip</code>
 ===== Running =====
 
 ==== The database server ====

--- a/web/dokuwiki/doc/install.txt
+++ b/web/dokuwiki/doc/install.txt
@@ -13,7 +13,7 @@ Follow the [[http://docs.mongodb.org/manual/installation/|documentation from Mon
 The installation of [[doc:README|IVRE]] itself can be done by:
 
   * using the ''%%setup.py%%'' (classical ''%%./setup.py build; sudo ./setup.py install%%'') script.
-  * using the ''%%pip%%'' command: with on a Debian-based system for example, install the packages ''%%python-pip%%'' and ''%%python-dev%%'' (needed to build dependencies) and run ''%%pip install ivre%%'' (this will download and install for you IVRE and its Python dependencies from [[https://pypi.python.org|PyPI]], the Python Package Index).
+  * using [[https://pypi.python.org/pypi/pip|pip]]: with on a Debian-based system for example, install the packages ''%%python-pip%%'' and ''%%python-dev%%'' (needed to build dependencies) and run ''%%pip install ivre%%'' (this will download and install for you IVRE and its Python dependencies from [[https://pypi.python.org|PyPI]], the Python Package Index).
   * building an RPM package (you can use the provided ''%%buildrpm%%'' script, or use the ''%%setup.py%%'' script with your own options) and then installing it.
   * using [[doc:DOCKER|Docker]] (in this case you do not need to follow the following instructions, as the Docker containers are already configured).
 


### PR DESCRIPTION
This PR adds a third option to build the `ivre/base` Docker image. For now, this image can be built using a tarball either downloaded from Github or generated locally. With this PR, it is possible to use pip to install IVRE from PyPI. 
