### PR TITLE
Fix minor things v1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,8 @@ specialized scripts.
           'web/static/templates/view-hosts.html',
           'web/static/templates/view-screenshots-only.html',
           'web/static/templates/view-scripts-only.html',
+          'web/static/templates/view-ports-only.html',
+          'web/static/templates/view-services-only.html',
           'web/static/templates/subview-cpes.html',
           'web/static/templates/subview-graph-elt-details.html',
           'web/static/templates/subview-host-summary.html',

--- a/web/static/templates/subview-host-summary.html
+++ b/web/static/templates/subview-host-summary.html
@@ -21,7 +21,7 @@
      ng-repeat="link in ::host.addr_links"
      ng-click="setparam(link.net)"
      >{{::link.addrpart}}<span ng-if="!$last">.</span></a>
-  <span ng-if="::host.hostnames_links">
+  <span ng-if="::(host.hostnames_links && host.hostnames_links.length)">
     (<span ng-repeat="hostnames in ::host.hostnames_links"><!--
     --><a class="clickable"
 	  ng-repeat="link in ::hostnames"


### PR DESCRIPTION
This PR fixes two minor things:
- The `view-ports-only.html` (used by the `displayPort` directive) and `view-services-only.html` (used by the `displayService` directive) files are missing from the `setup.py` file (since its creation).
- When an host doesn't have a name, some "OCD nagging" empty parentheses `()` are left behind in the rendered `subview-host-summary.html` template.