### PR TITLE
Fix analysercli filter

### DIFF
--- a/bin/analysercli
+++ b/bin/analysercli
@@ -55,19 +55,13 @@ class AnalyserCli(StackCli):
 
     def _build_filter(self, cmd):
         """Build a db.nmap.flt from the string `cmd`"""
-        query = []
-        cmd = cmd.split()
-        while cmd:
-            param = cmd.pop(0)
-            neg, param = self._flt_param(param)
-            value = cmd.pop(0)
-            if param == 'limit':
-                self._dfilter['limit'] = int(value)
-            else:
-                query.append((neg, param, value))
+        query = webutils.query_from_params({'q': cmd})
         (self._dfilter['filter'], _, _, _,
-         self._dfilter['skip'], _) = webutils.flt_from_query(
-             query, base_flt=db.nmap.flt_empty)
+         self._dfilter['skip'],
+         self._dfilter['limit']) = webutils.flt_from_query(
+             query, base_flt=db.nmap.flt_empty, force_limit=False)
+        if not self._dfilter['limit']:
+            del self._dfilter['limit']
 
     def do_count(self, _):
         """Print host count to stdout"""

--- a/ivre/webutils.py
+++ b/ivre/webutils.py
@@ -244,7 +244,7 @@ def get_init_flt():
     return DEFAULT_INIT_QUERY
 
 
-def flt_from_query(query, base_flt=None):
+def flt_from_query(query, base_flt=None, force_limit=True):
     """Return a tuple (`flt`, `archive`, `sortby`, `unused`, `skip`,
     `limit`):
 
@@ -259,14 +259,15 @@ def flt_from_query(query, base_flt=None):
 
       - an integer for the number of results to skip
 
-      - an integer for the maximum number of results to return
+      - an integer for the maximum number of results to return (always set if
+        `force_limit`)
 
     """
     unused = []
     sortby = []
     archive = False
     skip = config.WEB_SKIP
-    limit = config.WEB_LIMIT
+    limit = config.WEB_LIMIT if force_limit else None
     flt = get_init_flt() if base_flt is None else base_flt
     def add_unused(neg, param, value):
         """Add to the `unused` list a string representing (neg, param,


### PR DESCRIPTION
Without this PR, only filters with value are allowed in `analysercli`. That way, filters like `openport` are ignored and end with a CLI crash.

With this PR, filter handling is the same than for the web interface, allowing a more (in my opinion) convenient / usual way of specifying them.

```
$ ./analysercli 
[INFO] Initialization
Filter > openport category:Random limit:1000
[INFO] Reading database..
. > count
[INFO] Number of hosts:
	total:	1000
```