### PR TITLE
Bro: handle header lines after data lines

### DIFF
--- a/requirements-mongo-26.txt
+++ b/requirements-mongo-26.txt
@@ -1,0 +1,4 @@
+pymongo>=2.7.2,<=3.6.1
+pycrypto
+future
+bottle


### PR DESCRIPTION
This will make Bro parser work with different log formats (`cat old_format.log new_format.log | ivre passiverecon2db` would crash or bug without this patch).

The PR also includes a patch to fix PyMongo version for Python 2.6 (MongoDB / Python 2.6 tests were broken without this).