### PR TITLE
Docker/client: update Bro version + get "official" Nmap dev version

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of IVRE.
-# Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -23,13 +23,17 @@ MAINTAINER Pierre LALET <pierre.lalet@cea.fr>
 RUN apt-get -qy install p0f rsync screen ipython openssl tesseract-ocr \
     libfreetype6 libfontconfig1 fonts-dejavu
 
+# Install Nmap. Use included libpcap because to use the workaround for
+# Nmap issue #34 (https://github.com/nmap/nmap/issues/34) since we do
+# not know which kernel version will be used
 ADD https://github.com/nmap/nmap/tarball/master ./nmap.tar.gz
 RUN apt-get -qy install build-essential libssl-dev && \
     tar zxf nmap.tar.gz && \
     mv nmap-nmap-* nmap && \
     cd nmap && \
     ./configure --without-ndiff --without-zenmap --without-nping \
-                --without-ncat --without-nmap-update && \
+                --without-ncat --without-nmap-update \
+                --with-libpcap=included && \
     make && make install && \
     cd ../ && rm -rf nmap nmap.tar.gz && \
     apt-get -qy --purge autoremove build-essential libssl-dev

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -23,17 +23,15 @@ MAINTAINER Pierre LALET <pierre.lalet@cea.fr>
 RUN apt-get -qy install p0f rsync screen ipython openssl tesseract-ocr \
     libfreetype6 libfontconfig1 fonts-dejavu
 
-# Install Nmap, from p-l-/refactor-ls, see
-# https://github.com/nmap/nmap/pull/106
-ADD https://github.com/p-l-/nmap/tarball/refactor-ls ./nmap-pl-ls.tar.gz
+ADD https://github.com/nmap/nmap/tarball/master ./nmap.tar.gz
 RUN apt-get -qy install build-essential libssl-dev && \
-    tar zxf nmap-pl-ls.tar.gz && \
-    mv p-l--nmap-* nmap-pl-ls && \
-    cd nmap-pl-ls && \
+    tar zxf nmap.tar.gz && \
+    mv nmap-nmap-* nmap && \
+    cd nmap && \
     ./configure --without-ndiff --without-zenmap --without-nping \
                 --without-ncat --without-nmap-update && \
     make && make install && \
-    cd ../ && rm -rf nmap-pl-ls nmap-pl-ls.tar.gz && \
+    cd ../ && rm -rf nmap nmap.tar.gz && \
     apt-get -qy --purge autoremove build-essential libssl-dev
 
 # "Install" phantomjs for our http-screenshot NSE script replacement
@@ -51,12 +49,12 @@ ADD http-screenshot.nse /usr/local/share/nmap/scripts/http-screenshot.nse
 RUN nmap --script-update
 
 # Install bro
-ADD https://www.bro.org/downloads/release/bro-2.4.tar.gz ./bro-2.4.tar.gz
+ADD https://www.bro.org/downloads/release/bro-2.4.1.tar.gz ./bro.tar.gz
 RUN apt-get -qy install build-essential cmake libssl-dev libpcap-dev \
                         flex bison libpython2.7-dev swig && \
-    cd tmp/ && tar zxf ../bro-2.4.tar.gz && \
-    cd bro-2.4 && ./configure && make -j 4 && make install && \
-    cd / && rm -rf tmp/bro-2.4 bro-2.4.tar.gz && \
+    cd tmp/ && tar zxf ../bro.tar.gz && mv bro-* bro && \
+    cd bro && ./configure && make -j 4 && make install && \
+    cd / && rm -rf tmp/bro bro.tar.gz && \
     apt-get -qy --purge autoremove build-essential cmake libssl-dev \
                         libpcap-dev flex bison libpython2.7-dev swig
 


### PR DESCRIPTION
Nmap version was fetched from a forked repository to use specific code (nmap/nmap#106)
that has been integrated into the Nmap dev tree.
Also, a workaround for nmap/nmap#34 has been added.