### PR TITLE
Test multiple MongoDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
+
 env:
-  global:
-    - MONGODB_VERSION=2.6.10
+  - DB=mongo MONGODB_VERSION=2.6.10
+  - DB=mongo MONGODB_VERSION=3.4.2
 
 language: python
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -50,7 +50,8 @@ IVRE relies on:
     [p0f](http://lcamtuf.coredump.cx/p0f/) (version 2, will not work
     with version 3) for the passive fingerprint and flow modules.
 
-  * [MongoDB](http://www.mongodb.org/), version 2.6 minimum
+  * [MongoDB](http://www.mongodb.org/), version 2.6 minimum (tests are
+    run with versions 2.6.10 and 3.4.2)
 
   * [Neo4j](http://neo4j.com/) for the flow module
 

--- a/web/dokuwiki/doc/readme.txt
+++ b/web/dokuwiki/doc/readme.txt
@@ -25,7 +25,7 @@ IVRE relies on:
   * [[http://nmap.org/|Nmap]]
   * optionnaly [[https://zmap.io/|ZMap]] and/or [[https://github.com/robertdavidgraham/masscan|Masscan]]
   * [[http://www.bro.org/|Bro]] (version 2.3 minimum), [[http://qosient.com/argus/|Argus]], [[http://nfdump.sourceforge.net/|Nfdump]]& [[http://lcamtuf.coredump.cx/p0f/|p0f]] (version 2, will not work with version 3) for the passive fingerprint and flow modules.
-  * [[http://www.mongodb.org/|MongoDB]], version 2.6 minimum
+  * [[http://www.mongodb.org/|MongoDB]], version 2.6 minimum (tests are run with versions 2.6.10 and 3.4.2)
   * [[http://neo4j.com/|Neo4j]] for the flow module
   * a web server (successfully tested with [[https://httpd.apache.org/|Apache]] and [[http://nginx.org/|Nginx]], should work with anything capable of serving static files and run a Python-based CGI), although a test web server is now distributed with IVRE (''%%ivre httpd%%'')
   * a web browser (successfully tested with recent versions of [[https://www.mozilla.org/firefox/|Firefox]] and [[http://www.chromium.org/|Chromium]])


### PR DESCRIPTION
With this PR, we run the Travis-CI tests against two different MongoDB versions (2.6.10, which has to be supported per our documentation, and 3.4.2, the current latest stable release).