### PR TITLE
Fix and improve screenshots handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ install:
   - pip install $PIP_INSTALL_OPTIONS -r requirements-$DB.txt
   - test "$TRAVIS_PYTHON_VERSION" = 2.6 && pip install unittest2 || true
   - pip install $PIP_INSTALL_OPTIONS coverage codecov
+  # cleanup
+  - rm -rf ivre/
 
 # We need MongoDB 2.6
 # https://github.com/travis-ci/travis-ci/issues/2246
@@ -45,11 +47,14 @@ before_script:
   - cat .travis/ivre.conf >> ~/.ivre.conf
   # install p0f & Bro (.tar files)
   # for some reason, wget on travis-ci won't accept letsencrypt certificate
-  - for archive in tools-travis-ivre bro-2.3.2_ubuntu-12.04 nmap-7.50_ubuntu-precise; do wget --no-check-certificate https://ivre.rocks/data/tests/${archive}.tar.bz2 -O - | tar jxf - ; done
+  - for archive in tools-travis-ivre bro-2.3.2_ubuntu-12.04 nmap-7.60_ubuntu-precise; do wget --no-check-certificate https://ivre.rocks/data/tests/${archive}.tar.bz2 -O - | tar jxf - ; done
   - export PATH="`pwd`/tools/bin:`pwd`/usr/local/bro/bin:`pwd`/usr/local/nmap/bin:$PATH"
   - export LD_LIBRARY_PATH="`pwd`/tools/lib:`pwd`/usr/local/bro/lib"
   - export BROPATH=".:`pwd`/usr/local/bro/share/bro:`pwd`/usr/local/bro/share/bro/policy:`pwd`/usr/local/bro/share/bro/site"
   - cp tools/etc/p0f/* tests/
+  - cp `python -c "import ivre.config; print(ivre.config.guess_prefix('nmap_scripts'))"`/*.nse `pwd`/usr/local/nmap/share/nmap/scripts/
+  - for patch in `python -c "import ivre.config; print(ivre.config.guess_prefix('nmap_scripts'))"`/patches/*; do (cd `pwd`/usr/local/nmap/share/nmap && patch -p0 < $patch); done
+  - nmap --script-updatedb
   # get samples
   - mkdir tests/samples
   - cp tests/results-public-samples tests/samples/results

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,16 @@ python:
   - 3.5
   - 3.6
 
+# PhantomJS is supposed to be installed
+# (https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-PhantomJS),
+# but we need tesseract
+addons:
+  apt:
+    packages:
+    - tesseract-ocr
+    - tesseract-ocr-osd
+    - tesseract-ocr-eng
+
 install:
   - source ./.travis/install_${DB}.sh
   - pip install $PIP_INSTALL_OPTIONS .
@@ -52,6 +62,7 @@ before_script:
   - export LD_LIBRARY_PATH="`pwd`/tools/lib:`pwd`/usr/local/bro/lib"
   - export BROPATH=".:`pwd`/usr/local/bro/share/bro:`pwd`/usr/local/bro/share/bro/policy:`pwd`/usr/local/bro/share/bro/site"
   - cp tools/etc/p0f/* tests/
+  # install IVRE's Nmap scripts.
   - cp `python -c "import ivre.config; print(ivre.config.guess_prefix('nmap_scripts'))"`/*.nse `pwd`/usr/local/nmap/share/nmap/scripts/
   - for patch in `python -c "import ivre.config; print(ivre.config.guess_prefix('nmap_scripts'))"`/patches/*; do (cd `pwd`/usr/local/nmap/share/nmap && patch -p0 < $patch); done
   - nmap --script-updatedb

--- a/.travis/ivre.conf
+++ b/.travis/ivre.conf
@@ -13,4 +13,10 @@ NMAP_SCAN_TEMPLATES["default"]["pings"] = []
 NMAP_SCAN_TEMPLATES["default"]["scans"] = "T"
 NMAP_SCAN_TEMPLATES["default"]["osdetect"] = False
 NMAP_SCAN_TEMPLATES["default"]["traceroute"] = False
+NMAP_SCAN_TEMPLATES["http"] = NMAP_SCAN_TEMPLATES["default"].copy()
+NMAP_SCAN_TEMPLATES["http"]["ports"] = "T:80"
+NMAP_SCAN_TEMPLATES["http"]['scripts_categories'] = []
+NMAP_SCAN_TEMPLATES["http"]['scripts_exclude'] = []
+NMAP_SCAN_TEMPLATES["http"]['scripts_force'] = ["http-title", "http-screenshot"]
+
 AGENT_MASTER_PATH = "/home/travis/var_lib/ivre/master"

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -1288,7 +1288,7 @@ class NmapHandler(ContentHandler):
                                            os.path.dirname(self._fname),
                                            fname)]:
                         try:
-                            with open(full_fname) as fdesc:
+                            with open(full_fname, 'rb') as fdesc:
                                 data = fdesc.read()
                                 trim_result = utils.trim_image(data)
                                 if trim_result:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,6 +29,7 @@ import json
 import os
 import random
 import re
+import shutil
 import signal
 import socket
 import subprocess
@@ -362,6 +363,7 @@ class IvreTests(unittest.TestCase):
                           for port in host.get('ports', [])
                           for word in port.get('screenwords', []))
         self.assertTrue('IVRE' in screenwords)
+        shutil.rmtree('scans')
 
         RUN(["ivre", "scancli", "--update-schema"])
         RUN(["ivre", "scancli", "--update-schema", "--archives"])
@@ -1116,6 +1118,9 @@ class IvreTests(unittest.TestCase):
 
         self.assertEqual(RUN(["ivre", "ipinfo", "--init"],
                               stdin=open(os.devnull))[0], 0)
+        # Clean
+        shutil.rmtree("logs")
+
 
     def test_data(self):
         """ipdata (Maxmind, thyme.apnic.net) functions"""
@@ -1607,6 +1612,8 @@ class IvreTests(unittest.TestCase):
                              stdin=open(os.devnull))[0], 0)
         self.assertEqual(RUN(["ivre", "runscansagentdb", "--init"],
                              stdin=open(os.devnull))[0], 0)
+        for dirname in ['agentsdata', 'scans', 'tmp']:
+            shutil.rmtree(dirname)
 
 
 TESTS = set(["nmap", "passive", "data", "utils", "scans"])


### PR DESCRIPTION
This fixes a Python 3 issue with screenshot files. It adds tests, for this bug, for the `http-screenshot` Nmap script, and for the screenshots integration in IVRE (including the use of Tesseract to extract words from screenshots).

It also makes agents able to handle screenshots and adds a `geometry` argument in the `http-screenshot` script to control the browser's window size.

Fixes #408.