### PR TITLE
Command line: add --test-normal to scan2db

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -42,6 +42,7 @@ ivre/graphroute.py
 ivre/keys.py
 ivre/mathutils.py
 ivre/nmapopt.py
+ivre/nmapout.py
 ivre/passive.py
 ivre/scanengine.py
 ivre/target.py

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -408,7 +408,6 @@ class MongoDB(DB):
 
 class MongoDBNmap(MongoDB, DBNmap):
 
-    content_handler = xmlnmap.Nmap2Mongo
     needunwind = ["categories", "labels", "labels.tags",
                   "ports", "ports.scripts",
                   "ports.scripts.ssh-hostkey",
@@ -427,6 +426,8 @@ class MongoDBNmap(MongoDB, DBNmap):
                  **kargs):
         MongoDB.__init__(self, host, dbname, **kargs)
         DBNmap.__init__(self)
+        self.content_handler = xmlnmap.Nmap2Mongo
+        self.output_function = None
         self.colname_scans = colname_scans
         self.colname_hosts = colname_hosts
         self.colname_oldscans = colname_oldscans

--- a/ivre/nmapout.py
+++ b/ivre/nmapout.py
@@ -172,3 +172,4 @@ def displayhosts_json(recordsgen, out=sys.stdout):
 
     """
     out.write(json.dumps(recordsgen, default=utils.serialize))
+    out.write('\n')

--- a/ivre/nmapout.py
+++ b/ivre/nmapout.py
@@ -26,6 +26,7 @@ from ivre import utils
 
 import sys
 import os
+import json
 
 def displayhost(record, showscripts=True, showtraceroute=True, showos=True,
                 out=sys.stdout):

--- a/ivre/nmapout.py
+++ b/ivre/nmapout.py
@@ -164,3 +164,10 @@ def displayhosts(recordsgen, out=sys.stdout, **kargs):
             raw_input()
         else:
             out.write('\n')
+
+def displayhosts_json(recordsgen, out=sys.stdout):
+    """Displays (on `out`, by default `sys.stdout`) the Nmap scan
+    result contained in `record` as JSON.
+
+    """
+    out.write(json.dumps(recordsgen, default=utils.serialize))

--- a/ivre/nmapout.py
+++ b/ivre/nmapout.py
@@ -1,0 +1,166 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of IVRE.
+# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
+#
+# IVRE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IVRE is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+
+"""This sub-module contains function to convert & display Nmap scan
+results as they are stored in the database (JSON).
+
+"""
+
+from ivre import utils
+
+import sys
+import os
+
+def displayhost(record, showscripts=True, showtraceroute=True, showos=True,
+                out=sys.stdout):
+    """Displays (on `out`, by default `sys.stdout`) the Nmap scan
+    result contained in `record`.
+
+    """
+    try:
+        h = "Host %s" % utils.int2ip(record['addr'])
+    except:
+        h = "Host %s" % record['addr']
+    if record.get('hostnames'):
+        h += " (%s)" % '/'.join(x['name'] for x in record['hostnames'])
+    if 'source' in record:
+        h += ' from %s' % record['source']
+    if record.get('categories'):
+        h += ' (%s)' % ', '.join(record['categories'])
+    if 'state' in record:
+        h += ' (%s' % record['state']
+        if 'state_reason' in record:
+            h += ': %s' % record['state_reason']
+        h += ')\n'
+    out.write(h)
+    if 'infos' in record:
+        infos = record['infos']
+        if 'country_code' in infos or 'country_name' in infos:
+            out.write("\t%s - %s" % (infos.get('country_code', '?'),
+                                     infos.get('country_name', '?')))
+            if 'city' in infos:
+                out.write(' - %s' % infos['city'])
+            out.write('\n')
+        if 'as_num' in infos or 'as_name' in infos:
+            out.write("\tAS%s - %s\n" % (infos.get('as_num', '?'),
+                                         infos.get('as_name', '?')))
+    if 'starttime' in record and 'endtime' in record:
+        out.write("\tscan %s - %s\n" %
+                 (record['starttime'], record['endtime']))
+    if 'extraports' in record:
+        d = record['extraports']
+        for k in d:
+            out.write("\t%d ports %s (%s)\n" %
+                      (d[k][0], k, ', '.join(['%d %s' % (d[k][1][kk], kk)
+                                              for kk in d[k][1].keys()])))
+    if 'ports' in record:
+        d = record['ports']
+        d.sort(key=lambda x: (x.get('protocol'), x['port']))
+        for k in d:
+            if k.get('port') == 'host':
+                record['scripts'] = k['scripts']
+                continue
+            reason = ""
+            if 'state_reason' in k:
+                reason = " (%s" % k['state_reason']
+                for kk in filter(lambda x: x.startswith('state_reason_'),
+                                 k.keys()):
+                    reason += ", %s=%s" % (kk[13:], k[kk])
+                reason += ')'
+            srv = ""
+            if 'service_name' in k:
+                srv = "" + k['service_name']
+                if 'service_method' in k:
+                    srv += ' (%s)' % k['service_method']
+                for kk in ['service_product', 'service_version',
+                           'service_extrainfo', 'service_ostype',
+                           'service_hostname']:
+                    if kk in k:
+                        srv += ' %s' % k[kk]
+            out.write("\t%-10s%-8s%-22s%s\n" %
+                      ('%s/%d' % (k.get('protocol'), k['port']),
+                       k['state_state'], reason, srv))
+            if showscripts and k.get('scripts'):
+                for s in k['scripts']:
+                    if 'output' not in s:
+                        out.write('\t\t' + s['id'] + ':\n')
+                    else:
+                        o = filter(
+                            lambda x: x, map(lambda x: x.strip(),
+                                             s['output'].split('\n')))
+                        if len(o) == 0:
+                            out.write('\t\t' + s['id'] + ':\n')
+                        elif len(o) == 1:
+                            out.write('\t\t' + s['id'] + ': ' + o[0] + '\n')
+                        elif len(o) > 1:
+                            out.write('\t\t' + s['id'] + ': \n')
+                            for oo in o:
+                                out.write('\t\t\t' + oo + '\n')
+    if showscripts and record.get('scripts'):
+        out.write('\tHost scripts:\n')
+        for s in record['scripts']:
+            if 'output' not in s:
+                out.write('\t\t' + s['id'] + ':\n')
+            else:
+                o = [x.strip() for x in s['output'].split('\n') if x]
+                if len(o) == 0:
+                    out.write('\t\t' + s['id'] + ':\n')
+                elif len(o) == 1:
+                    out.write('\t\t' + s['id'] + ': ' + o[0] + '\n')
+                elif len(o) > 1:
+                    out.write('\t\t' + s['id'] + ': \n')
+                    for oo in o:
+                        out.write('\t\t\t' + oo + '\n')
+    if showtraceroute and record.get('traces'):
+        for k in record['traces']:
+            proto = k['protocol']
+            if proto in ['tcp', 'udp']:
+                proto += '/%d' % k['port']
+            out.write('\tTraceroute (using %s)\n' % proto)
+            hops = k['hops']
+            hops.sort(key=lambda x: x['ttl'])
+            for i in hops:
+                try:
+                    out.write('\t\t%3s %15s %7s\n' %
+                              (i['ttl'], utils.int2ip(i['ipaddr']),
+                               i['rtt']))
+                except:
+                    out.write('\t\t%3s %15s %7s\n' %
+                              (i['ttl'], i['ipaddr'], i['rtt']))
+    if showos and record.get('os', {}).get('osclass'):
+        o = record['os']['osclass']
+        maxacc = str(max([int(x['accuracy']) for x in o]))
+        o = filter(lambda x: x['accuracy'] == maxacc, o)
+        out.write('\tOS fingerprint\n')
+        for oo in o:
+            out.write(
+                '\t\t%(osfamily)s / %(type)s / %(vendor)s / '
+                'accuracy = %(accuracy)s\n' % oo)
+
+def displayhosts(recordsgen, out=sys.stdout, **kargs):
+    """Displays (on `out`, by default `sys.stdout`) the Nmap scan
+    results generated by `recordsgen`.
+
+    """
+    for record in recordsgen:
+        displayhost(record, out=out, **kargs)
+        if os.isatty(out.fileno()):
+            raw_input()
+        else:
+            out.write('\n')

--- a/ivre/tools/scan2db.py
+++ b/ivre/tools/scan2db.py
@@ -18,6 +18,7 @@
 
 import ivre.db
 import ivre.utils
+import ivre.xmlnmap
 
 import os
 import sys
@@ -56,7 +57,9 @@ def main():
     parser.add_argument('-s', '--source', default=None,
                         help='Scan source.')
     parser.add_argument('-t', '--test', action='store_true',
-                        help='Test mode.')
+                        help='Test mode (JSON output).')
+    parser.add_argument('--test-normal', action='store_true',
+                        help='Test mode ("normal" Nmap output).')
     parser.add_argument('--ports', '--port', action='store_true',
                         help='Store only hosts with a "ports" element.')
     parser.add_argument('--open-ports', action='store_true',
@@ -81,8 +84,10 @@ def main():
     args = parser.parse_args()
     database = ivre.db.db.nmap
     categories = args.categories.split(',') if args.categories else []
-    if args.test:
+    if args.test or args.test_normal:
         database = ivre.db.DBNmap()
+        if args.test_normal:
+            database.content_handler = ivre.xmlnmap.Nmap2Normal
     if args.never_archive:
         def gettoarchive(addr, _):
             return []

--- a/ivre/tools/scan2db.py
+++ b/ivre/tools/scan2db.py
@@ -84,10 +84,10 @@ def main():
     args = parser.parse_args()
     database = ivre.db.db.nmap
     categories = args.categories.split(',') if args.categories else []
-    if args.test or args.test_normal:
+    if args.test:
         database = ivre.db.DBNmap()
-        if args.test_normal:
-            database.content_handler = ivre.xmlnmap.Nmap2Normal
+    if args.test_normal:
+        database = ivre.db.DBNmap(output_mode="normal")
     if args.never_archive:
         def gettoarchive(addr, _):
             return []

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -610,10 +610,6 @@ class NmapHandler(ContentHandler):
         """
         pass
 
-    def outputresults(self):
-        """Subclasses may display any results here."""
-        pass
-
     def startElement(self, name, attrs):
         if name == 'nmaprun':
             if self._curscan is not None:
@@ -1039,14 +1035,6 @@ class Nmap2Txt(NmapHandler):
 
     def _addhost(self):
         self._db.append(self._curhost)
-
-    def outputresults(self):
-        print json.dumps(self._db, default=utils.serialize)
-
-
-class Nmap2Normal(Nmap2Txt):
-    def outputresults(self):
-        nmapout.displayhosts(self._db, out=sys.stdout)
 
 
 class Nmap2Mongo(NmapHandler):

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -25,7 +25,7 @@ This sub-module contains the parser for nmap's XML output files.
 
 """
 
-from ivre import utils, config
+from ivre import utils, config, nmapout
 
 from xml.sax.handler import ContentHandler, EntityResolver
 import datetime
@@ -1042,6 +1042,11 @@ class Nmap2Txt(NmapHandler):
 
     def outputresults(self):
         print json.dumps(self._db, default=utils.serialize)
+
+
+class Nmap2Normal(Nmap2Txt):
+    def outputresults(self):
+        nmapout.displayhosts(self._db, out=sys.stdout)
 
 
 class Nmap2Mongo(NmapHandler):

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -32,7 +32,6 @@ import datetime
 import sys
 import os
 import re
-import json
 import bson
 
 SCHEMA_VERSION = 4


### PR DESCRIPTION
This allows for users to get a "normal" Nmap output (as generated by `nmap -oN -`, or by `ivre scancli`) from XML (as generated by `nmap -oX -`) or JSON (as generated by `ivre scancli --json`) output without the need to import the result in IVRE's DB.