### PR TITLE
Add a filter to find hosts with at least one other open port than those specified 

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -763,6 +763,14 @@ have no effect if it is not expected)."""
             'state_state': state
         }}}
 
+    def searchportsother(self, ports, protocol='tcp', state='open'):
+        """Filters records with at least one port other than those
+        listed in `ports` with state `state`.
+
+        """
+        return self.searchport({'$nin': ports}, protocol=protocol,
+                               state=state)
+
     def searchports(self, ports, protocol='tcp', state='open', neg=False):
         return self.flt_and(*(self.searchport(p, protocol=protocol,
                                               state=state, neg=neg)

--- a/web/cgi-bin/scanjson.py
+++ b/web/cgi-bin/scanjson.py
@@ -409,6 +409,9 @@ for q in query:
         flt = db.nmap.flt_and(flt,
                               db.nmap.searchport(port, protocol=proto,
                                                  state=nq))
+    elif nq == 'otheropenport':
+        flt = db.nmap.flt_and(
+            flt, db.nmap.searchportsother(map(int, q[1].split(','))))
     elif nq == "screenshot":
         if q[1] is None:
             flt = db.nmap.flt_and(flt, db.nmap.searchscreenshot(neg=neg))

--- a/web/static/help.js
+++ b/web/static/help.js
@@ -266,6 +266,10 @@ var HELP = {
 	"title": "<b>(!)</b>openport",
 	"content": "Look for hosts with at least one open port.",
     },
+    "otheropenport:": {
+	"title": "otheropenport:<b>[port number](,[port number](,...))</b>",
+	"content": "Look for hosts with at least one open port other than those listed.",
+    },
     "screenshot": {
 	"title": "<b>(!)</b>screenshot<b>(:[port number])</b>",
 	"content": "Search results with at least one screenshot.",


### PR DESCRIPTION
Filter added to MongoDB specific code + WebUI.

This is a feature request from @serpilliere.