### PR TITLE
Match banners from Masscan against Nmap service fingerprints

### DIFF
--- a/ivre/tools/bro2db.py
+++ b/ivre/tools/bro2db.py
@@ -18,7 +18,6 @@
 
 """Update the flow database from Bro logs"""
 
-import itertools
 import os
 import re
 import sys

--- a/web/cgi-bin/scanjson.py
+++ b/web/cgi-bin/scanjson.py
@@ -246,6 +246,10 @@ def main():
         for port in rec.get('ports', []):
             if 'screendata' in port:
                 port['screendata'] = port['screendata'].encode('base64')
+            for script in port.get('scripts', []):
+                if "masscan" in script:
+                    try: del script['masscan']['raw']
+                    except KeyError: pass
         if not ipsasnumbers:
             if 'traces' in rec:
                 for trace in rec['traces']:


### PR DESCRIPTION
This handles more services from Masscan, and matches the `banner` output against Nmap service fingerprint database (Nmap needs to be installed on the computer running `ivre scan2db`).

This PR also includes a minor fix and the ability to get top values for `product:service` (only `product:port_number` was supported).