### PR TITLE
Reactive web

### DIFF
--- a/web/static/ivre/ivre.css
+++ b/web/static/ivre/ivre.css
@@ -133,10 +133,6 @@ form {
     margin-bottom: 10px;
 }
 
-.result-hidden-part {
-    display: none;
-}
-
 .summary > table > tbody > tr > td {
     padding-right: 10px;
     white-space: nowrap;

--- a/web/static/templates/subview-port-summary.html
+++ b/web/static/templates/subview-port-summary.html
@@ -18,20 +18,20 @@
 
 <a class="clickable"
    ng-click="setparam(port.protocol + '/' + port.port)"
-   >{{port.protocol}}/{{port.port}}</a>
+   >{{::port.protocol}}/{{::port.port}}</a>
 <span class="label label-status"
       ng-class="class_from_port_status(port.state_state)">
-  {{port.state_state | uppercase}}
+  {{::port.state_state | uppercase}}
 </span>
-<span class="dtnormal" title="ttl: {{port.state_reason_ttl}}">
-  {{port.state_reason}}
+<span class="dtnormal" title="ttl: {{::port.state_reason_ttl}}">
+  {{::port.state_reason}}
 </span>
 <span class="dtnormal result-url" title="URL">
   <code>
-    {{url_from_port(port, host.addr)}}
+    {{::url_from_port(port, host.addr)}}
   </code>
 </span>
 <img ng-if="port.screenshot == 'field'"
-     src="data:image/jpeg;base64,{{port.screendata}}"
+     src="data:image/jpeg;base64,{{::port.screendata}}"
      class="screenshot"
-     alt="Screenshot for port {{port.port}}"/>
+     alt="Screenshot for port {{::port.port}}"/>

--- a/web/static/templates/subview-ports-summary.html
+++ b/web/static/templates/subview-ports-summary.html
@@ -20,24 +20,24 @@
   <tr ng-repeat="summary in host.port_summary | orderBy: 'status'">
     <td>
       <span>
-        {{summary.count}} port{{summary.count > 1 && "s" || ""}}
+	{{::summary.count}} port{{::summary.count > 1 && "s" || ""}}
       </span>
     </td>
     <td>
       <span class="label label-status"
-            ng-class="class_from_port_status(summary.status)">
-        {{short_port_status(summary.status) | uppercase}}
+	    ng-class="class_from_port_status(summary.status)">
+	{{::short_port_status(summary.status) | uppercase}}
       </span>
     </td>
     <td>
       <span ng-if="summary.type == 'extra'"
-            ng-repeat="(reason, count) in summary.reasons">
-        {{count}} {{reason}}<span ng-if="!$last">, </span></span>
+	    ng-repeat="(reason, count) in summary.reasons">
+	{{::count}} {{::reason}}<span ng-if="!$last">, </span></span>
       <span ng-if="summary.type == 'ports'"
-            ng-repeat="port in summary.ports | orderBy: ['protocol','port']"
-            ><!--
+	    ng-repeat="port in summary.ports | orderBy: ['protocol','port']"
+	    ><!--
      --><a ng-click="setparam(port.protocol+'/'+port.port)" class="clickable">
-          {{port.protocol}}/{{port.port}}</a><span ng-if="!$last">, </span>
+	  {{::port.protocol}}/{{::port.port}}</a><span ng-if="!$last">, </span>
       </span>
     </td>
   </tr>

--- a/web/static/templates/subview-service-summary.html
+++ b/web/static/templates/subview-service-summary.html
@@ -16,18 +16,18 @@
   along with IVRE. If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<span ng-attr-title="{{port.service_method}}"
-      >{{port.service_name}}</span><!--
+<span ng-attr-title="{{::port.service_method}}"
+      >{{::port.service_name}}</span><!--
 --><span ng-if="port.service_product"
-	 >: {{port.service_product}}<!--
+	 >: {{::port.service_product}}<!--
   --><span ng-if="port.service_version"
-	   >, {{port.service_version}}</span><!--
+	   >, {{::port.service_version}}</span><!--
   --></span>
 <span ng-if="port.service_extrainfo"
-      >({{port.service_extrainfo}})</span>
+      >({{::port.service_extrainfo}})</span>
 <span ng-if="port.service_hostname"
-      >(hostname: {{port.service_hostname}})</span>
+      >(hostname: {{::port.service_hostname}})</span>
 <span ng-if="port.service_ostype"
-      >(ostype: {{port.service_ostype}})</span>
+      >(ostype: {{::port.service_ostype}})</span>
 <span ng-if="port.service_tunnel"
-      >(tunnel: {{port.service_tunnel}})</span>
+      >(tunnel: {{::port.service_tunnel}})</span>

--- a/web/static/templates/view-hosts.html
+++ b/web/static/templates/view-hosts.html
@@ -26,11 +26,11 @@
   <div host-summary=""></div>
 <!-- Next div is only displayed in summary mode-->
 <div class="summary"
-     ng-class="{'result-hidden-part': host.fulldisplay}"
+     ng-hide="host.fulldisplay"
      ports-summary=""></div>
 <!-- Next div is only displayed in full mode-->
 <div class="full"
-     ng-class="{'result-hidden-part': !host.fulldisplay}">
+     ng-if="host.fulldisplay">
   <!-- extraports -->
   <dd ng-repeat="(epstatus, epvalues) in host.extraports">
     {{epvalues[0]}} port{{epvalues[0] > 1 && "s" || ""}}


### PR DESCRIPTION
This PR aims to speed up the web rendering.

According to [Speeding up AngularJS apps with simple optimizations](https://www.binpress.com/tutorial/speeding-up-angular-js-with-simple-optimizations/135):
```
It’s known that Angular becomes slower with around 2,000 bindings due to the process behind dirty-checking. The less we can add to this limit the better, as bindings can add up without us really noticing it!
```

Using a `$$watchers` [counter](http://blog.yodersolutions.com/angularjs-count-the-number-of-watchers-on-a-page/), on a slow render query (`#1 range:64.170.144.217-69.39.229.61` on ModBus scan):
* Without the PR: 250 359 watchers (!)
* By rendering full view only if `host.fulldisplay`: 25494. On my computer, this is the difference between a "Slow script" box on Firefox and no box.
* By using the AngularJS one-time-binding syntax on summary `{{::`: 8866. Expanding the first result (`67.47.105.226`) go to 29698.
* By using this same syntax on full mode: 18975 with the first result opened.

More optimization could be done. This PR aims to be a first step in order to allow a better render time on big hosts.