### PR TITLE
feat(docker/client): install  python-pil needed by scan2db to trim_image 

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get -q update
 ## libfreetype6 libfontconfig1 fonts-dejavu: screenshots w/ phantomjs
 RUN apt-get -qy install p0f rsync screen ipython openssl tesseract-ocr \
     libfreetype6 libfontconfig1 fonts-dejavu imagemagick ffmpeg s3270 \
-    patch bash-completion bzip2 bro
+    patch bash-completion bzip2 bro python-pil
 
 # Install Nmap. Use included libpcap because to use the workaround for
 # Nmap issue #34 (https://github.com/nmap/nmap/issues/34) since we do


### PR DESCRIPTION
avoid ivre/utils.py:702 warning 