### PR TITLE
Passive: limit data size in subject and issuer of certificate records

### DIFF
--- a/ivre/passive.py
+++ b/ivre/passive.py
@@ -386,9 +386,14 @@ def _getinfos_cert(spec, to_binary):
     for key, value in list(viewitems(info)):
         if key in ['issuer', 'subject']:
             for skey, svalue in list(viewitems(value)):
-                if len(svalue) > utils.MAXVALLEN:
+                # We enforce a utils.MAXVALLEN // 10 size limits for
+                # subkey values in subject and issuer; this is because
+                # MongoDB cannot index values longer than 1024 bytes,
+                # and subject and issuer fields may have more than one
+                # key.
+                if len(svalue) > utils.MAXVALLEN // 10:
                     fullinfo.setdefault(key, {})[skey] = svalue
-                    info[key][skey] = svalue[:utils.MAXVALLEN]
+                    info[key][skey] = svalue[:utils.MAXVALLEN // 10]
         elif len(value) > utils.MAXVALLEN:
             fullinfo[key] = value
             info[key] = value[:utils.MAXVALLEN]


### PR DESCRIPTION
We enforce a `utils.MAXVALLEN // 10` size limits for subkey values in subject and issuer; this is because MongoDB cannot index values longer than 1024 bytes, and subject and issuer fields may have more than one key.