### PR TITLE
Fix error when using --list-agents with runscans-agentdb

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -3071,7 +3071,7 @@ class MongoDBAgent(MongoDB, DBAgent):
         return self.db[self.colname_agents].insert(agent)
 
     def get_agent(self, agentid):
-        return self.find(self.colname_agents, {"_id": agentid})
+        return self.find_one(self.colname_agents, {"_id": agentid})
 
     def get_free_agents(self):
         return (x['_id'] for x in


### PR DESCRIPTION
Stack trace :
    $ runscans-agentdb --add-local-master
    $ runscans-agentdb --add-agent ivre-share/fs/ --source MySource              
    $ runscans-agentdb --list-agents
    agent:
    Traceback (most recent call last):
      File "/usr/local/bin/runscans-agentdb", line 227, in <module>
        main()
      File "/usr/local/bin/runscans-agentdb", line 190, in main
        display_agent(agent)
      File "/usr/local/bin/runscans-agentdb", line 55, in display_agent
        print "  - id: %s" % agent['_id']
      File "/usr/lib/python2.7/dist-packages/pymongo/cursor.py", line 599, in __getitem__
        "instances" % index)
    TypeError: index '_id' cannot be applied to Cursor instances