### PR TITLE
WebUI: Added display vulnerabilities only filter.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -435,4 +435,5 @@ web/static/templates/view-ports-only.html
 web/static/templates/view-screenshots-only.html
 web/static/templates/view-scripts-only.html
 web/static/templates/view-services-only.html
+web/static/templates/view-vulnerabilities-only.html
 web/wsgi/app.wsgi

--- a/doc/WEBUI.md
+++ b/doc/WEBUI.md
@@ -240,6 +240,7 @@ single or double quotes.
     `display:script:[script id],[script id],...` only display (a
     particular) script outputs.
   - `display:screenshot` only display screenshots.
+  - `display:vulnerability` only display vulnerabilities.
 
 
 ---

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,7 @@ specialized scripts.
           'web/static/templates/view-scripts-only.html',
           'web/static/templates/view-ports-only.html',
           'web/static/templates/view-services-only.html',
+          'web/static/templates/view-vulnerabilities-only.html',
           'web/static/templates/subview-cpes.html',
           'web/static/templates/subview-graph-elt-details.html',
           'web/static/templates/subview-host-summary.html',

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -148,9 +148,8 @@ If your command includes spaces, you need to protect it by using single or doubl
   * ''%%display:cpe%%'' only display CPEs.
   * ''%%display:script:%%'', ''%%display:script:[script id]%%'' or ''%%display:script:[script id],[script id],...%%'' only display (a particular) script outputs.
   * ''%%display:screenshot%%'' only display screenshots.
-
+  * ''%%display:vulnerability%%'' only display vulnerabilities.
 
 ----
 
 This file is part of IVRE. Copyright 2011 - 2018 [[mailto:pierre.lalet@cea.fr|Pierre LALET]]
-

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -81,6 +81,7 @@
 	  <div ng-switch-when="cpe" display-cpe=""></div>
 	  <div ng-switch-when="port" display-port=""></div>
 	  <div ng-switch-when="service" display-service=""></div>
+	  <div ng-switch-when="vulnerability" display-vulnerability=""></div>
 	  <div ng-switch-default="host" display-host=""></div>
 	</div>
 	<div id="notes-container" class="col-sm-12 col-sm-offset-12 col-md-5 col-md-offset-7"

--- a/web/static/ivre/content.js
+++ b/web/static/ivre/content.js
@@ -416,6 +416,10 @@ var HELP_FILTERS = {
 	    "title": "display:cpe",
 	    "content": "Display only CPEs.",
 	},
+	"display:vulnerability": {
+	    "title": "display:vulnerability",
+	    "content": "Display only vulnerabilities.",
+	},
     },
 };
 

--- a/web/static/ivre/controllers.js
+++ b/web/static/ivre/controllers.js
@@ -328,8 +328,10 @@ ivreWebUi
 	$scope.results = [];
 	$scope.display_mode = "host";
 	$scope.display_mode_args = [];
-	$scope.script_display_mode_needed_scripts_group = function(scripts) {
+	$scope.script_display_mode_needed_scripts_group = function(scripts, vulns = false) {
 	    if(scripts === undefined || scripts.length === 0)
+		return false;
+	    if(vulns && !scripts.some(function (x) { return x.hasOwnProperty('vulns'); }))
 		return false;
 	    if($scope.display_mode_args.length === 0)
 		return true;
@@ -525,6 +527,11 @@ ivreWebUi
 	    templateUrl: 'templates/view-cpes-only.html'
 	};
     })
+    .directive('displayVulnerability', function() {
+	return {
+	    templateUrl: 'templates/view-vulnerabilities-only.html'
+	};
+    })
     .directive('hostSummary', function() {
 	return {
 	    templateUrl: 'templates/subview-host-summary.html'
@@ -639,6 +646,10 @@ function set_display_mode(mode) {
     else if (mode.substr(0, 8) === "service:") {
         args = mode.substr(8).split(',');
 	mode = "service";
+    }
+    else if (mode.substr(0, 13) === "vulnerability") {
+        args = [];
+	mode = "vulnerability";
     }
     scope.display_mode_args = args;
     scope.display_mode = mode;

--- a/web/static/templates/view-vulnerabilities-only.html
+++ b/web/static/templates/view-vulnerabilities-only.html
@@ -1,0 +1,52 @@
+<!--
+  This file is part of IVRE.
+  Copyright 2011 - 2018 Pierre LALET <pierre.lalet@cea.fr>
+
+  IVRE is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  IVRE is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="result-container"
+     ng-repeat="host in results"
+     >
+  <div host-summary=""></div>
+  <div class="full">
+    <!-- ports w/ scripts, etc. -->
+    <dt ng-repeat-start="port in ::host.ports | orderBy:['protocol','port']"
+	ng-if="::port.port !== -1 && script_display_mode_needed_scripts_group(port.scripts, true)"
+	class="port">
+      <div port-summary=""></div>
+    </dt>
+    <dd ng-repeat-end
+	ng-if="port.port !== -1 && script_display_mode_needed_scripts_group(port.scripts, true)">
+      <div ng-if="::port.service_name"
+	   class="result-service"
+	   service-summary="">
+      </div>
+      <div ng-repeat="script in ::port.scripts | filter:{vulns: '!'}">
+	{{::script.id}}
+	<pre class="result-scripts-output"
+	     script-output="port"/>
+      </div>
+    </dd>
+    <!-- hostscripts -->
+    <dt class="result-host-scripts"
+	ng-if="script_display_mode_needed_scripts_group(host.scripts, true)"
+	>Host scripts</dt>
+    <dd ng-repeat="script in ::host.scripts | filter:{vulns: '!'}">
+      {{::script.id}}
+      <pre class="result-scripts-output"
+	   script-output="host"/>
+    </dd>
+  </div>
+</div>


### PR DESCRIPTION
Added a new filter display directive (`display:vulnerability`) that will only display script outputs that report vulnerabilities. Currently it doesn't support:

- Highlighting: when using the `vuln:(:[vuln id](:[status]))` it doesn't highlight the script output reporting the specified vulnerability.
- Filtering: it doesn't support filtering by vulnerability identifier, as something like `display:vulnerability(:[vulnerability id](,[vulnerability id](,...)))` would