### PR TITLE
Docker: fix doc and build for web-apache

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -111,9 +111,9 @@ that the version of IVRE on PyPI is not always up-to-date. From the
 ### Alternative build for the web image using Apache ###
 
 To use Apache (rather than Nginx) for the `ivre/web` image, simply
-run:
+run, from the `docker/` directory:
 
-    $ docker pull debian:stable
+    $ docker pull ivre/base  # or build it locally
     $ docker build -t ivre/web web-apache
 
 Unlike the default `ivre/web` image, this image uses the Debian
@@ -211,5 +211,5 @@ ivreclient`.
 
 ---
 
-This file is part of IVRE. Copyright 2011 - 2015
+This file is part of IVRE. Copyright 2011 - 2018
 [Pierre LALET](mailto:pierre.lalet@cea.fr)

--- a/docker/web-apache/Dockerfile
+++ b/docker/web-apache/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of IVRE.
-# Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2018 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -18,6 +18,10 @@ FROM ivre/base
 MAINTAINER Pierre LALET <pierre.lalet@cea.fr>
 
 # Install Apache2 & Dokuwiki
+## Dokuwiki does not exist in stable, but does in testing
+RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease
+RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list
+RUN apt-get -q update
 RUN apt-get -qy install apache2 dokuwiki
 
 # Add links for IVRE Web UI
@@ -50,6 +54,7 @@ ADD doku-conf-local.php etc/dokuwiki/local.php
 
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
+ENV APACHE_RUN_DIR /var/run/apache2
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_LOG_DIR /var/log/apache2
 ENV APACHE_PID_FILE /var/run/apache2.pid

--- a/web/dokuwiki/doc/docker.txt
+++ b/web/dokuwiki/doc/docker.txt
@@ -91,10 +91,10 @@ $ docker build -t ivre/base base-pip
 </code>
 ==== Alternative build for the web image using Apache ====
 
-To use Apache (rather than Nginx) for the ''%%ivre/web%%'' image, simply run:
+To use Apache (rather than Nginx) for the ''%%ivre/web%%'' image, simply run, from the ''%%docker/%%'' directory:
 
 <code>
-$ docker pull debian:stable
+$ docker pull ivre/base  # or build it locally
 $ docker build -t ivre/web web-apache
 
 </code>
@@ -195,5 +195,5 @@ If you do not want to exit the shell but only detach from it, use ''%%C-p C-q%%'
 
 ----
 
-This file is part of IVRE. Copyright 2011 - 2015 [[mailto:pierre.lalet@cea.fr|Pierre LALET]]
+This file is part of IVRE. Copyright 2011 - 2018 [[mailto:pierre.lalet@cea.fr|Pierre LALET]]
 


### PR DESCRIPTION
The documentation update is related to #483.

The build file (`Dockerfile`) has been fixed, and `ivre/web-apache` images should now be built automatically.