### PR TITLE
Responsive graph

### DIFF
--- a/web/static/ivre/graph.js
+++ b/web/static/ivre/graph.js
@@ -16,6 +16,10 @@
  * along with IVRE. If not, see <http://www.gnu.org/licenses/>.
  */
 
+/************* Graphing constants **************/
+
+MAPRATIO = 250 / 500;
+
 /************* Graphing utilities **************/
 
 
@@ -228,8 +232,8 @@ function build_chart_plane(chart, ips) {
 }
 
 function build_chart_map(chart, locs, fullworld) {
-    var w = 550,
-    h = 300;
+    var w = $('#' + chart).width(),
+    h = w * MAPRATIO;
 
     document.getElementById("chartstitle").innerHTML = "Map";
     var vis = d3.select("#"+chart).append("svg")
@@ -633,7 +637,7 @@ function build_chart_ports(chart, ips) {
 }
 
 function build_chart(chart, field, dataset) {
-    var w = 540,
+    var w = $("#" + chart).width() - 20,
     h = 30 * dataset.length,
     //labelpad = 60,
     labelpad = 10 + d3.max(dataset, function(t) {

--- a/web/static/ivre/graph.js
+++ b/web/static/ivre/graph.js
@@ -877,7 +877,10 @@ function build_chart(chart, field, dataset) {
 	.attr("transform", function(d, i) {
 	    return "translate(" + labelpad + "," + y(i) + ")";
 	});
-    
+
+    colorBg = $("#" + chart).getBg();
+    colorFg = getComputedStyle($("#" + chart)[0]).color;
+
     var bar = bars.append("svg:rect")
 	//.attr("fill", "steelblue")
 	.attr("fill", function(d, i) { return color[i % color.length]; })
@@ -903,12 +906,17 @@ function build_chart(chart, field, dataset) {
 	.attr("y", y.rangeBand() / 2)
 	.attr("dy", ".35em")
 	.attr("text-anchor", "end")
-	.text(function(d) {return d;});
+	.text(function(d) {return d;})
+	.attr("fill", colorFg);
     
     bars.append("svg:text")
 	.attr("x", function(d, i) {
 	    return x(d, i) + (x(d, i) < (w-10)/2 ? 10 : -10);
 	})
+	.attr("fill", function(d, i) {
+	    return x(d, i) < (w - 10) / 2 ? colorFg : colorBg;
+	})
+	.attr("font-weight", "bold")
 	.attr("y", y.rangeBand() / 2)
 	.attr("dy", ".35em")
 	.attr("text-anchor", function(d, i) {

--- a/web/static/ivre/utils.js
+++ b/web/static/ivre/utils.js
@@ -153,3 +153,14 @@ function changefav(href) {
 	document.head.removeChild(oldfav);
     document.head.appendChild(fav);
 }
+
+jQuery.fn.getBg = function() {
+    // Get the real computed background color (!= getComputedStyle)
+    return $(this).parents().filter(function() {
+
+	var color = $(this).css('background-color');
+
+	if(color != 'transparent' && color != 'rgba(0, 0, 0, 0)' && color != undefined) 
+	    return color;
+    }).css('background-color');
+};


### PR DESCRIPTION
This PR (try to) enhances the responsiveness of top values graphs and chart maps, by:
* Removing arbitrary size (and using whole available space)
* Using background color for element inside histogram
* Render values in bold

Before:
![before](https://cloud.githubusercontent.com/assets/4194483/8479506/8e4b74fe-20d8-11e5-88e0-f3a3bbddf70c.png)

After:
![after](https://cloud.githubusercontent.com/assets/4194483/8479511/93689282-20d8-11e5-9f58-2b840fad3ef7.png)

With another background and custom colors:
![bgcolor](https://cloud.githubusercontent.com/assets/4194483/8479553/d11c906a-20d8-11e5-9e97-70fe4473cb35.png)
