### PR TITLE
DB/Neo4j: pin py2neo version to 3.*

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -34,8 +34,8 @@ following modules:
   * [Bottle](https://bottlepy.org/)
   * [Crypto](http://www.pycrypto.org/)
   * [pymongo](http://api.mongodb.org/python/) version 2.7.2 minimum.
-  * [py2neo](http://py2neo.org/v3/) version 3 minimum, optional, to
-    use the flow module.
+  * [py2neo](http://py2neo.org/v3/) version 3, optional, to use the
+    flow module.
   * [sqlalchemy](http://www.sqlalchemy.org/) and
     [psycopg2](http://initd.org/psycopg/) to use the experimental
     PostgreSQL backend.

--- a/requirements-neo4j.txt
+++ b/requirements-neo4j.txt
@@ -1,4 +1,4 @@
-py2neo>=3
+py2neo>=3,<4
 pycrypto
 future
 bottle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pymongo>=2.7.2
-py2neo>=3
+py2neo>=3,<4
 pycrypto
 sqlalchemy
 psycopg2

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ specialized scripts.
         'bottle',
     ],
     extras_require={
-        'Flow': ["py2neo>=3"],
+        'Flow': ["py2neo>=3,<4"],
         'PostgreSQL': ["sqlalchemy", "psycopg2"],
         'GSSAPI authentication': ["python-krbV"],
         'Screenshots': ["PIL"],

--- a/web/dokuwiki/doc/install.txt
+++ b/web/dokuwiki/doc/install.txt
@@ -17,7 +17,7 @@ To install IVRE, you'll need [[http://www.python.org/|Python]] 2 (version 2.6 mi
   * [[https://bottlepy.org/|Bottle]]
   * [[http://www.pycrypto.org/|Crypto]]
   * [[http://api.mongodb.org/python/|pymongo]] version 2.7.2 minimum.
-  * [[http://py2neo.org/v3/|py2neo]] version 3 minimum, optional, to use the flow module.
+  * [[http://py2neo.org/v3/|py2neo]] version 3, optional, to use the flow module.
   * [[http://www.sqlalchemy.org/|sqlalchemy]] and [[http://initd.org/psycopg/|psycopg2]] to use the experimental PostgreSQL backend.
   * [[http://www.pythonware.com/products/pil/|PIL]] optional, to trim screenshots.
 


### PR DESCRIPTION
The API has changed in version 4, and we do not want to spend time to port IVRE's code to py2neo 4 for now.

Fixes #571.