### PR TITLE
Use BroFile to parse passiverecon logs

### DIFF
--- a/ivre/passive.py
+++ b/ivre/passive.py
@@ -177,8 +177,7 @@ def _prepare_rec(spec, ignorenets, neverignore):
 
 def handle_rec(sensor, ignorenets, neverignore,
                # these argmuments are provided by **bro_line
-               ts, host, srvport, recon_type, source, value, targetval):
-    recon_type = recon_type[14:]  # skip PassiveRecon::
+               timestamp, host, srvport, recon_type, source, value, targetval):
     if host is None:
         spec = {
             'targetval': targetval,
@@ -203,10 +202,11 @@ def handle_rec(sensor, ignorenets, neverignore,
         spec.update({'source': source})
     spec = _prepare_rec(spec, ignorenets, neverignore)
     # Python 2/3 compat: python 3 has datetime.timestamp()
-    if hasattr(ts, "timestamp"):
-        float_ts = ts.timestamp()
-    else:
-        float_ts = time.mktime(ts.timetuple()) + ts.microsecond / (1000.*1000.)
+    try:
+        float_ts = timestamp.timestamp()
+    except AttributeError:
+        float_ts = time.mktime(timestamp.timetuple()) \
+                   + timestamp.microsecond / (1000.*1000.)
     return float_ts, spec
 
 
@@ -335,6 +335,7 @@ _GETINFOS_FUNCTIONS = {
     'DNS_ANSWER': _getinfos_dns,
     'SSL_SERVER': _getinfos_cert,
 }
+
 
 def getinfos(spec):
     """This functions takes a document from a passive sensor, and

--- a/ivre/passive.py
+++ b/ivre/passive.py
@@ -28,6 +28,7 @@ This sub-module contains functions used for passive recon.
 import re
 import hashlib
 import subprocess
+import time
 
 
 from future.utils import viewitems
@@ -175,11 +176,10 @@ def _prepare_rec(spec, ignorenets, neverignore):
 
 
 def handle_rec(sensor, ignorenets, neverignore,
-               # these argmuments are provided by *<line.split()>
-               timestamp, host, port, recon_type, source, value,
-               targetval):
+               # these argmuments are provided by **bro_line
+               ts, host, srvport, recon_type, source, value, targetval):
     recon_type = recon_type[14:]  # skip PassiveRecon::
-    if host == '-':
+    if host is None:
         spec = {
             'targetval': targetval,
             'recontype': recon_type,
@@ -197,12 +197,17 @@ def handle_rec(sensor, ignorenets, neverignore,
         }
     if sensor is not None:
         spec.update({'sensor': sensor})
-    if port != '-':
-        spec.update({'port': int(port)})
+    if srvport is not None:
+        spec.update({'port': srvport})
     if source != '-':
         spec.update({'source': source})
     spec = _prepare_rec(spec, ignorenets, neverignore)
-    return float(timestamp), spec
+    # Python 2/3 compat: python 3 has datetime.timestamp()
+    if hasattr(ts, "timestamp"):
+        float_ts = ts.timestamp()
+    else:
+        float_ts = time.mktime(ts.timetuple()) + ts.microsecond / (1000.*1000.)
+    return float_ts, spec
 
 
 def _getinfos_http_client_authorization(spec):
@@ -330,7 +335,6 @@ _GETINFOS_FUNCTIONS = {
     'DNS_ANSWER': _getinfos_dns,
     'SSL_SERVER': _getinfos_cert,
 }
-
 
 def getinfos(spec):
     """This functions takes a document from a passive sensor, and


### PR DESCRIPTION
This is the first step to allow putting other standard bro logs into db. The goal was to refactor the `ivre.passive` code to be *less* adherent to how passiverecon logs are structured.