### PR TITLE
Passivereon: ignore more TCP banners based on c$service

### DIFF
--- a/bro/ivre/passiverecon/__load__.bro
+++ b/bro/ivre/passiverecon/__load__.bro
@@ -393,7 +393,8 @@ event pop3_request(c: connection, is_orig: bool, command: string, arg: string) {
 }
 
 event tcp_contents(c: connection, is_orig: bool, seq: count, contents: string) {
-    if (seq == 1 && !("ftp-data" in c$service)) {
+    if (seq == 1 && "ftp-data" !in c$service && "gridftp-data" !in c$service &&
+        "irc-dcc-data" !in c$service) {
         if (is_orig && c$resp$size == 0 && c$history == TCP_BANNER_HISTORY &&
             ! (TCP_CLIENT_BANNER_IGNORE in contents))
             Log::write(LOG, [$ts=c$start_time,


### PR DESCRIPTION
Namely: ignore gridftp-data & irc-dcc-data (ftp-data was already ignored)