### PR TITLE
GeoIP: rename EU* alias to EU

### DIFF
--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -631,13 +631,14 @@ class FakeArgparserParent(object):
 
 # Country aliases:
 #   - UK: GB
-#   - EU*: EU + 28 EU member states
+#   - EU: 28 EU member states, + EU itself, for historical reasons
 COUNTRY_ALIASES = {
     "UK": "GB",
-    "EU*": [
-        "EU", "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI",
-        "FR", "DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT",
-        "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "GB",
+    "EU": [
+        "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR",
+        "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK",
+        "SI", "ES", "SE", "GB",
+        "EU",
     ],
 }
 
@@ -650,9 +651,10 @@ def country_unalias(country):
 
       - "UK": alias for "GB".
 
-      - "EU*": alias for a list containing "EU" (which is a code used
-        in Maxming GeoIP database) plus the list of the country codes
-        of the European Union member states.
+      - "EU": alias for a list containing the list of the country
+        codes of the European Union member states. It also includes
+        "EU" itself, because that was a valid "country" code in
+        previous Maxmind GeoIP databases.
 
     """
     if isinstance(country, basestring):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -728,8 +728,8 @@ which `predicate()` is True, given `webflt`.
 
         self.check_nmap_count_value(
             "nmap_extended_eu_count",
-            ivre.db.db.nmap.searchcountry(['EU*', 'CH', 'NO']),
-            ["--country=EU*,CH,NO"], "country:EU*,CH,NO"
+            ivre.db.db.nmap.searchcountry(['EU', 'CH', 'NO']),
+            ["--country=EU,CH,NO"], "country:EU,CH,NO"
         )
 
         # Filters


### PR DESCRIPTION
Since "EU" is no longer a used country code in Maxmind GeoIP databases (since #530), this PR renames the previous "EU*" alias to "EU".