### PR TITLE
DB/Mongo: Fix top CPE (object of type 'zip' has no len()")

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -2596,7 +2596,7 @@ it is not expected)."""
             cpeflt2 = dict(("cpes.%s" % key, value) for key, value in cpeflt)
             # We need to keep enough cpes.* fields for the projection
             # *and* for our filter
-            fields = fields[:max(fields.index(field), len(cpeflt)) + 1]
+            fields = fields[:max(fields.index(field), len(cpeflt2)) + 1]
             flt = self.flt_and(flt, cpeflt1)
             specialproj = dict(("cpes.%s" % fname, 1) for fname in fields)
             specialproj["_id"] = 0


### PR DESCRIPTION
While calculating the top CPEs, I got the following error.

```
Traceback (most recent call last):
  File "/usr/lib64/python3.7/wsgiref/handlers.py", line 138, in run
    self.finish_response()
  File "/usr/lib64/python3.7/wsgiref/handlers.py", line 179, in finish_response
    for data in self.result:
  File "/home/ivre/.env-ivre/lib/python3.7/site-packages/ivre/web/app.py", line 295, in get_nmap_top
    topnbr=topnbr))
  File "/home/ivre/.env-ivre/lib/python3.7/site-packages/ivre/db/mongo.py", line 2599, in topvalues
    fields = fields[:max(fields.index(field), len(cpeflt)) + 1]
TypeError: object of type 'zip' has no len()
```

Python 3 no longer supports using the `len` built-in on `zip` objects. The best (?) option is to convert the `cpeflt` to a list before trying to calculate the length. Since the `cpeflt` will be small, the performance penalty is negligible.
