### PR TITLE
Update mongo.py

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -1115,7 +1115,7 @@ index) unsigned 128-bit integers in MongoDB.
         except (KeyError, ValueError):
             pass
         else:
-            update["$unset"]['addr'] = ""
+            update["$unset"] = { "addr": "" }
             update["$set"]["addr_0"] = addr[0]
             update["$set"]["addr_1"] = addr[1]
         updated = False


### PR DESCRIPTION
Fix migrate_schema_hosts_10_11(): a dict was being not initialized and made the update process crash