### PR TITLE
WebUI: multiple fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,8 @@ specialized scripts.
           'web/static/templates/view-hosts.html',
           'web/static/templates/view-screenshots-only.html',
           'web/static/templates/view-scripts-only.html',
+          'web/static/templates/view-ports-only.html',
+          'web/static/templates/view-services-only.html',
           'web/static/templates/subview-cpes.html',
           'web/static/templates/subview-graph-elt-details.html',
           'web/static/templates/subview-host-summary.html',

--- a/web/static/templates/subview-host-summary.html
+++ b/web/static/templates/subview-host-summary.html
@@ -21,7 +21,7 @@
      ng-repeat="link in ::host.addr_links"
      ng-click="setparam(link.net)"
      >{{::link.addrpart}}<span ng-if="!$last">.</span></a>
-  <span ng-if="::host.hostnames_links">
+  <span ng-if="::(host.hostnames_links && host.hostnames_links.length)">
     (<span ng-repeat="hostnames in ::host.hostnames_links"><!--
     --><a class="clickable"
 	  ng-repeat="link in ::hostnames"

--- a/web/static/templates/subview-port-summary.html
+++ b/web/static/templates/subview-port-summary.html
@@ -6,7 +6,7 @@
   under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
- 
+
   IVRE is distributed in the hope that it will be useful, but WITHOUT
   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
@@ -33,6 +33,6 @@
   </code>
 </span>
 <img ng-if="::port.screenshot == 'field'"
-     src="data:image/jpeg;base64,{{::port.screendata}}"
+     ng-src="data:image/jpeg;base64,{{::port.screendata}}"
      class="screenshot"
      alt="Screenshot for port {{::port.port}}"/>


### PR DESCRIPTION
This PR fixes three minor things:
- The `view-ports-only.html` (used by the `displayPort` directive) and `view-services-only.html` (used by the `displayService` directive) files are missing from the `setup.py` file (since its creation).
- When an host doesn't have a name, some "OCD nagging" empty parentheses `()` are left behind in the rendered `subview-host-summary.html` template.
- Using `ng-src` instead of `src` allowing Angular to compile the template 
before the browser tries to download the screenshot (shown in the browser console as an error `GET data:image/jpeg;base64,{{::port.screendata}} net::ERR_INVALID_URL`)