### PR TITLE
Nmap XML: fix ftp-anon file size type

### DIFF
--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -286,7 +286,9 @@ def add_ftp_anon_data(script):
                          if value is not None)
         size = fileentry.get("size")
         if size is not None and size.isdigit():
-            result["total"]["bytes"] += int(size)
+            size = int(size)
+            fileentry["size"] = size
+            result["total"]["bytes"] += size
         result["total"]["files"] += 1
         cur_vol["files"].append(fileentry)
     if cur_vol["files"]:


### PR DESCRIPTION
Again, for the record, a Python script to update existing records:

```Python
import re

from ivre.db import db

for host in db.nmap.get(db.nmap.searchfile(re.compile(''),
                                           scripts=['ftp-anon'])):
    update = False
    for port in host.get('ports', []):
        for script in port.get('scripts', []):
            if script['id'] == 'ftp-anon':
                for fileentry in script['ls'].get(
                        'volumes', [{'files': []}])[0].get(
                            'files', []):
                    if isinstance(fileentry.get("size"), basestring) and fileentry['size'].isdigit():
                        fileentry["size"] = int(fileentry["size"])
                        print fileentry
                        update = True
    if update:
        db.nmap.db[db.nmap.colname_hosts].update(
            {'_id': host['_id']},
            {'$set': {
                'ports': host['ports'],
            }},
        )
```