### PR TITLE
Add functions to look for open SMB shares

### DIFF
--- a/web/cgi-bin/scanjson.py
+++ b/web/cgi-bin/scanjson.py
@@ -351,6 +351,11 @@ for q in query:
         flt = db.nmap.flt_and(flt, db.nmap.searchsmb(
             **{q[0][4:]: ivre.utils.str2regexp(q[1])})
         )
+    elif q[0] == 'smbshare':
+        flt = db.nmap.flt_and(
+            flt,
+            db.nmap.searchsmbshares(access="" if q[1] is None else q[1]),
+        )
     elif nq == 'torcert':
         flt = db.nmap.flt_and(flt, db.nmap.searchtorcert())
     elif q[0] == 'webfiles':

--- a/web/static/help.js
+++ b/web/static/help.js
@@ -191,6 +191,10 @@ var HELP = {
 	"title": "smb.workgroup:[NetBIOS]",
 	"content": "Search results with SMB service in a specific workgroup (NetBIOS).",
     },
+    "smbshare": {
+	"title": "smbshare<b>(:[access mode])</b>",
+	"content": "Search results with SMB shares with anonymous access. Access can be 'r', 'w' or 'rw' (default is read or write).",
+    },
     "sshkey:": {
 	"title": "sshkey:<b>[fingerprint or base64]</b>",
 	"content": "Look for a particular SSH key, given (part of) its fingerprint or base64 encoded key.",

--- a/web/static/ivre.js
+++ b/web/static/ivre.js
@@ -1279,6 +1279,10 @@ function add_param_objects(p, pp) {
     else if (p.substr(0, 7) === 'cookie:')
 	add_param_object(parametersobjunalias, 'script',
 			 [b, 'http-headers:/Set-Cookie: ' + p.substr(7) + '=/']);
+    else if (p.substr(0, 8) === 'smbshare' && (p.length === 8 ||
+					       p.substr(8, 1) === ':'))
+	add_param_object(parametersobjunalias, 'hostscript',
+			 [b, 'smb-enum-shares:/READ|WRITE|STYPE_DISKTREE/']);
     else if (p.substr(0, 4) === 'smb.') {
 	/*
 	 * smb.* filters are very specific: they rely on the
@@ -2094,7 +2098,8 @@ function set_tooltip_filter(elt) {
 	var matching_keys = Object.keys(HELP).filter(
 	    function(key) {
 		return ((':/'.indexOf(key.slice(-1)) === -1
-			 && key !== 'screenshot') ?
+			 && key !== 'screenshot'
+			 && key !== 'smbshare') ?
 			elt.value === key.substr(0, elt.value.length) :
 			elt.value.substr(0, key.length) === key.substr(0, elt.value.length));
 	    }

--- a/web/static/templates/menu.html
+++ b/web/static/templates/menu.html
@@ -32,7 +32,8 @@
     <li><a class="clickable" onclick="setparam('nfs', undefined, true, true); setparam('display', 'script:nfs-ls', true);">NFS</a></li>
     <li><a class="clickable" onclick="setparam('nis');">NIS / YP</a></li>
     <li><a class="clickable" onclick="setparam('x11srv');">X11</a></li>
-    <li><a class="clickable" onclick="setparam('x11open');">X11 (open)</a></li>
+    <li><a class="clickable" onclick="setparam('x11open');"
+	   >&nbsp;<i class="icon-chevron-right"></i> open</a></li>
   </ul>
 </li>
 
@@ -44,8 +45,11 @@
   <ul class="dropdown-menu">
     <li><a class="clickable" onclick="setparam('xp445');">XP / 445</a></li>
     <li><a class="clickable"
-	   onclick="setparam('hostscript', 'smb-enum-shares:/WRITE/', false, true); setparam('display', 'script:smb-enum-shares', true);"
-	   >Writable shares</a></li>
+	   onclick="setparam('smbshare', undefined, true, true); setparam('display', 'script:smb-enum-shares', true);"
+	   >SMB shares</a></li>
+    <li><a class="clickable"
+	   onclick="setparam('smbshare', 'w', true, true); setparam('display', 'script:smb-enum-shares', true);"
+	   >&nbsp;<i class="icon-chevron-right"></i> writable</a></li>
     <li><a class="clickable"
 	   onclick="setparam('mssqlemptypwd');"
 	   >MS-SQL empty password</li></a>
@@ -129,7 +133,7 @@
 	   onclick="setparam('devicetype', 'webcam');">Webcam</a></li>
     <li><a class="clickable"
 	   onclick="setparam('geovision');"
-	   ><i class="icon-chevron-right"></i> GeoVision</a></li>
+	   >&nbsp;<i class="icon-chevron-right"></i> GeoVision</a></li>
     <li><a class="clickable"
 	   onclick="setparam('netdev');">Network devices</a></li>
     <li><a class="clickable"


### PR DESCRIPTION
This code uses the structured data from `smb-enum-shares.nse` Nmap script.

This requires a recent version of Nmap **and either** to reload the scans from the Nmap XML files **or** to use a script to adapt the results from your DB, like:

```python
def update_smb_enum_shares(archive=False):
    cursor = ivre.db.db.nmap.get(
        ivre.db.db.nmap.searchscript(name='smb-enum-shares', host=True),
        fields=["_id", "scripts"],
        archive=archive,
    )
    collection = ivre.db.db.nmap.colname_oldhosts if archive else ivre.db.db.nmap.colname_hosts
    for host in cursor:
        changed = False
        for script in host['scripts']:
            if script['id'] == 'smb-enum-shares' and 'smb-enum-shares' in script:
                script['smb-enum-shares'] = ivre.xmlnmap.change_smb_enum_shares(script['smb-enum-shares'])
                changed = True
        if changed:
            ivre.db.db.nmap.db[collection].update(
                {'_id': host['_id']},
                {'$set': {
                    'scripts': host['scripts'],
                }}
            )

update_smb_enum_shares()
update_smb_enum_shares(archive=True)
```