### PR TITLE
Partial parsing of mongodb-{info,databases} NSE scripts

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -411,6 +411,8 @@ class MongoDBNmap(MongoDB, DBNmap):
                   "ports.scripts.smb-enum-shares.shares",
                   "ports.scripts.ls.volumes",
                   "ports.scripts.ls.volumes.files",
+                  "ports.scripts.mongodb-databases.databases",
+                  "ports.scripts.mongodb-databases.databases.shards",
                   "ports.screenwords",
                   "traces", "traces.hops",
                   "os.osmatch", "os.osclass", "hostnames",

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -938,6 +938,9 @@ class NmapHandler(ContentHandler):
                                      "empty, got [%r]\n" % self._curtablepath)
                 self._curtable = {}
                 return
+            if ignore_script(self._curscript):
+                self._curscript = None
+                return
             infokey = self._curscript.get('id', None)
             infokey = ALIASES_TABLE_ELEMS.get(infokey, infokey)
             if self._curtable:
@@ -1003,9 +1006,6 @@ class NmapHandler(ContentHandler):
                                 fname=full_fname,
                             )
                         )
-            if ignore_script(self._curscript):
-                self._curscript = None
-                return
             current.setdefault('scripts', []).append(self._curscript)
             self._curscript = None
         elif name in ['table', 'elem']:

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -463,6 +463,11 @@ IGNORE_SCRIPTS = {
     'drda-info': set(['The response contained no EXCSATRD']),
     'rdp-enum-encryption': set(['Received unhandled packet']),
     'ldap-search': set(['ERROR: Failed to bind as the anonymous user']),
+    'mongodb-databases': set([
+        'ERROR: Script execution failed (use -d to debug)',
+        'No Bson data returned',
+    ]),
+    'mongodb-info': set(['ERROR: Script execution failed (use -d to debug)']),
     # host scripts
     'firewalk': set(['None found']),
     'ipidseq': set(['Unknown']),


### PR DESCRIPTION
This PR:
* Add error magics for [`mongodb-info`](https://nmap.org/nsedoc/scripts/mongodb-info.html), [`mongodb-databases`](https://nmap.org/nsedoc/scripts/mongodb-databases.html) NSE scripts.
* Parse `mongodb-databases` output, including databases and shards.
* Fix the order of execution of output error detection and output parsing.