### PR TITLE
 Split package into ivre, ivre-docs, ivre-web, python{,2}-ivre and ivre-data

### DIFF
--- a/ivre/geoiputils.py
+++ b/ivre/geoiputils.py
@@ -92,12 +92,14 @@ def unzip_all(fname, cond=None, clean=True):
         os.unlink(os.path.join(config.GEOIP_PATH, fname))
 
 
-def gunzip(fname):
+def gunzip(fname, clean=True):
     if not fname.endswith('.gz'):
         raise Exception('filename should end with ".gz"')
     with utils.open_file(os.path.join(config.GEOIP_PATH, fname)) as inp:
         with open(os.path.join(config.GEOIP_PATH, fname[:-3]), "wb") as outp:
             outp.write(inp.read())
+    if clean:
+        os.unlink(os.path.join(config.GEOIP_PATH, fname))
 
 
 def untar_all(fname, cond=None, clean=True):

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -19,7 +19,8 @@
 # along with IVRE. If not, see <http://www.gnu.org/licenses/>.
 
 pkgbase='ivre'
-pkgname=('ivre' 'ivre-web' 'ivre-docs' 'python-ivre' 'python2-ivre')
+# ivre-data must be the last one as it changes $pkgver
+pkgname=('ivre' 'ivre-docs' 'ivre-web' 'python-ivre' 'python2-ivre' 'ivre-data')
 pkgver=0.9.12
 pkgrel=1
 pkgdesc='Network recon framework'
@@ -70,6 +71,16 @@ package_ivre() {
      "${pkgdir}/usr/share/ivre/dokuwiki" \
      "${pkgdir}/usr/share/ivre/web"
   install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" doc/LICENSE*
+}
+
+package_ivre-data() {
+  pkgdesc+=' (data files)'
+  pkgver+="_`date -u +%Y%m%d%H%M%S`"
+  cd "$srcdir/$pkgbase"
+  mkdir -p "${pkgdir}/usr/share/ivre/geoip"
+  echo "GEOIP_PATH = '${pkgdir}/usr/share/ivre/geoip'" > tmp_ivre_conf
+  PYTHONPATH=./build/lib IVRE_CONF=./tmp_ivre_conf ./build/script*/ivre ipdata --download --import-all
+  rm tmp_ivre_conf
 }
 
 package_ivre-docs() {

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -18,59 +18,138 @@
 # You should have received a copy of the GNU General Public License
 # along with IVRE. If not, see <http://www.gnu.org/licenses/>.
 
-pkgname='ivre'
+pkgbase='ivre'
+pkgname=('ivre' 'ivre-web' 'ivre-docs' 'python-ivre' 'python2-ivre')
 pkgver=0.9.12
 pkgrel=1
 pkgdesc='Network recon framework'
 arch=('any')
 url='https://ivre.rocks/'
 license=('GPL3')
-depends=('python' 'python-pymongo' 'python-future' 'python-bottle')
-optdepends=('python-py2neo: experimental flow analysis (Neo4j backend)'
-            'python-sqlalchemy: experimental PostgreSQL & SQLite backends'
-            'python-psycopg2: experimental PostgreSQL backend'
-            'python-pillow: trim screenshots on insertion'
-            'tesseract: extract words from screenshots on insertion'
-            'python-crypto: extract data from public keys ("ivre getmoduli")'
-            'python-scapy: parse PCAP files for ARP inspection (flow analysis)'
-            'python-matplotlib: create graphs from command line tools'
-            'python-dbus: 3D traceroute graphs'
-            'mongodb: database server'
-            'postgresql: database server (experimental backend)'
-            'neo4j-community: database server (experimental flow analysis)'
-            'apache: Web server'
-            'mod_wsgi: Web server'
-            'dokuwiki: Web server (notebook)'
-            'nmap: Network scan'
-            'masscan: Network scan'
-            'zmap: Network scan'
-            'bro: Network traffic analysis'
-            'argus: Network traffic analysis'
-            'nfdump: Netflow analysis'
-            'imagemagick: Screenshots via Nmap scripts'
-            'phantomjs: HTTP screenshots via Nmap script'
-            'ffmpeg: RTSP Screenshots via Nmap script')
 makedepends=('git' 'python-setuptools')
-backup=('etc/httpd/conf/extra/ivre.conf')
 branch="`git branch | awk '/^*/ {print $2}'`"
 source=("git+file://`readlink -f ../../`#branch=$branch")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd "$srcdir/$pkgname"
+  cd "$srcdir/$pkgbase"
   python setup.py --version | sed "s/\.dev/.dev_${branch//-/_}_/"
 }
 
-build() {
-  cd "$srcdir/$pkgname"
-  python setup.py build
+prepare() {
+    cp -a ${srcdir}/${pkgbase}{,-py2}
 }
 
-package() {
-  cd "$srcdir/$pkgname"
+build() {
+  (
+    cd "$srcdir/$pkgbase"
+    python setup.py build
+  )
+  (
+    cd "$srcdir/$pkgbase-py2"
+    python2 setup.py build
+  )
+}
+
+package_ivre() {
+  depends=('python-ivre')
+  optdepends=('ivre-docs: Documentation'
+              'nmap: Network scan'
+              'masscan: Network scan'
+              'zmap: Network scan'
+              'bro: Network traffic analysis'
+              'argus: Network traffic analysis'
+              'nfdump: Netflow analysis'
+              'imagemagick: Screenshots via Nmap scripts'
+              'phantomjs: HTTP screenshots via Nmap script'
+              'ffmpeg: RTSP Screenshots via Nmap script')
+  cd "$srcdir/$pkgbase"
+  python setup.py install --root="${pkgdir}" --prefix=/usr --optimize=1
+  rm -r "${pkgdir}/usr/lib" \
+     "${pkgdir}/usr/share/doc" \
+     "${pkgdir}/usr/share/ivre/dokuwiki" \
+     "${pkgdir}/usr/share/ivre/web"
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" doc/LICENSE*
+}
+
+package_ivre-docs() {
+  pkgdesc+=' (documentation)'
+  cd "$srcdir/$pkgbase"
+  python setup.py install --root="${pkgdir}" --prefix=/usr --optimize=1
+  rm -r "${pkgdir}/usr/bin" "${pkgdir}/usr/lib" \
+     "${pkgdir}/usr/share/ivre" \
+     "${pkgdir}/etc/bash_completion.d"
+}
+
+package_ivre-web() {
+  depends=('ivre' 'python-bottle')
+  optdepends=('apache: Web server'
+              'mod_wsgi: Web server'
+              'dokuwiki: Web server (notebook)')
+  pkgdesc+=' (web application)'
+  backup=('etc/httpd/conf/extra/ivre.conf')
+  cd "$srcdir/$pkgbase"
+  python setup.py install --root="${pkgdir}" --prefix=/usr --optimize=1
+  rm -r "${pkgdir}/usr/bin" "${pkgdir}/usr/lib" \
+     "${pkgdir}/usr/share/doc" \
+     "${pkgdir}/usr/share/ivre/bro" \
+     "${pkgdir}/usr/share/ivre/data" \
+     "${pkgdir}/usr/share/ivre/docker" \
+     "${pkgdir}/usr/share/ivre/geoip" \
+     "${pkgdir}/usr/share/ivre/honeyd" \
+     "${pkgdir}/usr/share/ivre/nmap_scripts" \
+     "${pkgdir}/etc/bash_completion.d"
   install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" doc/LICENSE*
   install -Dm0644 "pkg/apache/ivre.conf" "$pkgdir/etc/httpd/conf/extra/ivre.conf"
-  python setup.py install --root="$pkgdir" --optimize=1
+}
+
+package_python-ivre() {
+  depends=('python' 'python-pymongo' 'python-future')
+  optdepends=('python-py2neo: experimental flow analysis (Neo4j backend)'
+              'python-sqlalchemy: experimental PostgreSQL & SQLite backends'
+              'python-psycopg2: experimental PostgreSQL backend'
+              'python-pillow: trim screenshots on insertion'
+              'tesseract: extract words from screenshots on insertion'
+              'python-pycryptodome: extract data from public keys ("ivre getmoduli")'
+              'python-scapy: parse PCAP files for ARP inspection (flow analysis)'
+              'python-matplotlib: create graphs from command line tools'
+              'python-dbus: 3D traceroute graphs'
+              'mongodb: database server'
+              'postgresql: database server (experimental backend)'
+              'neo4j-community: database server (experimental flow analysis)')
+  pkgdesc+=' (library)'
+  cd "$srcdir/$pkgbase"
+  python setup.py install --root="${pkgdir}" --prefix=/usr --optimize=1
+  rm -r "${pkgdir}/usr/bin" \
+     "${pkgdir}/usr/share" \
+     "${pkgdir}/etc/bash_completion.d"
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" doc/LICENSE*
   sed -i "s/\.dev/.dev_${branch//-/_}_/" \
       "${pkgdir}"/usr/lib/python*/site-packages/ivre/{VERSION,__init__.py}
 }
+
+package_python2-ivre() {
+  depends=('python2' 'python2-pymongo' 'python2-future')
+  optdepends=('python2-py2neo: experimental flow analysis (Neo4j backend)'
+              'python2-sqlalchemy: experimental PostgreSQL & SQLite backends'
+              'python2-psycopg2: experimental PostgreSQL backend'
+              'python2-pillow: trim screenshots on insertion'
+              'tesseract: extract words from screenshots on insertion'
+              'python2-pycryptodome: extract data from public keys ("ivre getmoduli")'
+              'python2-scapy: parse PCAP files for ARP inspection (flow analysis)'
+              'python2-matplotlib: create graphs from command line tools'
+              'python2-dbus: 3D traceroute graphs'
+              'mongodb: database server'
+              'postgresql: database server (experimental backend)'
+              'neo4j-community: database server (experimental flow analysis)')
+  pkgdesc+=' (library)'
+  cd "$srcdir/$pkgbase-py2"
+  python2 setup.py install --root="${pkgdir}" --prefix=/usr --optimize=1
+  rm -r "${pkgdir}/usr/bin" \
+     "${pkgdir}/usr/share" \
+     "${pkgdir}/etc/bash_completion.d"
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" doc/LICENSE*
+  sed -i "s/\.dev/.dev_${branch//-/_}_/" \
+      "${pkgdir}"/usr/lib/python*/site-packages/ivre/{VERSION,__init__.py}
+}
+


### PR DESCRIPTION
This has been applied to [AUR](https://aur.archlinux.org/pkgbase/ivre/) and BlackArch (BlackArch/blackarch#2275), without the `ivre-data` package.

This package is specifically useful for offline networks.