### PR TITLE
nmap2db: fix --merge with JSON files

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -428,9 +428,10 @@ class DBNmap(DB):
                             host['infos'].update(data)
                 if not needports or 'ports' in host:
                     if merge and self.merge_host(host):
-                        return True
-                    self.archive_from_func(host, gettoarchive)
-                    self.store_host(host)
+                        pass
+                    else:
+                        self.archive_from_func(host, gettoarchive)
+                        self.store_host(host)
             self.store_scan_doc({'_id': filehash})
         return True
 


### PR DESCRIPTION
Until this, nmap2db would stop after merging the first already existing host.