### PR TITLE
WebUI/help: use homogeneous title for sshkey

### DIFF
--- a/web/static/help.js
+++ b/web/static/help.js
@@ -243,7 +243,7 @@ var HELP_FILTERS = {
 	    "content": "Search results with SMB shares with anonymous access. Access can be 'r', 'w' or 'rw' (default is read or write).",
 	},
 	"sshkey": {
-	    "title": "sshkey(:<b>[output of ssh-hostkey script])</b>",
+	    "title": "sshkey<b>(:[output of ssh-hostkey script])</b>",
 	    "content": "Look for hosts with SSH host keys reported by Nmap.",
 	},
 	"sshkey.type:": {


### PR DESCRIPTION
After that, filter `sshkey` will be similar to other filters with optional arguments (see #85). 