### PR TITLE
Import User-Agents from passive into view with corresponding filters

### DIFF
--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -312,7 +312,7 @@ def str2regexp(string):
 
     """
     if string.startswith('/'):
-        string = string.split('/', 2)[1:]
+        string = string[1:].rsplit('/', 1)
         if len(string) == 1:
             string.append('')
         string = re.compile(

--- a/ivre/view.py
+++ b/ivre/view.py
@@ -78,8 +78,9 @@ def _extract_passive_HTTP_CLIENT_HEADER(rec):
         return {}
     return {'ports': [{
         'port': -1,
-        'scripts': [{'id': 'passive-http-user-agent',
-                     'output': rec['value']}],
+        'scripts': [{'id': 'http-user-agent',
+                     'output': rec['value'],
+                     'http-user-agent': [rec['value']]}],
     }]}
 
 

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -496,6 +496,11 @@ def flt_from_query(query, base_flt=None):
                         client_value_or_hash=split[1],
                         neg=neg,
                     ))
+        elif param == "http-user-agent":
+            flt = db.view.flt_and(flt, db.view.searchscript(
+                name=param,
+                output=(utils.str2regexp(value) if value else None),
+                neg=neg))
         # OS fingerprint
         elif not neg and param == "os":
             flt = db.view.flt_and(

--- a/tests/results-public-samples
+++ b/tests/results-public-samples
@@ -259,3 +259,5 @@ view_count_ja3_server_a95 = 9
 view_count_ja3_server_a95_fd22 = 4
 view_count_ja3_client_raw = 1
 view_count_ja3_server_clt_fd22 = 5
+view_count_http_user_agent = 6
+view_count_http_user_agent_URL_7_3 = 3

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2970,6 +2970,25 @@ which `predicate()` is True, given `webflt`.
             ["--ssl-ja3-server", ":%s" % (ja3)],
             "ssl-ja3-server::%s" % (ja3),
         )
+        self.check_view_count_value(
+            "view_count_http_user_agent",
+            ivre.db.db.view.searchscript(name='http-user-agent'),
+            ["--http-user-agent"],
+            "http-user-agent",
+        )
+        ret, out, err = RUN(["ivre", "view", "--host", "10.251.23.139"])
+        self.assertEqual(ret, 0)
+        self.assertTrue(not err)
+        self.assertTrue("http-user-agent" in out.decode())
+        regexp = '/URL/7.3/i'
+        self.check_view_count_value(
+            "view_count_http_user_agent_URL_7_3",
+            ivre.db.db.view.searchscript(
+                name='http-user-agent',
+                output=ivre.utils.str2regexp(regexp)),
+            ["--http-user-agent", regexp],
+            "http-user-agent:%s" % regexp,
+        )
 
     def test_conf(self):
         # Ensure env var IVRE_CONF is taken into account

--- a/web/dokuwiki/doc/webui.txt
+++ b/web/dokuwiki/doc/webui.txt
@@ -125,6 +125,7 @@ If your command includes spaces, you need to protect it by using single or doubl
   * ''%%xp445%%'' look for Windows XP machines with TCP/445 port open.
   * ''%%[!]ssl-ja3-client[:JA3]%%'' look for hosts with a JA3 or with the given JA3.
   * ''%%[!]ssl-ja3-server[:[JA3S][:JA3]]%%'' look for hosts with a JA3S, with the given JA3S, with a JA3S corresponding to the given JA3 or with the given JA3S corresponding to the given JA3.
+  * ''%%[!]http-user-agent[:[string or regexp]]%%'' look for hosts using a User-Agent matching the argument.
   * ''%%os:%%'' look for a specific value in the OS discovery results.
   * ''%%devtype:%%'', ''%%devicetype:%%'' look for a type of devices.
   * ''%%netdev%%'', ''%%networkdevice%%'' look for network devices (firewalls, routers, ...).

--- a/web/static/ivre/content.js
+++ b/web/static/ivre/content.js
@@ -306,6 +306,10 @@ var HELP_FILTERS = {
 	    "title": "(!)ssl-ja3-server<b>[:[JA3S][:JA3]]</b>",
 	    "content": "Look for hosts with a JA3S, with the given JA3S, with a JA3S corresponding to the given JA3 or with the given JA3S corresponding to the given JA3",
 	},
+	"http-user-agent": {
+	    "title": "(!)http-user-agent<b>[:[string or regexp]]</b>",
+	    "content": "Look for hosts using a User-Agent matching the argument."
+	},
 	/* OS fingerprint */
 	"os:": {
 	    "title": "os:<b>[string or regexp]</b>",


### PR DESCRIPTION
The option `http-user-agent` (cli and webui) accepts : 
- nothing : every hosts known to use a User-Agent will be retrieved.
- or a string : that will retrieve every hosts which use this exact User-Agent
- or a regular expression : that will retrieve every hosts which use a User-Agent that matches the regex
