### PR TITLE
[Feature] export to single HTML file

### DIFF
--- a/web/static/ivre/utils.js
+++ b/web/static/ivre/utils.js
@@ -171,3 +171,55 @@ function array_swap(arr, x, y) {
     arr[y] = tmp;
     return arr;
 }
+
+function exportDOM() {
+    // Get current DOM
+    var reportDOM = $("body").clone();
+
+    // Clean it
+    reportDOM.find("#navbar").remove();
+    reportDOM.find('style').remove();
+    reportDOM.find('script').remove();
+
+    // Get full CSS
+    var cssText = "";
+    $.each(document.styleSheets, function(sheetIndex, sheet) {
+       $.each(sheet.cssRules || sheet.rules, function(ruleIndex, rule) {
+	   cssText += rule.cssText;
+       });
+    });
+
+    // Convert images
+    reportDOM.find("img[src]").each(function(index, img) {
+	var canvas = document.createElement('canvas');
+	var context = canvas.getContext('2d');
+	context.drawImage(img, 0, 0);
+	img.src = canvas.toDataURL("image/png");
+    });
+
+    // Rebuild a web page
+    var content = "<html><head><style>" + cssText + "</style></head><body>" + reportDOM.html() + "</body></html>";
+    return new Blob([content], {"type": "text\/html" });
+};
+
+function download_blob(blob, title) {
+    // Build a link element to download Blob
+    var div = document.body;
+    var a = document.createElement('a');
+    a.onclick = function() {
+	this.setAttribute('href', window.URL.createObjectURL(blob));
+	return true;
+    };
+    if(title === undefined)
+	title = "Unknown.bin";
+    a.download = title;
+    a.href = "#";
+
+    // Trigger click event
+    div.appendChild(a);
+    a.click();
+
+    // Clean
+    document.removeElement(a);
+    return false;
+}

--- a/web/static/ivre/utils.js
+++ b/web/static/ivre/utils.js
@@ -177,7 +177,7 @@ function exportDOM() {
     var reportDOM = $("body").clone();
 
     // Clean it
-    reportDOM.find("#navbar").remove();
+    reportDOM.find(".no-export").remove();
     reportDOM.find('style').remove();
     reportDOM.find('script').remove();
 

--- a/web/static/report.html
+++ b/web/static/report.html
@@ -52,7 +52,7 @@
     </div>
 
     <!-- Configuration -->
-    <div class="row" ng-show="showfilter">
+    <div class="row no-export" ng-show="showfilter">
       <div class="page-header col-sm-10 col-sm-offset-1">
 	<h2 class="page-header">Configuration</h2>
 	<div class="col-sm-3">

--- a/web/static/templates/menu.html
+++ b/web/static/templates/menu.html
@@ -17,7 +17,7 @@
 -->
 
 <!-- The top navigation bar -->
-<div id="navbar" class="navbar navbar-inverse navbar-fixed-top row">
+<div id="navbar" class="navbar navbar-inverse navbar-fixed-top row no-export">
   <div class="col-lg-2 col-sm-1">
     <div class="navbar-ivre">
       <!-- The logo + app name -->

--- a/web/static/templates/menu.html
+++ b/web/static/templates/menu.html
@@ -78,14 +78,6 @@
 	</a></li>
       </ul>
     </li>
-
-    <!-- Upload -->
-    <li ng-if="::uploadok">
-      <a class="clickable" href="upload.html" title="Upload scan results">
-	<i class="glyphicon glyphicon-upload white"></i> Upload
-      </a>
-    </li>
-
   </ul>
 
   <!-- Droids Corp web site -->

--- a/web/static/templates/menu.html
+++ b/web/static/templates/menu.html
@@ -71,7 +71,10 @@
 	    <i class="glyphicon glyphicon-envelope"></i> Mail
 	</a></li>
 	<li><a href="#" onclick="document.location='report.html' + document.location.hash">
-	    <i class="glyphicon glyphicon-th-list "></i> Report
+	    <i class="glyphicon glyphicon-th-list"></i> Report
+	</a></li>
+	<li><a href="#" onclick="download_blob(exportDOM(), /([A-Za-z]+)\.html/g.exec(document.location.pathname)[1] + '_' + document.location.hash.substr(1).replace(' ', '_'))">
+	    <i class="glyphicon glyphicon-export"></i> HTML export
 	</a></li>
       </ul>
     </li>


### PR DESCRIPTION
This PR add a new submenu in *Share*, *HTML export*.

This feature export the current webpage into a single, standalone one where scripts, style and images are inlined.
In addition, elements which are not exportable (such as `navbar` and configuration menu in `report.html`) are tagged as `no-export`, and then will be removed from the exported page.

For instance, this feature can be used to send a full report by email, in HTML only.

Known issue: as Bootstrap icons are now fonts, there are badly exported (the font can be inlined in the exported page).

If one wants to obtain a fullpage screenshot, for instance for report, he can use the [firefox screenshot feature](http://stackoverflow.com/a/14830242)