### PR TITLE
Conf: allow setting a config file via env

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -84,6 +84,9 @@ You can override default values in three files:
     - `/usr/local/etc/ivre.conf` (read after, so higher priority)
   - one user-specific:
     - `~/.ivre.conf` (the last to be read, so highest priority)
+  - one environment based:
+    - `IVRE_CONF`, set it to the path of the configuration file to
+      read
 
 The file should contain lines of type `key = value`. Empty lines and
 comments (starting with the `#` character) are ignored. The following

--- a/ivre/config.py
+++ b/ivre/config.py
@@ -202,6 +202,8 @@ def get_config_file(paths=None):
                  for path in ['/etc', '/etc/ivre', '/usr/local/etc',
                               '/usr/local/etc/ivre']]
         paths.append(os.path.join(os.path.expanduser('~'), '.ivre.conf'))
+        if "IVRE_CONF" in os.environ:
+            paths.append(os.environ["IVRE_CONF"])
     for path in paths:
         if os.path.isfile(path):
             yield path

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1721,8 +1721,22 @@ class IvreTests(unittest.TestCase):
         for dirname in ['scans', 'tmp']:
             shutil.rmtree(dirname)
 
+    def test_conf(self):
+        # Ensure env var IVRE_CONF is taken into account
+        has_env_conf = "IVRE_CONF" in os.environ
+        if has_env_conf:
+            env_conf = os.environ["IVRE_CONF"]
+        else:
+            env_conf = __file__
+            os.environ["IVRE_CONF"] = env_conf
+        all_confs = list(ivre.config.get_config_file())
+        self.assertTrue(env_conf in all_confs,
+                        "Env conf %s should be in %s" % (env_conf, all_confs))
+        if not has_env_conf:
+            del os.environ["IVRE_CONF"]
 
-TESTS = set(["nmap", "passive", "data", "utils", "scans"])
+
+TESTS = set(["nmap", "passive", "data", "utils", "scans", "conf"])
 
 
 DATABASES = {


### PR DESCRIPTION
This PR allows to add a top priority configuration file by setting the environment variable `IVRE_CONF`.