### PR TITLE
Handle Nmap's new "ls" NSE module

### DIFF
--- a/doc/WEBUI.md
+++ b/doc/WEBUI.md
@@ -61,6 +61,8 @@ displayed in the rightmost part of the screen.
     - `script`, `portscript` (like `script`), `hostscript`
     - `script:[scriptname]`, `portscript:[scriptname]` (like `script:`),
       `hostscript:[scriptname]`
+    - `file` (or `file.filename`), `file.time`, `file.size`,
+      `file.uid`, `file.gid`, `file.permission`
     - `smb.os`, `smb.lanmanager`, `smb.domain`, `smb.dnsdomain`,
       `smb.forest`, `smb.workgroup`
     - `cert.issuer`, `cert.subject`

--- a/doc/WEBUI.md
+++ b/doc/WEBUI.md
@@ -232,8 +232,9 @@ single or double quotes.
 
   - `display:host` set the default display mode.
   - `display:cpe` only display CPEs.
-  - `display:script:[scriptid]` only display a particular script
-    output.
+  - `display:script:`, `display:script:[script id]` or
+    `display:script:[script id],[script id],...` only display (a
+    particular) script outputs.
   - `display:screenshot` only display screenshots.
 
 

--- a/doc/WEBUI.md
+++ b/doc/WEBUI.md
@@ -161,7 +161,9 @@ single or double quotes.
     seems to get a lot a false positives.
   - `banner:` look for a specific banner of a service.
   - `cookie:` look for HTTP servers setting a specific cookie.
-  - `file:` look for a pattern in the shared files (FTP, SMB, ...).
+  - `file:[pattern]`, `file:[scriptid]:[pattern]`,
+    `file:[scriptid],[scriptid],...:[pattern]` look for a pattern in
+    the shared files (FTP, SMB, ...).
   - `geovision` look for GeoVision web-cams.
   - `httptitle:` look for a specific HTML title value of the homepage
     of a web site.
@@ -187,6 +189,9 @@ single or double quotes.
     specific host name (NetBIOS).
   - `smb.workgroup:[NetBIOS]` search results with SMB service in a
     specific workgroup (NetBIOS).
+  - `smbshare`, `smbshare:[access mode]` search results with SMB
+    shares with anonymous access. Access can be 'r', 'w' or 'rw'
+    (default is read or write).
   - `sshkey:` look for a particular SSH key.
   - `torcert` look for Tor certificates.
   - `webfiles` look for "typical" web files in the shared folders.
@@ -200,8 +205,8 @@ single or double quotes.
     routers, ...).
   - `phonedev` look for telephony devices.
   - `cpe(:[type](:[vendor](:[product](:[version]))))` look for a given cpe. Each field can be a /regex/.
-  - `[!]hop:` look for a particular IP address in the traceroute
-    results.
+  - `[!]hop:[IP]`, `[!]hop:[IP]:[TTL]` look for a particular IP
+    address in the traceroute results.
   - `[!]hopname:` look for a matching hostname in the traceroute
     results.
   - `[!]hopdomain:` look for a hostname within a matching domain name
@@ -210,6 +215,9 @@ single or double quotes.
     TCP or UDP port (using `[!][port number]` directly is equivalent
     to `[!]tcp/[port number]`).
   - `[!]openport` look for hosts with at least one open port.
+  - `otheropenport:[port number]`,
+    `otheropenport:[port number],[port number],...` look for hosts
+    with at least one open port other than those specified.
   - `notes` search results with an associated note.
 
 ### Sort ###

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -237,6 +237,13 @@ class DB(object):
 class DBNmap(DB):
 
     content_handler = xmlnmap.Nmap2Txt
+    ls_scripts = {
+        "afp-ls": ["ports.scripts"],
+        #"ftp-anon": ["ports.scripts"],
+        "http-ls": ["ports.scripts"],
+        "nfs-ls": ["ports.scripts", "scripts"],
+        "smb-ls": ["scripts"],
+    }
 
     def __init__(self):
         try:

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -239,7 +239,7 @@ class DBNmap(DB):
     content_handler = xmlnmap.Nmap2Txt
     ls_scripts = {
         "afp-ls": ["ports.scripts"],
-        #"ftp-anon": ["ports.scripts"],
+        "ftp-anon": ["ports.scripts"],
         "http-ls": ["ports.scripts"],
         "nfs-ls": ["ports.scripts", "scripts"],
         "smb-ls": ["scripts"],

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -402,6 +402,9 @@ class MongoDBNmap(MongoDB, DBNmap):
                   "ports.scripts.ssh-hostkey", "scripts",
                   "ports.screenwords",
                   "scripts.smb-enum-shares.shares",
+                  "ports.scripts.ls.volumes",
+                  "ports.scripts.ls.volumes.files",
+                  "scripts.ls.volumes", "scripts.ls.volumes.files",
                   "extraports.filtered", "traces", "traces.hops",
                   "os.osmatch", "os.osclass", "hostnames",
                   "hostnames.domains", "cpes"]
@@ -1701,6 +1704,7 @@ have no effect if it is not expected)."""
           - cert.* / smb.* / sshkey.*
           - modbus.* / s7.* / enip.*
           - screenwords
+          - file.*
           - hop
         """
         colname = self.colname_oldhosts if archive else self.colname_hosts
@@ -2105,6 +2109,12 @@ have no effect if it is not expected)."""
                 "ip": "Device IP",
             }.get(subfield, subfield)
             field = 'ports.scripts.enip-info.' + subfield
+        elif field == 'file' or field.startswith('file.'):
+            # This will not work for nfs-ls when run as a host script
+            # or for smb-ls, until we mix host scripts and port
+            # scripts (next document version)
+            field = 'ports.scripts.ls.volumes.files.%s' % (field[5:]
+                                                           or 'filename')
         elif field == 'screenwords':
             field = 'ports.screenwords'
             flt = self.flt_and(flt, self.searchscreenshot(words=True))

--- a/ivre/webutils.py
+++ b/ivre/webutils.py
@@ -407,9 +407,16 @@ def flt_from_query(query):
         elif param == 'cookie':
             flt = db.nmap.flt_and(flt, db.nmap.searchcookie(value))
         elif param == 'file':
-            flt = db.nmap.flt_and(
-                flt,
-                db.nmap.searchfile(utils.str2regexp(value)))
+            value = value.split(':', 1)
+            if len(value) == 1:
+                flt = db.nmap.flt_and(
+                    flt, db.nmap.searchfile(utils.str2regexp(value[0]))
+                )
+            else:
+                flt = db.nmap.flt_and(
+                    flt, db.nmap.searchfile(utils.str2regexp(value[1]),
+                                            scripts=value[0].split(','))
+                )
         elif not neg and param == 'geovision':
             flt = db.nmap.flt_and(flt, db.nmap.searchgeovision())
         elif param == 'httptitle':

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -40,6 +40,14 @@ SCHEMA_VERSION = 2
 # which is not supported for now
 IGNORE_TABLE_ELEMS = set(['xmpp-info', 'sslv2'])
 
+ALIASES_TABLE_ELEMS = {
+    # ls unified output (ls NSE module)
+    "afp-ls": "ls",
+    "http-ls": "ls",
+    "nfs-ls": "ls",
+    "smb-ls": "ls",
+}
+
 ADD_TABLE_ELEMS = {
     'modbus-discover':
     re.compile('^ *DEVICE IDENTIFICATION: *(?P<deviceid>.*?) *$', re.M),
@@ -540,6 +548,7 @@ class NmapHandler(ContentHandler):
                 self._curtable = {}
                 return
             infokey = self._curscript.get('id', 'infos')
+            infokey = ALIASES_TABLE_ELEMS.get(infokey, infokey)
             if self._curtable:
                 if self._curtablepath:
                     sys.stderr.write("WARNING, self._curtablepath should be "

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -98,7 +98,7 @@ If your command includes spaces, you need to protect it by using single or doubl
   * ''%%authhttp%%'' look for HTTP servers with authentication and a default (e.g., ''%%admin%%''/''%%admin%%'') login/password working. The Nmap script seems to get a lot a false positives.
   * ''%%banner:%%'' look for a specific banner of a service.
   * ''%%cookie:%%'' look for HTTP servers setting a specific cookie.
-  * ''%%file:%%'' look for a pattern in the shared files (FTP, SMB, ...).
+  * ''%%file:[pattern]%%'', ''%%file:[scriptid]:[pattern]%%'', ''%%file:[scriptid],[scriptid],...:[pattern]%%'' look for a pattern in the shared files (FTP, SMB, ...).
   * ''%%geovision%%'' look for GeoVision web-cams.
   * ''%%httptitle:%%'' look for a specific HTML title value of the homepage of a web site.
   * ''%%nfs%%'' look for NFS servers.
@@ -115,6 +115,7 @@ If your command includes spaces, you need to protect it by using single or doubl
   * ''%%smb.os:[OS]%%'' search results with SMB service with a specific OS.
   * ''%%smb.server:[NetBIOS]%%'' search results with SMB service in a specific host name (NetBIOS).
   * ''%%smb.workgroup:[NetBIOS]%%'' search results with SMB service in a specific workgroup (NetBIOS).
+  * ''%%smbshare%%'', ''%%smbshare:[access mode]%%'' search results with SMB shares with anonymous access. Access can be 'r', 'w' or 'rw' (default is read or write).
   * ''%%sshkey:%%'' look for a particular SSH key.
   * ''%%torcert%%'' look for Tor certificates.
   * ''%%webfiles%%'' look for "typical" web files in the shared folders.
@@ -127,11 +128,12 @@ If your command includes spaces, you need to protect it by using single or doubl
   * ''%%netdev%%'', ''%%networkdevice%%'' look for network devices (firewalls, routers, ...).
   * ''%%phonedev%%'' look for telephony devices.
   * ''%%cpe(:[type](:[vendor](:[product](:[version]))))%%'' look for a given cpe. Each field can be a /regex/.
-  * ''%%[!]hop:%%'' look for a particular IP address in the traceroute results.
+  * ''%%[!]hop:[IP]%%'', ''%%[!]hop:[IP]:[TTL]%%'' look for a particular IP address in the traceroute results.
   * ''%%[!]hopname:%%'' look for a matching hostname in the traceroute results.
   * ''%%[!]hopdomain:%%'' look for a hostname within a matching domain name in the traceroute results.
   * ''%%[!]tcp/[port number]%%'', ''%%[!]udp/[port number]%%'', look for an open TCP or UDP port (using ''%%[!][port number]%%'' directly is equivalent to ''%%[!]tcp/[port number]%%'').
   * ''%%[!]openport%%'' look for hosts with at least one open port.
+  * ''%%otheropenport:[port number]%%'', ''%%otheropenport:[port number],[port number],...%%'' look for hosts with at least one open port other than those specified.
   * ''%%notes%%'' search results with an associated note.
 
 ==== Sort ====

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -38,6 +38,7 @@ The third part allows to explore the results by generating graphs displayed in t
     * ''%%devicetype%%'', ''%%devicetype:[port]%%''
     * ''%%script%%'', ''%%portscript%%'' (like ''%%script%%''), ''%%hostscript%%''
     * ''%%script:[scriptname]%%'', ''%%portscript:[scriptname]%%'' (like ''%%script:%%''),  ''%%hostscript:[scriptname]%%''
+    * ''%%file%%'' (or ''%%file.filename%%''), ''%%file.time%%'', ''%%file.size%%'',  ''%%file.uid%%'', ''%%file.gid%%'', ''%%file.permission%%''
     * ''%%smb.os%%'', ''%%smb.lanmanager%%'', ''%%smb.domain%%'', ''%%smb.dnsdomain%%'',  ''%%smb.forest%%'', ''%%smb.workgroup%%''
     * ''%%cert.issuer%%'', ''%%cert.subject%%''
     * ''%%modbus.deviceid%%'', ''%%enip.vendor%%'', ''%%enip.product%%'', ''%%enip.serial%%'',  ''%%enip.devtype%%'', ''%%enip.prodcode%%'', ''%%enip.rev%%'', ''%%enip.ip%%''

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -146,7 +146,7 @@ If your command includes spaces, you need to protect it by using single or doubl
 
   * ''%%display:host%%'' set the default display mode.
   * ''%%display:cpe%%'' only display CPEs.
-  * ''%%display:script:[scriptid]%%'' only display a particular script output.
+  * ''%%display:script:%%'', ''%%display:script:[script id]%%'' or ''%%display:script:[script id],[script id],...%%'' only display (a particular) script outputs.
   * ''%%display:screenshot%%'' only display screenshots.
 
 

--- a/web/static/help.js
+++ b/web/static/help.js
@@ -411,6 +411,7 @@ var HELP_TOPVALUES = {
     callbacks: [],
     aliases: {
 	"cpe": "cpe.version",
+	"file": "file.filename",
     },
     content: {
 	"cpe.type": {
@@ -456,6 +457,30 @@ var HELP_TOPVALUES = {
 	"domains": {
 	    "title": "<b>(!)</b>domains<b>(:[level])</b>:",
 	    "content": "DNS domains (optionally limited to the specified level).",
+	},
+	"file.filename": {
+	    "title": "<b>(!)</b>file or <b>(!)</b>file.filename",
+	    "content": "Filenames from shared folders (AFP, SMB, NFS)."
+	},
+	"file.time": {
+	    "title": "<b>(!)</b>file.time",
+	    "content": "Timestamps from shared folders (AFP, SMB, NFS)."
+	},
+	"file.size": {
+	    "title": "<b>(!)</b>file.size",
+	    "content": "File sizes from shared folders (AFP, SMB, NFS)."
+	},
+	"file.uid": {
+	    "title": "<b>(!)</b>file.uid",
+	    "content": "File owners UID from shared folders (AFP, SMB, NFS)."
+	},
+	"file.gid": {
+	    "title": "<b>(!)</b>file.gid",
+	    "content": "File owners GID from shared folders (AFP, SMB, NFS)."
+	},
+	"file.permission": {
+	    "title": "<b>(!)</b>file.permission",
+	    "content": "File permissions from shared folders (AFP, SMB, NFS)."
 	},
 	"portlist:open": {
 	    "content": "portlist:open",

--- a/web/static/help.js
+++ b/web/static/help.js
@@ -183,7 +183,7 @@ var HELP_FILTERS = {
 	    "content": "Look for HTTP servers setting a specific cookie.",
 	},
 	"file:": {
-	    "title": "file:<b>[pattern or regexp]</b>",
+	    "title": "file:<b>([scrtipt id](,[script id](,...)):)[pattern or regexp]</b>",
 	    "content": "Look for a pattern in the shared files (FTP, SMB, ...).",
 	},
 	"geovision": {

--- a/web/static/ivre/controllers.js
+++ b/web/static/ivre/controllers.js
@@ -528,7 +528,19 @@ function set_display_mode(mode) {
 	mode = "host"; // default
     scope.$apply(function() { 
 	if(mode.substr(0, 7) === "script:") {
-	    args = mode.substr(7).split(",");
+	    args = mode.substr(7).split(',').reduce(function(accu, value) {
+		switch(value) {
+		case "":
+		    return accu;
+		case "ls":
+		    return accu.concat([
+			"afp-ls", "ftp-anon", "http-ls", "nfs-ls", "smb-ls",
+			"gopher-ls", "http-vlcstreamer-ls",
+		    ]);
+		default:
+		    return accu.concat([value]);
+		}
+	    }, []);
 	    mode = "script";
 	}
 	scope.display_mode_args = args;

--- a/web/static/templates/menu.html
+++ b/web/static/templates/menu.html
@@ -64,7 +64,7 @@
   <ul class="dropdown-menu">
     <li><a class="clickable" onclick="setparam('authhttp');">HTTP Auth</a></li>
     <li><a class="clickable"
-	   onclick="setparam('webfiles');">Shared web files</a></li>
+	   onclick="setparam('webfiles', undefined, true, true); setparam('display', 'script:ls', true)">Shared web files</a></li>
     <li><a class="clickable"
 	   onclick="setparam('script', 'http-git:\'/Git repository found/\'');"
 	   >Git repository</a></li>


### PR DESCRIPTION
This PR contains code to use structured output generate by NSE script that use the "ls" module, and to generate it when importing results from Nmap without the "ls" module.

It is necessary to update existing host records by running `scancli --update-schema; scancli --update-schema --archives`.

Reference: [Nmap PR 106](https://github.com/nmap/nmap/pull/106) "Add an `ls` module to unify arguments and outputs for `-ls` scripts"