### PR TITLE
Replaced count() with find_one() in the remove() function

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -1034,7 +1034,7 @@ have no effect if it is not expected)."""
             colname_scans = self.colname_scans
         self.db[colname_hosts].remove(spec_or_id=host['_id'])
         for scanid in self.getscanids(host):
-            if self.get({'scanid': scanid}, archive=archive).count() == 0:
+            if self.find_one(colname_hosts, {'scanid': scanid}) is None:
                 self.db[colname_scans].remove(spec_or_id=scanid)
 
     def archive(self, host, unarchive=False):


### PR DESCRIPTION
The count() operation was slowing down huge file imports.
Replacing it with a find_one() reduces import time by 10.
This is particularly effective on huge files.