### PR TITLE
Passive: hide full{value,infos} from user, move it to MongoDB specific code

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -187,10 +187,6 @@ class PassiveCSVFile(CSVFile):
                 line.update(additional_info['infos'])
             except KeyError:
                 pass
-            try:
-                line.update(additional_info['fullinfos'])
-            except KeyError:
-                pass
         if "addr" in line:
             line["addr"] = self.ip2internal(line["addr"])
         else:
@@ -1762,8 +1758,7 @@ returns a generator.
                 self.tables.passive.lastseen, self.tables.passive.port,
                 self.tables.passive.recontype, self.tables.passive.source,
                 self.tables.passive.targetval, self.tables.passive.value,
-                self.tables.passive.fullvalue, self.tables.passive.info,
-                self.tables.passive.moreinfo
+                self.tables.passive.info, self.tables.passive.moreinfo
             ]).select_from(flt.select_from)
         )
         for key, way in sort or []:
@@ -1803,10 +1798,6 @@ returns the first result, or None if no result exists."""
                 spec.update(additional_info['infos'])
             except KeyError:
                 pass
-            try:
-                spec.update(additional_info['fullinfos'])
-            except KeyError:
-                pass
         addr = spec.pop("addr", None)
         if not isinstance(timestamp, datetime.datetime):
             timestamp = datetime.datetime.fromtimestamp(timestamp)
@@ -1833,7 +1824,6 @@ returns the first result, or None if no result exists."""
             'port': spec.pop("port", 0),
             'recontype': spec.pop("recontype"),
             # source, targetval, value: otherfields
-            'fullvalue': spec.pop("fullvalue", None),
             'info': info,
             'moreinfo': spec,
             'schema_version': spec.pop('schema_version', None),
@@ -1867,7 +1857,6 @@ passive table."""
                 except KeyError:
                     pass
                 line.update(line.pop('infos', {}))
-                line.update(line.pop('fullinfos', {}))
                 for key, value in viewitems(line):
                     if isinstance(value, dict) and len(value) == 1 \
                        and "$numberLong" in value:

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -1158,7 +1158,7 @@ class PostgresDBPassive(PostgresDB, SQLDBPassive):
                         'count', 'firstseen', 'lastseen',
                         # grouped
                         'sensor', 'port', 'recontype', 'source', 'targetval',
-                        'value', 'fullvalue', 'info', 'moreinfo'
+                        'value', 'info', 'moreinfo'
                     ]],
                     select([tmp.columns['addr'],
                             func.sum_(tmp.columns['count']),
@@ -1166,15 +1166,15 @@ class PostgresDBPassive(PostgresDB, SQLDBPassive):
                             func.max_(tmp.columns['lastseen'])] + [
                                 tmp.columns[col] for col in [
                                     'sensor', 'port', 'recontype', 'source',
-                                    'targetval', 'value', 'fullvalue', 'info',
-                                    'moreinfo']])\
+                                    'targetval', 'value', 'info', 'moreinfo'
+                                    ]])\
                     .where(
                         tmp.columns['addr'] != None
                         # noqa: E711 (BinaryExpression)
                     )\
                     .group_by(*(tmp.columns[col] for col in [
                         'addr', 'sensor', 'port', 'recontype', 'source',
-                        'targetval', 'value', 'fullvalue', 'info', 'moreinfo'
+                        'targetval', 'value', 'info', 'moreinfo'
                     ]))
                 )\
                 .on_conflict_do_update(
@@ -1204,7 +1204,7 @@ class PostgresDBPassive(PostgresDB, SQLDBPassive):
                         'count', 'firstseen', 'lastseen',
                         # grouped
                         'sensor', 'port', 'recontype', 'source', 'targetval',
-                        'value', 'fullvalue', 'info', 'moreinfo'
+                        'value', 'info', 'moreinfo'
                     ]],
                     select([tmp.columns['addr'],
                             func.sum_(tmp.columns['count']),
@@ -1212,15 +1212,15 @@ class PostgresDBPassive(PostgresDB, SQLDBPassive):
                             func.max_(tmp.columns['lastseen'])] + [
                                 tmp.columns[col] for col in [
                                     'sensor', 'port', 'recontype', 'source',
-                                    'targetval', 'value', 'fullvalue', 'info',
-                                    'moreinfo']])\
+                                    'targetval', 'value', 'info', 'moreinfo'
+                                    ]])\
                     .where(
                         tmp.columns['addr'] == None
                         # noqa: E711 (BinaryExpression)
                     )\
                     .group_by(*(tmp.columns[col] for col in [
                         'addr', 'sensor', 'port', 'recontype', 'source',
-                        'targetval', 'value', 'fullvalue', 'info', 'moreinfo'
+                        'targetval', 'value', 'info', 'moreinfo'
                     ]))
                 )\
                 .on_conflict_do_update(

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -542,10 +542,9 @@ class Passive(Base):
     source = Column(String(64))
     targetval = Column(Text)
     value = Column(Text)
-    fullvalue = Column(Text)
     info = Column(SQLJSONB)
     moreinfo = Column(SQLJSONB)
-    # moreinfo and fullvalue contain data that are not tested for
+    # moreinfo contain data that are not tested for
     # unicity on insertion (the unicity is guaranteed by the value)
     # for performance reasons
     schema_version = Column(Integer, default=passive.SCHEMA_VERSION)

--- a/ivre/keys.py
+++ b/ivre/keys.py
@@ -167,9 +167,7 @@ class SSLPassiveKey(PassiveKey, SSLKey):
         SSLKey.__init__(self)
 
     def getkeys(self, record):
-        certtext = self._der2key(record['fullvalue']
-                                 if 'fullvalue' in record
-                                 else record['value'])
+        certtext = self._der2key(record['value'])
         if certtext is None:
             return
 

--- a/ivre/tools/ipinfo.py
+++ b/ivre/tools/ipinfo.py
@@ -59,7 +59,7 @@ def disp_rec(rec):
     if 'source' in rec:
         print(rec['source'], end=' ')
     if 'value' in rec:
-        value = utils.printable(rec.get('fullvalue', rec['value']))
+        value = utils.printable(rec['value'])
         if isinstance(value, bytes):
             value = value.decode()
         print(value, end=' ')
@@ -149,10 +149,6 @@ def disp_recs_json(flt, sort, limit, skip):
                 del rec[fld]
             except KeyError:
                 pass
-        if 'fullvalue' in rec:
-            rec['value'] = rec.pop('fullvalue')
-        if 'fullinfos' in rec:
-            rec.setdefault('infos', {}).update(rec.pop('fullinfos'))
         if (rec.get('recontype') == 'SSL_SERVER' and
             rec.get('source') == 'cert' and
             isinstance(rec.get('value'), bytes)):

--- a/ivre/view.py
+++ b/ivre/view.py
@@ -37,7 +37,7 @@ def _extract_passive_HTTP_CLIENT_HEADER_SERVER(rec):
     # TODO: (?) handle Host: header for DNS
     # FIXME: catches ip addresses as domain name.
     if 'source' in rec and rec['source'] == 'HOST':
-        values = rec.get('fullvalue', rec['value']).split(".")
+        values = rec['value'].split(".")
         domains = [values.pop()]
         while values:
             domains.insert(0, values.pop() + "." + domains[0])
@@ -58,7 +58,7 @@ def _extract_passive_HTTP_SERVER_HEADER(rec):
     # TODO: handle other header values and merge them
     if rec.get('source') != 'SERVER':
         return {'ports': [port]}
-    value = rec.get('fullvalue', rec['value'])
+    value = rec['value']
     script = {'id': 'http-server-header', 'output': value}
     port['scripts'] = [script]
     banner = (b"HTTP/1.1 200 OK\r\nServer: " + utils.nmap_decode_data(value) +
@@ -79,13 +79,13 @@ def _extract_passive_HTTP_CLIENT_HEADER(rec):
     return {'ports': [{
         'port': -1,
         'scripts': [{'id': 'passive-http-user-agent',
-                     'output': rec.get('fullvalue', rec['value'])}],
+                     'output': rec['value']}],
     }]}
 
 
 def _extract_passive_TCP_SERVER_BANNER(rec):
     """Handle banners from tcp servers."""
-    value = rec.get('fullvalue', rec['value'])
+    value = rec['value']
     if rec['recontype'] == 'SSH_SERVER':
         value += "\r\n"
     port = {
@@ -117,7 +117,7 @@ def _extract_passive_SSH_SERVER_HOSTKEY(rec):
     #
     # (MAYBE) we should add a "lastseen" tag to every intel in view.
     value = utils.encode_b64(
-        utils.nmap_decode_data(rec.get('fullvalue', rec['value']))
+        utils.nmap_decode_data(rec['value'])
     ).decode()
     fingerprint = rec['infos']['md5']
     key = {'type': rec['infos']['algo'],
@@ -157,7 +157,7 @@ def _extract_passive_SSL_SERVER(rec):
     """Handle ssl server headers."""
     if rec.get('source') != 'cert':
         return {}
-    value = db.passive.from_binary(rec.get('fullvalue', rec['value']))
+    value = db.passive.from_binary(rec['value'])
     script = {"id": "ssl-cert"}
     port = {
         'state_state': 'open',
@@ -175,7 +175,7 @@ def _extract_passive_SSL_SERVER(rec):
 
 def _extract_passive_DNS_ANSWER(rec):
     """Handle dns server headers."""
-    name = rec.get('fullvalue', rec['value'])
+    name = rec['value']
     domains = rec['infos']['domain']
     return {'hostnames': [{'domains': domains,
                            'type': rec['source'].split('-', 1)[0],


### PR DESCRIPTION
Move 'fullvalue' and 'fullinfos' functions in mongodb specific code, since they are used only for size restrictions on mongodb indexes.