### PR TITLE
DB/View: support regexp lookups in .searchja3*()

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -1222,17 +1222,17 @@ class DBView(DBActive):
                 # There are no additional arguments
                 flt = self.flt_and(flt, self.searchja3server())
             else:
-                splitted = args.ssl_ja3_server.split(':', 1)
-                if len(splitted) == 1:
+                split = args.ssl_ja3_server.split(':', 1)
+                if len(split) == 1:
                     # Only a JA3 server is given
                     flt = self.flt_and(flt, self.searchja3server(
-                        value_or_hash_srv=splitted[0]
+                        value_or_hash=split[0]
                     ))
                 else:
                     # Both client and server JA3 are given
                     flt = self.flt_and(flt, self.searchja3server(
-                        value_or_hash_srv=splitted[0],
-                        value_or_hash_clt=splitted[1]
+                        value_or_hash=split[0],
+                        client_value_or_hash=split[1],
                     ))
         return flt
 
@@ -1418,20 +1418,21 @@ class DBView(DBActive):
         return cls._searchja3(value_or_hash, 'ssl-ja3-client', neg=neg)
 
     @classmethod
-    def searchja3server(cls, value_or_hash_srv=None,
-                        value_or_hash_clt=None, neg=False):
+    def searchja3server(cls, value_or_hash=None, client_value_or_hash=None,
+                        neg=False):
         script_id = 'ssl-ja3-server'
-        if not value_or_hash_clt:
-            return cls._searchja3(value_or_hash_srv, script_id, neg=neg)
-        key_client, value_client = cls.ja3keyvalue(value_or_hash_clt)
+        if not client_value_or_hash:
+            return cls._searchja3(value_or_hash, script_id, neg=neg)
+        key_client, value_client = cls.ja3keyvalue(client_value_or_hash)
         values = {'client.%s' % (key_client): value_client}
-        if value_or_hash_srv:
-            key_srv, value_srv = cls.ja3keyvalue(value_or_hash_srv)
+        if value_or_hash:
+            key_srv, value_srv = cls.ja3keyvalue(value_or_hash)
             values[key_srv] = value_srv
         return cls.searchscript(
             name=script_id,
             values=values,
-            neg=neg)
+            neg=neg,
+        )
 
 
 class _RecInfo(object):

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of IVRE.
-# Copyright 2011 - 2018 Pierre LALET <pierre.lalet@cea.fr>
+# Copyright 2011 - 2019 Pierre LALET <pierre.lalet@cea.fr>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -480,18 +480,18 @@ def flt_from_query(query, base_flt=None):
                 # There are no additional arguments
                 flt = db.view.flt_and(flt, db.view.searchja3server(neg=neg))
             else:
-                splitted = value.split(':', 1)
-                if len(splitted) == 1:
+                split = value.split(':', 1)
+                if len(split) == 1:
                     # Only a JA3 server is given
                     flt = db.view.flt_and(flt, db.view.searchja3server(
-                        value_or_hash_srv=splitted[0],
+                        value_or_hash=split[0],
                         neg=neg,
                     ))
                 else:
                     # Both client and server JA3 are specified
                     flt = db.view.flt_and(flt, db.view.searchja3server(
-                        value_or_hash_srv=splitted[0],
-                        value_or_hash_clt=splitted[1],
+                        value_or_hash=split[0],
+                        client_value_or_hash=split[1],
                         neg=neg,
                     ))
         # OS fingerprint

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -472,7 +472,8 @@ def flt_from_query(query, base_flt=None):
             flt = db.view.flt_and(flt, db.view.searchxp445())
         elif param == "ssl-ja3-client":
             flt = db.view.flt_and(flt, db.view.searchja3client(
-                value_or_hash=value,
+                value_or_hash=(None if value is None else
+                               utils.str2regexp(value)),
                 neg=neg
             ))
         elif param == "ssl-ja3-server":
@@ -480,11 +481,12 @@ def flt_from_query(query, base_flt=None):
                 # There are no additional arguments
                 flt = db.view.flt_and(flt, db.view.searchja3server(neg=neg))
             else:
-                split = value.split(':', 1)
+                split = [utils.str2regexp(v) if v else None
+                         for v in value.split(':', 1)]
                 if len(split) == 1:
                     # Only a JA3 server is given
                     flt = db.view.flt_and(flt, db.view.searchja3server(
-                        value_or_hash=split[0],
+                        value_or_hash=(split[0]),
                         neg=neg,
                     ))
                 else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2940,7 +2940,7 @@ which `predicate()` is True, given `webflt`.
         self.check_view_count_value(
             "view_count_ja3_server_a95",
             ivre.db.db.view.searchja3server(
-                value_or_hash_srv=ja3s
+                value_or_hash=ja3s
             ),
             ["--ssl-ja3-server", ja3s],
             "ssl-ja3-server:%s" % ja3s,
@@ -2948,8 +2948,8 @@ which `predicate()` is True, given `webflt`.
         self.check_view_count_value(
             "view_count_ja3_server_a95_fd22",
             ivre.db.db.view.searchja3server(
-                value_or_hash_srv=ja3s,
-                value_or_hash_clt=ja3
+                value_or_hash=ja3s,
+                client_value_or_hash=ja3
             ),
             ["--ssl-ja3-server", "%s:%s" % (ja3s, ja3)],
             "ssl-ja3-server:%s:%s" % (ja3s, ja3),
@@ -2957,7 +2957,7 @@ which `predicate()` is True, given `webflt`.
         self.check_view_count_value(
             "view_count_ja3_server_clt_fd22",
             ivre.db.db.view.searchja3server(
-                value_or_hash_clt=ja3
+                client_value_or_hash=ja3
             ),
             ["--ssl-ja3-server", ":%s" % (ja3)],
             "ssl-ja3-server::%s" % (ja3),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2922,10 +2922,18 @@ which `predicate()` is True, given `webflt`.
         self.check_view_count_value(
             "view_count_ja3_client_raw",
             ivre.db.db.view.searchja3client(
-                value_or_hash=ja3_raw
+                value_or_hash=ja3_raw,
             ),
             ["--ssl-ja3-client", ja3_raw],
             "ssl-ja3-client:%s" % ja3_raw,
+        )
+        self.check_view_count_value(
+            "view_count_ja3_client_raw",
+            ivre.db.db.view.searchja3client(
+                value_or_hash=re.compile('^%s$' % ja3_raw),
+            ),
+            ["--ssl-ja3-client", '/^%s$/' % ja3_raw],
+            "ssl-ja3-client:/^%s$/" % ja3_raw,
         )
         ja3 = "fd2273056f386e0ba8004e897c337037"
         self.check_view_count_value(


### PR DESCRIPTION
This PR also fixes `DBView.searchja3server()` API to match `DBPassive.searchja3server()`.