### PR TITLE
setup.py now uses setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # This file is part of IVRE.
 # Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
@@ -26,8 +26,9 @@ $ python setup.py build
 # python setup.py install
 """
 
-from distutils.core import setup
-import os
+from setuptools import setup
+from os import listdir
+from os import path
 
 setup(
     name='ivre',
@@ -117,8 +118,8 @@ setup(
         ('share/ivre/web/static/fi/css',
          ['web/static/fi/css/flag-icon.css']),
         ('share/ivre/web/static/fi/flags/4x3',
-         [os.path.join('web/static/fi/flags/4x3/', x)
-          for x in os.listdir('web/static/fi/flags/4x3/')]),
+         [path.join('web/static/fi/flags/4x3/', x)
+          for x in listdir('web/static/fi/flags/4x3/')]),
         # Dokuwiki
         ('share/ivre/dokuwiki',
          ['web/dokuwiki/backlinks.patch']),
@@ -136,8 +137,8 @@ setup(
         ('share/ivre/dokuwiki/media',
          ['web/dokuwiki/media/logo.png']),
         ('share/ivre/dokuwiki/media/doc/screenshots',
-         [os.path.join('doc/screenshots', x)
-          for x in os.listdir('doc/screenshots')]),
+         [path.join('doc/screenshots', x)
+          for x in listdir('doc/screenshots')]),
         ('share/ivre/web/cgi-bin',
          ['web/cgi-bin/scanjson.py']),
         ('share/doc/ivre',


### PR DESCRIPTION
setup.py uses setuptools instead of distutils

setup for developers available:
```
python setup.py develop
```