### PR TITLE
Replace screen by "proper" subprocess management in agent

### DIFF
--- a/agent/agent
+++ b/agent/agent
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 # This file is part of IVRE.
-# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2016 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -39,20 +39,47 @@ scan () {
     nmap $NMAPOPTS --script="$NMAPSCRIPTS" -iL - -oX -
 }
 
-if [ "$TERM" != "screen" ] ; then
-    screen "$0" $@
-    exit 0
-fi
+someone_alive () {
+    pids=$1
+    for pid in $pids; do
+        # Is $pid alive?
+        kill -0 $pid 2> /dev/null && return 0
+    done
+
+    # Everyone is dead
+    return 1
+}
 
 mkdir -p "$INDIR" "$CURDIR" "$OUTDIR" "$ERRORDIR"
 
-if [ -z "$INTHREAD" ] ; then
-    screen -X setenv INTHREAD 1
-    for i in `seq 2 $THREADS` ; do
-	sleep 1
-	screen "$0" $@
+# master
+if [ -z "$IVRE_WORKER" ] ; then
+    master_prompt="[master     ] "
+
+    # clean children on exit
+    trap "trap - TERM INT EXIT; echo '${master_prompt}shuting down' >&2;\
+          kill -- -$$; exit" TERM INT EXIT
+
+    echo "${master_prompt}spawning $THREADS workers" >&2
+    export IVRE_WORKER=1
+    worker_pids=""
+    for i in `seq 1 $THREADS` ; do
+        worker_prompt="[worker `printf %-4d $i`] "
+        ("$0" "$@" 2>&1 | sed -u "s/^/$worker_prompt/") &
+        worker_pids="$! $worker_pids"
     done
+    unset IVRE_WORKER
+
+    # handle wait interruptions (any non terminating signal)
+    while someone_alive $worker_pids; do
+        wait
+    done
+
+    exit 0
 fi
+
+# worker
+echo "worker ready" >&2
 
 while true ; do
     [ -f "want_down" ] && break
@@ -61,14 +88,17 @@ while true ; do
 	$SLEEP
 	continue
     fi
-    if ! mv "$INDIR/$fname" "$CURDIR/" ; then
+    if ! mv "$INDIR/$fname" "$CURDIR/" 2> /dev/null ; then
 	continue
     fi
+    echo "scan $fname" >&2
+
     if ! (filter < "$CURDIR/$fname" | scan | bzip2 > "$CURDIR/$fname.xml.bz2") ; then
 	mv "$CURDIR/$fname.xml.bz2" "$ERRORDIR/$fname-`date +%s`.xml.bz2"
 	cp "$CURDIR/$fname" "$ERRORDIR/$fname-`date +%s`"
 	mv "$CURDIR/$fname" "$INDIR/"
 	$SLEEP
+        echo "error with $fname" >&2
     else
 	if [ "$STOREDOWN" = "true" ] ||
 	    bzgrep -q -F '<status state="up"' "$CURDIR/$fname.xml.bz2" ; then
@@ -77,5 +107,6 @@ while true ; do
 	    rm -f "$CURDIR/$fname.xml.bz2"
 	fi
 	rm -f "$CURDIR/$fname"
+        echo "done $fname" >&2
     fi
 done


### PR DESCRIPTION
The agent now spawns worker agent subprocesses, waits for them while at
least one is alive, and kills (SIGTERM) its whole process tree on exit,
SIGINT or SIGTERM.

This allows to use the agent more flexibly (for example in a systemd
service). As a bonus, it removes the `screen` dependency on the agent side, for what it is worth... 

The PR also adds some light logging to see what the agent workers are doing. @pl, could you also check that these messages are consistent?

As a preview/bonux, here is a sample systemd service file I use to run the agent on by boxes:

```cfg
[Unit]
Description=IVRE scan agent
After=network.target
Requires=network.target

[Service]
EnvironmentFile=-/etc/sysconfig/ivre-agent
WorkingDirectory=/var/lib/ivre-agent/
ExecStartPre=/bin/sh -c 'mkdir -p input output'
ExecStartPre=/bin/sh -c 'chgrp ivre input output'
ExecStartPre=/bin/sh -c 'chmod 2775 input'
ExecStartPre=/bin/sh -c 'chmod 2755 output'
# Replace by relevent path
ExecStart=/opt/ivre/agent/agent
User=root
Group=ivre

[Install]
WantedBy=multi-user.target
```
