### PR TITLE
Parsing CPE (Common Platform Enumeration) strings

### DIFF
--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -199,6 +199,33 @@ def ignore_script(script):
     return False
 
 
+def cpe2dict(cpe_str):
+    """Helper function to parse CPEs. This is a very partial/simple parser."""
+    # Remove prefix
+    if len(cpe_str) < 5 or cpe_str[:5] != "cpe:/":
+        sys.stderr.write("WARNING, invalid cpe format (%s)\n" % cpe_str)
+        return {"value": cpe_str}
+    cpe_body = cpe_str[5:]
+    parts = cpe_body.split(":", 3)
+    l = len(parts)
+    if l < 2:
+        sys.stderr.write("WARNING, invalid cpe format (%s)\n" % cpe_str)
+        return {"value": cpe_str}
+    cpe_type = parts[0]
+    cpe_vend = parts[1]
+    cpe_prod = parts[2] if l > 2 else ""
+    cpe_comp = parts[3] if l > 3 else ""
+
+    ret = {
+        "type": cpe_type,
+        "vendor": cpe_vend,
+        "product": cpe_prod,
+        "components": cpe_comp,
+        "value": cpe_str,
+    }
+    return ret
+
+
 class NoExtResolver(EntityResolver):
 
     """A simple EntityResolver that will prevent any external
@@ -232,6 +259,12 @@ class NmapHandler(ContentHandler):
         self._curhostnames = None
         self._filehash = filehash
         print "READING %r (%r)" % (fname, self._filehash)
+
+    def _pre_addhost(self):
+        """Executed before _addhost for host object post-treatment"""
+        if 'cpes' in self._curhost:
+            cpes = self._curhost['cpes']
+            self._curhost['cpes'] = cpes.values()
 
     def _addhost(self):
         """Subclasses may store self._curhost here."""
@@ -446,6 +479,9 @@ class NmapHandler(ContentHandler):
                 attrsdict['domains'] = list(
                     utils.get_domains(attrsdict['host']))
             self._curtrace['hops'].append(attrsdict)
+        elif name == 'cpe':
+            # start recording
+            self._curdata = ''
 
     def endElement(self, name):
         if name == 'nmaprun':
@@ -454,6 +490,7 @@ class NmapHandler(ContentHandler):
         elif name == 'host':
             if self._curhost['state'] == 'up' and ('ports' in self._curhost
                                                    or not self._needports):
+                self._pre_addhost()
                 self._addhost()
             self._curhost = None
         elif name == 'hostnames':
@@ -533,6 +570,8 @@ class NmapHandler(ContentHandler):
                     lastlevel.append(self._curdata)
                 else:
                     lastlevel[k] = self._curdata
+                if k == 'cpe':
+                    self._add_cpe_to_host()
                 # stop recording characters
                 self._curdata = None
             self._curtablepath.pop()
@@ -542,6 +581,49 @@ class NmapHandler(ContentHandler):
             else:
                 self._curhost['traces'].append(self._curtrace)
             self._curtrace = None
+        elif name == 'cpe':
+            self._add_cpe_to_host()
+
+    def _add_cpe_to_host(self):
+        """Adds the cpe in self._curdata to the host-wide cpe list, taking
+        port/script/osmatch context into account.
+
+        """
+        cpe = self._curdata
+        self._curdata = None
+        path = None
+
+        # What is the path to reach this CPE?
+        if self._curport is not None:
+            if self._curscript is not None and 'id' in self._curscript:
+                # Should not happen, but handle the case anyway
+                path = 'ports{port:%s, scripts.id:%s'\
+                        % (self._curport['port'], self._curscript['id'])
+            else:
+                path = 'ports.port:%s' % self._curport['port']
+            self._curport.setdefault('cpes', []).append(cpe)
+
+        elif self._curscript is not None and 'id' in self._curscript:
+            # Host-wide script
+            path = 'scripts.id:%s' % self._curscript['id']
+
+        elif 'os' in self._curhost and\
+                self._curhost['os'].get('osmatch', []): # Host-wide
+            lastosmatch = self._curhost['os']['osmatch'][-1]
+            line = lastosmatch['line']
+            path = "os.osmatch.line:%s" % line
+            lastosmatch.setdefault('cpes', []).append(cpe)
+
+        # CPEs are indexed in a dictionnary to agglomerate origins,
+        # but this dict is replaced with its values() in _pre_addhost.
+        cpes = self._curhost.setdefault('cpes', {})
+        if cpe not in cpes:
+            cpeobj = cpe2dict(cpe)
+            cpes[cpe] = cpeobj
+        else:
+            cpeobj = cpes[cpe]
+        cpeobj.setdefault('origins', []).append(path)
+
 
     def characters(self, content):
         if self._curdata is not None:

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -202,19 +202,19 @@ def ignore_script(script):
 def cpe2dict(cpe_str):
     """Helper function to parse CPEs. This is a very partial/simple parser."""
     # Remove prefix
-    if len(cpe_str) < 5 or cpe_str[:5] != "cpe:/":
+    if not cpe_str.startswith("cpe:/"):
         sys.stderr.write("WARNING, invalid cpe format (%s)\n" % cpe_str)
         return {"value": cpe_str}
     cpe_body = cpe_str[5:]
     parts = cpe_body.split(":", 3)
-    l = len(parts)
-    if l < 2:
+    nparts = len(parts)
+    if nparts < 2:
         sys.stderr.write("WARNING, invalid cpe format (%s)\n" % cpe_str)
         return {"value": cpe_str}
     cpe_type = parts[0]
     cpe_vend = parts[1]
-    cpe_prod = parts[2] if l > 2 else ""
-    cpe_comp = parts[3] if l > 3 else ""
+    cpe_prod = parts[2] if nparts > 2 else ""
+    cpe_comp = parts[3] if nparts > 3 else ""
 
     ret = {
         "type": cpe_type,

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -597,7 +597,7 @@ class NmapHandler(ContentHandler):
         if self._curport is not None:
             if self._curscript is not None and 'id' in self._curscript:
                 # Should not happen, but handle the case anyway
-                path = 'ports{port:%s, scripts.id:%s'\
+                path = 'ports{port:%s, scripts.id:%s}'\
                         % (self._curport['port'], self._curscript['id'])
             else:
                 path = 'ports.port:%s' % self._curport['port']

--- a/web/static/ivre.css
+++ b/web/static/ivre.css
@@ -183,3 +183,4 @@ form {
 .result-cpe {
     margin: 5px 0px;
 }
+

--- a/web/static/ivre.css
+++ b/web/static/ivre.css
@@ -176,6 +176,8 @@ form {
     padding: 0px 5px;
     margin: -1px 0px -1px -6px;
     background-color: #F5F5F5;
+    word-break: break-all;
+    word-wrap: break-word;
 }
 
 .result-cpe {

--- a/web/static/ivre.css
+++ b/web/static/ivre.css
@@ -170,3 +170,14 @@ form {
     margin: 1%;
     max-width: 98%;
 }
+
+.result-cpe-item {
+    border: 1px solid #ccc;
+    padding: 0px 5px;
+    margin: -1px 0px -1px -6px;
+    background-color: #F5F5F5;
+}
+
+.result-cpe {
+    margin: 5px 0px;
+}

--- a/web/static/ivre.js
+++ b/web/static/ivre.js
@@ -1953,6 +1953,45 @@ ivreWebUi
 	    }
 	    return result;
 	};
+    $scope.get_reshaped_cpes = function(host) {
+        if(host.n_cpes)
+            return host.n_cpes;
+        cpes = host.cpes;
+        n_cpes = {};
+        type2str = {
+            'h': 'Hardware',
+            'o': 'OS',
+            'a': 'Application',
+        };
+        my_setdefault = function(d, key) {
+            if(!("data" in d)) {
+                d.data = {};
+                d.expand = false;
+            }
+            if(key in d.data) {
+                return d.data[key];
+            } else {
+                d.data[key] = {"name":key, "expand": false, "data": {}};
+                return d.data[key];
+            }
+        }
+        for(var i in cpes) {
+            cpe = cpes[i];
+            type = type2str[cpe.type] || "Unknown";
+            type_d = my_setdefault(n_cpes, type);
+            vend_d = my_setdefault(type_d, cpe.vendor);
+            prod_d = my_setdefault(vend_d, cpe.product);
+            comp_d = my_setdefault(prod_d, cpe.components);
+            comp_d.origins || (comp_d.origins = []);
+            comp_d.origins = comp_d.origins.concat(cpe.origins);
+            comp_d.value = cpe.value;
+        }
+        host.n_cpes = n_cpes;
+        return host.n_cpes;
+    };
+    $scope.toggle_expand = function(treenode) {
+        treenode.expand = !treenode.expand;
+    };
     })
     .directive('displayHost', function() {
 	return {

--- a/web/static/ivre.js
+++ b/web/static/ivre.js
@@ -1599,6 +1599,33 @@ function get_scope(controller) {
 	)).scope();
 }
 
+// Popover directive
+
+ivreWebUi.directive('popover', function(){
+    return {
+        restrict: 'A',
+        link: function(scope, element, attrs){
+            $(element).click(function(){
+                e.lement.preventDefault();
+            });
+            $(element).hover(function(){
+                // on mouseenter
+                $(element).popover('show').on("mouseleave", function () {
+                var _this = this;
+                todo = function () {
+                    if (!$(".popover:hover").length) {
+                        $(_this).popover("hide");
+                    } else {
+                        setTimeout(todo, 100);
+                    }
+                };
+                setTimeout(todo, 10);
+            });
+            }, function(){});
+        }
+    };
+});
+
 // The Web UI display controller
 
 ivreWebUi
@@ -1959,9 +1986,9 @@ ivreWebUi
         cpes = host.cpes;
         n_cpes = {};
         type2str = {
-            'h': 'Hardware',
+            'h': 'Hw',
             'o': 'OS',
-            'a': 'Application',
+            'a': 'App',
         };
         my_setdefault = function(d, key) {
             if(!("data" in d)) {
@@ -1985,6 +2012,8 @@ ivreWebUi
             comp_d.origins || (comp_d.origins = []);
             comp_d.origins = comp_d.origins.concat(cpe.origins);
             comp_d.value = cpe.value;
+            comp_d.tooltitle = cpe.value;
+            comp_d.toolcontent = cpe.origins.join('<br/>');
         }
         host.n_cpes = n_cpes;
         return host.n_cpes;

--- a/web/static/templates/view-hosts.html
+++ b/web/static/templates/view-hosts.html
@@ -131,20 +131,20 @@
       <div class="span1">{{type.name}}</div>
       <div class="span11">
         <div class="row-fluid result-cpe-item" ng-repeat="vendor in type.data">
-          <div class="span4"><i ng-if="!vendor.name">Empty</i>{{vendor.name}}</div>
-          <div class="span8">
+          <div class="span3"><i ng-if="!vendor.name">Empty</i>{{vendor.name}}</div>
+          <div class="span9">
             <div class="row-fluid result-cpe-item" ng-repeat="product in vendor.data">
-              <div class="span6"><i ng-if="!product.name">Empty</i>{{product.name}}</div>
-              <div class="span6">
+              <div class="span7"><i ng-if="!product.name">Empty</i>{{product.name}}</div>
+              <div class="span5">
                 <div class="row-fluid result-cpe-item" ng-repeat="comp in product.data">
                   <div class="span12">
                     <a
                      data-html="true"
-                     class="clickable"
                      data-title="{{comp.tooltitle}}"
                      data-content="{{comp.toolcontent}}"
                      popover>
-                      <i ng-if="!comp.name">Empty</i>{{comp.name}}</a></div>
+                      <i ng-if="!comp.name">Empty</i>{{comp.name}}</a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/web/static/templates/view-hosts.html
+++ b/web/static/templates/view-hosts.html
@@ -123,5 +123,34 @@
       accuracy = {{osclass.accuracy}}
     </div>
   </dd>
-</div>
+  <dt class="result-cpe" ng-if="host.cpes">
+    CPE (Common Platform Enumeration)
+  </dt>
+  <div class="container-fluid" ng-if="host.cpes">
+    <div class="row-fluid result-cpe-item" ng-repeat="type in get_reshaped_cpes(host).data">
+      <div class="span1">{{type.name}}</div>
+      <div class="span11">
+        <div class="row-fluid result-cpe-item" ng-repeat="vendor in type.data">
+          <div class="span4"><i ng-if="!vendor.name">Empty</i>{{vendor.name}}</div>
+          <div class="span8">
+            <div class="row-fluid result-cpe-item" ng-repeat="product in vendor.data">
+              <div class="span6"><i ng-if="!product.name">Empty</i>{{product.name}}</div>
+              <div class="span6">
+                <div class="row-fluid result-cpe-item" ng-repeat="comp in product.data">
+                  <div class="span12">
+                    <a
+                     data-html="true"
+                     class="clickable"
+                     data-title="{{comp.tooltitle}}"
+                     data-content="{{comp.toolcontent}}"
+                     popover>
+                      <i ng-if="!comp.name">Empty</i>{{comp.name}}</a></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
This PR adds a basic support of CPE (Common Platform Enumeration) returned by some nmap components (osmatch, scripts or port information).

- `xmlnmap.py` now parses CPE information: any cpe is added to to the element that found it, for example:
```
[...]
    ports: [
            {
                "service_method": "probed",
                "state_reason": "syn-ack",
                "state_reason_ttl": 119,
                "protocol": "tcp",
                "service_name": "msrpc",
                "state_state": "open",
                "cpes": [
                    "cpe:/o:microsoft:windows"
                ],
                "service_product": "Microsoft Windows RPC",
                "service_conf": 10,
                "service_ostype": "Windows",
                "port": 135
            },
[...]
            "osmatch": [
                {
                    "line": "59470",
                    "cpes": [
                        "cpe:/o:microsoft:windows_7::-",
                        "cpe:/o:microsoft:windows_7::sp1",
                        "cpe:/o:microsoft:windows_server_2008::sp1",
                        "cpe:/o:microsoft:windows_8"
                    ],
                    "name": "Microsoft Windows 7 SP0 - SP1, Windows Server 2008 SP1, or Windows 8",
                    "accuracy": "100"
                }
            ],
[...]
```

This information is also parsed and aggregated at the host level:
```
        "cpes": [
            {
                "product": "windows_server_2008",
                "vendor": "microsoft",
                "origins": [
                    "os.osmatch.line:59470"
                ],
                "value": "cpe:/o:microsoft:windows_server_2008::sp1",
                "components": ":sp1",
                "type": "o"
            },
            {
                "product": "windows",
                "vendor": "microsoft",
                "origins": [
                    "ports.port:135",
                    "ports.port:2103",
                    "ports.port:2105",
                    "ports.port:2107",
                    "ports.port:49152",
                    "ports.port:49153",
                    "ports.port:49154",
                    "ports.port:49155",
                    "ports.port:49156"
                ],
                "value": "cpe:/o:microsoft:windows",
                "components": "",
                "type": "o"
            },
[...]
        ]
```
This parsing is very simple, and do not cover the full CPE specification, only examples found in nmap xml scan results.
- This PR also includes some UI additions to diplay this information nicely.

Further improvements can include :
- Only keeping the most precise CPEs (eliminating CPEs that are a substring of other ones).
- Adding a `cpe:` request type.
- Linking CPEs with CVE databases (for example using [vFeed](https://github.com/toolswatch/vFeed)).