### PR TITLE
ipinfo: fix `--short` when an IP is None

### DIFF
--- a/ivre/tools/ipinfo.py
+++ b/ivre/tools/ipinfo.py
@@ -127,7 +127,8 @@ def disp_recs_std(flt):
 
 def disp_recs_short(flt):
     for addr in db.passive.distinct('addr', flt=flt):
-        print(ivre.utils.int2ip(addr))
+        if addr is not None:
+            print(ivre.utils.int2ip(addr))
 
 
 def disp_recs_distinct(field, flt):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1244,6 +1244,9 @@ class IvreTests(unittest.TestCase):
         )
         self.assertEqual(count + new_count, total_count)
 
+        ret, out, err = RUN(["ivre", "ipinfo", "--short"])
+        self.assertEqual(ret, 0)
+
         self.assertEqual(RUN(["ivre", "ipinfo", "--init"],
                              stdin=open(os.devnull))[0], 0)
         # Clean


### PR DESCRIPTION
Also do not display `None` value when doing `ivre ipinfo --distinct addr`