### PR TITLE
WebUI: add display:cpe filter

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -343,6 +343,7 @@ web/static/templates/progressbar.html
 web/static/templates/subview-host-summary.html
 web/static/templates/subview-port-summary.html
 web/static/templates/subview-service-summary.html
+web/static/templates/view-cpes-only.html
 web/static/templates/view-hosts.html
 web/static/templates/view-screenshots-only.html
 web/static/templates/view-scripts-only.html

--- a/doc/WEBUI.md
+++ b/doc/WEBUI.md
@@ -225,5 +225,7 @@ single or double quotes.
 ### Display ###
 
   - `display:host` set the default display mode.
+  - `display:cpe` only display CPEs.
   - `display:script:[scriptid]` only display a particular script
     output.
+  - `display:screenshot` only display screenshots.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # This file is part of IVRE.
-# Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 
 """
 This module is part of IVRE.
-Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
 
 Standard setup.py file. Run
 
@@ -78,6 +78,7 @@ setup(
          ['web/static/templates/filters.html',
           'web/static/templates/menu.html',
           'web/static/templates/progressbar.html',
+          'web/static/templates/view-cpes-only.html',
           'web/static/templates/view-hosts.html',
           'web/static/templates/view-screenshots-only.html',
           'web/static/templates/view-scripts-only.html',

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -146,5 +146,7 @@ If your command includes spaces, you need to protect it by using single or doubl
 ==== Display ====
 
   * ''%%display:host%%'' set the default display mode.
+  * ''%%display:cpe%%'' only display CPEs.
   * ''%%display:script:[scriptid]%%'' only display a particular script output.
+  * ''%%display:screenshot%%'' only display screenshots.
 

--- a/web/static/help.js
+++ b/web/static/help.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of IVRE.
- * Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+ * Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
  *
  * IVRE is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -303,6 +303,10 @@ var HELP = {
     "display:screenshot": {
 	"title": "display:screenshot",
 	"content": "Display only screenshots.",
+    },
+    "display:cpe": {
+	"title": "display:cpe",
+	"content": "Display only CPEs.",
     },
 };
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2,7 +2,7 @@
 
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+  Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -79,6 +79,7 @@
 	     ng-switch="display_mode">
 	  <div ng-switch-when="script" display-script=""></div>
 	  <div ng-switch-when="screenshot" display-screenshot=""></div>
+	  <div ng-switch-when="cpe" display-cpe=""></div>
 	  <div ng-switch-default="host" display-host=""></div>
 	</div>
 	<div id="notes-container" class="span5"

--- a/web/static/ivre.js
+++ b/web/static/ivre.js
@@ -2037,6 +2037,11 @@ ivreWebUi
 	    templateUrl: 'templates/view-screenshots-only.html'
 	};
     })
+    .directive('displayCpe', function() {
+	return {
+	    templateUrl: 'templates/view-cpes-only.html'
+	};
+    })
     .directive('hostSummary', function() {
 	return {
 	    templateUrl: 'templates/subview-host-summary.html'

--- a/web/static/templates/view-cpes-only.html
+++ b/web/static/templates/view-cpes-only.html
@@ -1,0 +1,91 @@
+<!--
+  This file is part of IVRE.
+  Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
+
+  IVRE is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  IVRE is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="result-container"
+     ng-repeat="host in results"
+     >
+  <div host-summary=""></div>
+  <div class="full">
+    <table>
+      <tr ng-repeat="summary in host.port_summary | orderBy: 'status'">
+	<td>
+	  <span>
+	    {{summary.count}} port{{summary.count > 1 && "s" || ""}}
+	  </span>
+	</td>
+	<td>
+	  <span class="label label-status"
+		ng-class="class_from_port_status(summary.status)">
+	    {{short_port_status(summary.status) | uppercase}}
+	  </span>
+	</td>
+	<td>
+	  <span ng-if="summary.type == 'extra'"
+		ng-repeat="(reason, count) in summary.reasons">
+	    {{count}} {{reason}}<span ng-if="!$last">, </span></span>
+	  <span ng-if="summary.type == 'ports'"
+		ng-repeat="port in summary.ports | orderBy: ['protocol','port']"
+		><!--
+         --><a ng-click="setparam(port.protocol+'/'+port.port)" class="clickable">
+	      {{port.protocol}}/{{port.port}}</a><span ng-if="!$last">, </span>
+	  </span>
+	</td>
+      </tr>
+    </table>
+    <dt class="result-cpe" ng-if="host.cpes">
+      CPE (Common Platform Enumeration)
+    </dt>
+    <dd>
+      <div class="container-fluid" ng-if="host.cpes">
+	<div class="row-fluid result-cpe-item"
+	     ng-repeat="type in get_reshaped_cpes(host).data">
+	  <div class="span1">{{type.name}}</div>
+	  <div class="span11">
+            <div class="row-fluid result-cpe-item"
+		 ng-repeat="vendor in type.data">
+              <div class="span3">
+		<i ng-if="!vendor.name">Empty</i>{{vendor.name}}
+	      </div>
+              <div class="span9">
+		<div class="row-fluid result-cpe-item"
+		     ng-repeat="product in vendor.data">
+		  <div class="span7">
+		    <i ng-if="!product.name">Empty</i>{{product.name}}
+		  </div>
+		  <div class="span5">
+                    <div class="row-fluid result-cpe-item"
+			 ng-repeat="comp in product.data">
+                      <div class="span12">
+			<a data-html="true"
+			   data-title="{{comp.tooltitle}}"
+			   data-content="{{comp.toolcontent}}"
+			   popover>
+			  <i ng-if="!comp.name">Empty</i>{{comp.name}}
+			</a>
+                      </div>
+                    </div>
+		  </div>
+		</div>
+              </div>
+            </div>
+	  </div>
+	</div>
+      </div>
+    </dd>
+  </div>
+</div>


### PR DESCRIPTION
After PR #31, this adds a filter `display:cpe` to the Web UI to only display the CPE results.