### PR TITLE
DB/Mongo: add .distinct() method using the aggregation framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ before_script:
   - wget -O - "https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=imap.cap.gz" | zcat > tests/samples/imap.pcap
   - for file in telnet-raw.pcap nb6-startup.pcap nb6-http.pcap nb6-telephone.pcap nb6-hotspot.pcap ; do wget "https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=$file" -O "tests/samples/$file" ; done
 
-script: cd tests/ && python tests.py
+script: cd tests/ && travis_wait 30 python tests.py

--- a/ivre/tools/ipinfo.py
+++ b/ivre/tools/ipinfo.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # This file is part of IVRE.
-# Copyright 2011 - 2014 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2016 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -105,12 +105,12 @@ def disp_recs_std(flt):
 
 
 def disp_recs_short(flt):
-    for addr in db.passive.get(flt).distinct('addr'):
+    for addr in db.passive.distinct('addr', flt=flt):
         print ivre.utils.int2ip(addr)
 
 
 def disp_recs_distinct(field, flt):
-    for value in db.passive.get(flt).distinct(field):
+    for value in db.passive.distinct(field, flt=flt):
         print value
 
 


### PR DESCRIPTION
This saves memory and is much more efficient.

Also, `ivre scancli` uses `.distinct()`, which fixes #274.