### PR TITLE
runscansagentdb assign targets with an agent_id.

### DIFF
--- a/doc/AGENT.md
+++ b/doc/AGENT.md
@@ -124,6 +124,10 @@ Now we can add a scan, and assign the (available) agents to that scan:
 
     $ ivre runscansagentdb --assign-free-agents --routable --limit 1000
 
+We can also specify an agent id for the scan:
+
+        $ ivre runscansagentdb --assign 543bfc8a312f915728f1709b --routable --limit 1000
+
 And see if it works:
 
     $ ivre runscansagentdb --list-scans

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -1541,7 +1541,7 @@ class DBAgent(DB):
         """
         raise NotImplementedError
 
-    def add_scan(self, target, assign_to_free_agents=True):
+    def add_scan(self, target, assign_to_agent=None):
         itertarget = iter(target)
         try:
             fdesc = itertarget.fdesc
@@ -1563,9 +1563,15 @@ class DBAgent(DB):
             "lock": None
         }
         scanid = self._add_scan(scan)
-        if assign_to_free_agents:
+        if assign_to_agent is True:
+            # If no agent id is specified but "True" is passed then assign
+            # any free agents available).
             for agentid in self.get_free_agents():
                 self.assign_agent(agentid, scanid)
+        elif assign_to_agent is not None:
+            self.assign_agent(assign_to_agent, scanid)
+        # If no agent id is specified and assign-to-free agent is not set,
+        # just create the scan and do not affect it to an agent.
 
     def _add_scan(self, scan):
         raise NotImplementedError


### PR DESCRIPTION
`Runscansagentdb --assign` can now directly assign targets to an agent. This permit to avoid specifying a scan without agent and then specify the agent for the scan on another command.