### PR TITLE
Make Ivre's Bro script compatible with Bro 2.5 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ before_script:
   - echo "NMAP_SHARE_PATH = '`pwd`/usr/local/nmap/share/nmap'" >> ~/.ivre.conf
   # install p0f, Bro & Nmap (.tar files)
   # for some reason, wget on travis-ci won't accept letsencrypt certificate
-  - for archive in tools-travis-ivre bro-2.6_ubuntu-`awk -F = '/^DISTRIB_RELEASE=/ {print $2}' /etc/lsb-release` nmap-7.60_ubuntu-precise; do wget -q --no-check-certificate https://ivre.rocks/data/tests/${archive}.tar.bz2 -O - | tar jxf - ; done
+  - BRO_VERSION="2.$((RANDOM % 2 + 5))"; echo "BRO_VERSION $BRO_VERSION"; for archive in tools-travis-ivre bro-${BRO_VERSION}_ubuntu-`awk -F = '/^DISTRIB_RELEASE=/ {print $2}' /etc/lsb-release` nmap-7.60_ubuntu-precise; do wget -q --no-check-certificate https://ivre.rocks/data/tests/${archive}.tar.bz2 -O - | tar jxf - ; done
   # get GeoIP CSV files -- we are supposed to build them, but that's
   # disabled in Travis since that's too slow
   - wget -q --no-check-certificate -P `python -c 'from ivre import config; print(config.GEOIP_PATH)'` https://ivre.rocks/data/tests/db/GeoLite2-{ASN,City,Country}.dump-IPv4.csv.bz2; bunzip2 "/`python -c 'from ivre import config; print(config.GEOIP_PATH)'`/"GeoLite2-{ASN,City,Country}.dump-IPv4.csv.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ before_script:
   - wget -q --no-check-certificate -O tests/samples/banners.pcap https://ivre.rocks/data/tests/banners.pcap
   - for file in tests/samples/*.cap; do mv "$file" "${file/.cap/.pcap}"; done
   - export BRO_SAMPLES=`pwd`/usr/local/bro/testing
-  - ivre --version; echo; bro --version
+  - ivre --version; echo; bro --version; echo; nmap --version
 
 script: (test "$DB" != "maxmind" || test "$TRAVIS_PYTHON_VERSION" = 2.6 || test "$TRAVIS_PYTHON_VERSION" = 3.3 || (flake8 --ignore= setup.py bin/ivre && flake8 --ignore=E402,W504 tests/tests.py && flake8 --ignore=W504 ivre/ && echo "flake8 OK (except W504)")) && (test "$DB" != "maxmind" || test "$TRAVIS_PYTHON_VERSION" != 3.7 || (codespell  --ignore-words=.travis/codespell_ignore `git ls-files | grep -vE '^web/static/(an|bs|d3|jq|lk)/|^data/'` 2>/dev/null && echo "codespell OK")) && cd tests/ && coverage erase && coverage run --parallel-mode tests.py --coverage && coverage combine && coverage report
 

--- a/bro/ivre/passiverecon/bare.bro
+++ b/bro/ivre/passiverecon/bare.bro
@@ -35,6 +35,7 @@ event bro_init() {
     Log::disable_stream(Weird::LOG);
     Log::disable_stream(Notice::LOG);
     Log::disable_stream(Files::LOG);
+    Log::disable_stream(Reporter::LOG);
 
     local filter = Log::get_filter(PassiveRecon::LOG, "default");
     filter$path = getenv("LOG_PATH") == "" ? "/dev/stdout" : getenv("LOG_PATH");

--- a/bro/ivre/passiverecon/ja3.bro
+++ b/bro/ivre/passiverecon/ja3.bro
@@ -92,13 +92,13 @@ event ssl_extension(c: connection, is_orig: bool, code: count, val: string) {
         if (code in grease) {
             next;
         }
-        c$ivreja3c$extensions += cat(code);
+        c$ivreja3c$extensions[|c$ivreja3c$extensions|] = cat(code);
     }
     else {
         if (! c?$ivreja3s) {
             c$ivreja3s = IvreJA3SStore();
         }
-        c$ivreja3s$extensions += cat(code);
+        c$ivreja3s$extensions[|c$ivreja3s$extensions|] = cat(code);
     }
 }
 
@@ -112,7 +112,7 @@ event ssl_extension_ec_point_formats(c: connection, is_orig: bool, point_formats
             if (point_format in grease) {
                 next;
             }
-            c$ivreja3c$ec_point_fmt += cat(point_format);
+            c$ivreja3c$ec_point_fmt[|c$ivreja3c$ec_point_fmt|] = cat(point_format);
         }
     }
 }
@@ -128,12 +128,16 @@ event ssl_extension_elliptic_curves(c: connection, is_orig: bool, curves: index_
             if (curve in grease) {
                 next;
             }
-            c$ivreja3c$e_curves += cat(curve);
+            c$ivreja3c$e_curves[|c$ivreja3c$e_curves|] = cat(curve);
         }
     }
 }
 
+@if(Version::number >= 20600 || (Version::number == 20500 && Version::info$commit >= 944))
 event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) &priority=1
+@else
+event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec) &priority=1
+@endif
 {
     if (! c?$ivreja3c) {
         c$ivreja3c = IvreJA3CStore();
@@ -145,7 +149,7 @@ event ssl_client_hello(c: connection, version: count, record_version: count, pos
         if (cipher in grease) {
             next;
         }
-        ciphers_string += cat(cipher);
+        ciphers_string[|ciphers_string|] = cat(cipher);
     }
 
     c$ssl$ivreja3c = fmt(
@@ -157,7 +161,11 @@ event ssl_client_hello(c: connection, version: count, record_version: count, pos
     );
 }
 
+@if(Version::number >= 20600 || (Version::number == 20500 && Version::info$commit >= 944))
 event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@else
+event ssl_server_hello(c: connection, version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@endif
 {
     if (! c?$ivreja3s) {
         c$ivreja3s = IvreJA3SStore();

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -22,7 +22,7 @@ to integrate screenshots, install
 [FFmpeg](http://ffmpeg.org/) and [PhantomJS](http://phantomjs.org/).
 
 If you plan to analyze PCAP file on a machine, install, depending on
-your needs, [Bro](http://www.bro.org/) (version 2.6 minimum),
+your needs, [Bro](http://www.bro.org/) (version 2.5 minimum),
 [p0f](http://lcamtuf.coredump.cx/p0f/) (version 2, will not work with
 version 3), [Argus](http://qosient.com/argus/) and/or
 [Nfdump](http://nfdump.sourceforge.net/).

--- a/doc/README.md
+++ b/doc/README.md
@@ -55,7 +55,7 @@ IVRE relies on:
   * optionally [ZMap](https://zmap.io/) and/or
     [Masscan](https://github.com/robertdavidgraham/masscan)
 
-  * [Bro](http://www.bro.org/) (version 2.6 minimum),
+  * [Bro](http://www.bro.org/) (version 2.5 minimum),
     [Argus](http://qosient.com/argus/),
     [Nfdump](https://github.com/phaag/nfdump)&
     [p0f](http://lcamtuf.coredump.cx/p0f/) (version 2, will not work
@@ -121,7 +121,7 @@ recon, you can skip this part.
 
 ## Using Bro ##
 
-You need to run Bro (2.6 minimum, regularly tested with 2.6) with the
+You need to run Bro (2.5 minimum, tested with 2.5 and 2.6) with the
 option `-b` and the location of the `passiverecon/bare.bro` file. If
 you want to run it on the `eth0` interface, for example, run (replace
 `/usr/share/ivre` by the appropriate location; use `python -c 'import

--- a/web/dokuwiki/doc/install.txt
+++ b/web/dokuwiki/doc/install.txt
@@ -10,7 +10,7 @@ If you want to use the "flow" module, you also need to install [[http://neo4j.co
 
 If you plan to run scans from a machine, install [[http://nmap.org/|Nmap]] and optionally [[https://zmap.io/|ZMap]] and [[https://github.com/robertdavidgraham/masscan|Masscan]]. If you want to integrate screenshots, install [[https://github.com/tesseract-ocr/tesseract|Tesseract]], [[https://www.imagemagick.org/|ImageMagick]], [[http://ffmpeg.org/|FFmpeg]] and [[http://phantomjs.org/|PhantomJS]].
 
-If you plan to analyze PCAP file on a machine, install, depending on your needs, [[http://www.bro.org/|Bro]] (version 2.6 minimum), [[http://lcamtuf.coredump.cx/p0f/|p0f]] (version 2, will not work with version 3), [[http://qosient.com/argus/|Argus]] and/or [[http://nfdump.sourceforge.net/|Nfdump]].
+If you plan to analyze PCAP file on a machine, install, depending on your needs, [[http://www.bro.org/|Bro]] (version 2.5 minimum), [[http://lcamtuf.coredump.cx/p0f/|p0f]] (version 2, will not work with version 3), [[http://qosient.com/argus/|Argus]] and/or [[http://nfdump.sourceforge.net/|Nfdump]].
 
 To install IVRE, you'll need [[http://www.python.org/|Python]] 2 (version 2.6 minimum, prefer 2.7) or 3 (version 3.3 minimum), with the following modules:
 

--- a/web/dokuwiki/doc/readme.txt
+++ b/web/dokuwiki/doc/readme.txt
@@ -26,7 +26,7 @@ IVRE relies on:
     * optionally [[http://www.sqlalchemy.org/|sqlalchemy]] and [[http://initd.org/psycopg/|psycopg2]] to use the **experimental** PostgreSQL backend.
   * [[http://nmap.org/|Nmap]] version 7.25BETA2 minimum (actually, earlier versions can be used by setting ''%%script_timeout%%'' to ''%%None%%'' in each scan template).
   * optionally [[https://zmap.io/|ZMap]] and/or [[https://github.com/robertdavidgraham/masscan|Masscan]]
-  * [[http://www.bro.org/|Bro]] (version 2.6 minimum), [[http://qosient.com/argus/|Argus]], [[https://github.com/phaag/nfdump|Nfdump]]& [[http://lcamtuf.coredump.cx/p0f/|p0f]] (version 2, will not work with version 3) for the passive fingerprint and flow modules.
+  * [[http://www.bro.org/|Bro]] (version 2.5 minimum), [[http://qosient.com/argus/|Argus]], [[https://github.com/phaag/nfdump|Nfdump]]& [[http://lcamtuf.coredump.cx/p0f/|p0f]] (version 2, will not work with version 3) for the passive fingerprint and flow modules.
   * [[http://www.mongodb.org/|MongoDB]], version 2.6 minimum (tests are run with versions 2.6.12, 3.0.15, 3.2.21, 3.4.17, 3.6.8, 4.0.2 and 4.1.3).
   * optionally [[http://neo4j.com/|Neo4j]] for the flow module.
   * optionally [[https://www.postgresql.org/|PostgreSQL]], version 9.5 minimum (tests are run with versions 9.5.10, 9.6.6 and 10.1), for the **experimental** PostgreSQL backend.
@@ -56,7 +56,7 @@ The following steps will show some examples of **passive** network recon with IV
 
 ===== Using Bro =====
 
-You need to run Bro (2.6 minimum, regularly tested with 2.6) with the option ''%%-b%%'' and the location of the ''%%passiverecon/bare.bro%%'' file. If you want to run it on the ''%%eth0%%'' interface, for example, run (replace ''%%/usr/share/ivre%%'' by the appropriate location; use ''%%python -c 'import ivre.config; print(ivre.config.guess_prefix())'%%'' if you cannot find it):
+You need to run Bro (2.5 minimum, tested with 2.5 and 2.6) with the option ''%%-b%%'' and the location of the ''%%passiverecon/bare.bro%%'' file. If you want to run it on the ''%%eth0%%'' interface, for example, run (replace ''%%/usr/share/ivre%%'' by the appropriate location; use ''%%python -c 'import ivre.config; print(ivre.config.guess_prefix())'%%'' if you cannot find it):
 
 <code>
 # mkdir logs


### PR DESCRIPTION
#624 made Ivre's "passiverecon" Bro script compatible with Bro 2.6 only. It was actually easier than I initially thought to continue to also support 2.5(.x).

This also adds Travis tests with random Bro versions (2.5 and 2.6).