### PR TITLE
"screenwords" improvements

### DIFF
--- a/bin/httpd-ivre
+++ b/bin/httpd-ivre
@@ -3,7 +3,7 @@
 
 # This program is part of IVRE.
 #
-# Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -18,9 +18,6 @@
 # along with IVRE. If not, see <http://www.gnu.org/licenses/>.
 
 """
-This program is part of IVRE.
-Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
-
 This program runs a simple httpd server to provide an out-of-the-box
 access to the web user interface.
 
@@ -29,7 +26,7 @@ deployments should use "real" web servers (IVRE has been successfully
 tested with both Apache and Nginx).
 """
 
-from ivre import utils
+from ivre import config
 
 import os
 
@@ -87,9 +84,9 @@ def parse_args():
 def main():
     """This function is called when __name__ == "__main__"."""
     global BASEDIR, CGIDIR, DOKUWIKIDIR
-    BASEDIR = utils.guess_prefix(directory='web/static')
-    CGIDIR = utils.guess_prefix(directory='web/cgi-bin')
-    DOKUWIKIDIR = utils.guess_prefix(directory='dokuwiki')
+    BASEDIR = config.guess_prefix(directory='web/static')
+    CGIDIR = config.guess_prefix(directory='web/cgi-bin')
+    DOKUWIKIDIR = config.guess_prefix(directory='dokuwiki')
     if BASEDIR is None or CGIDIR is None or DOKUWIKIDIR is None:
         raise Exception('Cannot find where IVRE is installed')
     args = parse_args()

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -460,7 +460,8 @@ have no effect if it is not expected)."""
             **kargs
         )
 
-    def getscreenshot(self, port):
+    @staticmethod
+    def getscreenshot(port):
         """Returns the content of a port's screenshot."""
         url = port.get('screenshot')
         if url is None:

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -1784,6 +1784,7 @@ have no effect if it is not expected)."""
             field = 'ports.scripts.enip-info.' + subfield
         elif field == 'screenwords':
             field = 'ports.screenwords'
+            flt = self.flt_and(flt, self.searchscreenshot(words=True))
         elif field == 'hop':
             field = 'traces.hops.ipaddr'
             outputproc = lambda x: {'count': x['count'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -565,7 +565,7 @@ class IvreTests(unittest.TestCase):
             broprocess = subprocess.Popen(
                 ['bro', '-b', '-r', fname,
                  os.path.join(
-                     ivre.utils.guess_prefix('passiverecon'),
+                     ivre.config.guess_prefix('passiverecon'),
                      'passiverecon.bro')],
                 env=broenv)
             broprocess.wait()
@@ -705,8 +705,8 @@ class IvreTests(unittest.TestCase):
     def test_utils(self):
         """Functions that have not yet been tested"""
 
-        self.assertIsNotNone(ivre.utils.guess_prefix())
-        self.assertIsNone(ivre.utils.guess_prefix("inexistant"))
+        self.assertIsNotNone(ivre.config.guess_prefix())
+        self.assertIsNone(ivre.config.guess_prefix("inexistant"))
 
         # IP addresses manipulation utils
         with self.assertRaises(ValueError):


### PR DESCRIPTION
A new method `.setscreenwords()` have been added to run `tesseract` against an already inserted screenshot.

The code calling `tesseract` has been moved from `ivre.db.mondo` (...) to `ivre.utils`.

A filter has been added when asking for `.topvalues("screenwords")` to make it faster.