### PR TITLE
Passive: fix .searchtimeago() and .searchnewer() new= parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ before_script:
   - wget -q --no-check-certificate -O - https://ivre.rocks/data/tests/dnsbl.pcap.bz2 | bunzip2 > tests/samples/dnsbl.pcap
   ## PCAP files from the Wireshark project
   - for file in dns.cap imap.cap http.cap telnet-raw.pcap nb6-startup.pcap nb6-http.pcap nb6-telephone.pcap nb6-hotspot.pcap Teredo.pcap sr-header.pcap; do wget -q "https://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=$file" -O "tests/samples/$file"; done
-  - for file in SSHv2.cap; do wget -q "http://packetlife.net/captures/$file" -O "tests/samples/$file"; done
+  - for file in SSHv2.cap; do wget -q "http://packetlife.net/media/captures/$file" -O "tests/samples/$file"; done
   - wget -q 'https://www.cloudshark.org/captures/616566f75f0c/download' -O tests/samples/gre-sample.pcap
   # 2015-09-18-Nuclear-EK-traffic comes from https://www.malware-traffic-analysis.net/2015/09/18/2015-09-18-Nuclear-EK-traffic.pcap.zip
   - for file in banners.pcap 2015-09-18-Nuclear-EK-traffic.pcap; do wget -q --no-check-certificate -O tests/samples/$file https://ivre.rocks/data/tests/$file; done

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -4265,17 +4265,17 @@ setting values according to the keyword arguments.
         return {'recontype': 'TCP_SERVER_BANNER', 'value': banner}
 
     @staticmethod
-    def searchtimeago(delta, neg=False, new=False):
+    def searchtimeago(delta, neg=False, new=True):
         if not isinstance(delta, datetime.timedelta):
             delta = datetime.timedelta(seconds=delta)
-        return {'lastseen' if new else 'firstseen':
+        return {'firstseen' if new else 'lastseen':
                 {'$lt' if neg else '$gte': datetime.datetime.now() - delta}}
 
     @staticmethod
-    def searchnewer(timestamp, neg=False, new=False):
+    def searchnewer(timestamp, neg=False, new=True):
         if not isinstance(timestamp, datetime.datetime):
             timestamp = datetime.datetime.fromtimestamp(timestamp)
-        return {'lastseen' if new else 'firstseen':
+        return {'firstseen' if new else 'lastseen':
                 {'$lte' if neg else '$gt': timestamp}}
 
 

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -2330,9 +2330,9 @@ passive table."""
         )
 
     @classmethod
-    def searchtimeago(cls, delta, neg=False, new=False):
-        field = cls.tables.passive.lastseen if new else \
-            cls.tables.passive.firstseen
+    def searchtimeago(cls, delta, neg=False, new=True):
+        field = cls.tables.passive.firstseen if new else \
+            cls.tables.passive.lastseen
         if not isinstance(delta, datetime.timedelta):
             delta = datetime.timedelta(seconds=delta)
         now = datetime.datetime.now()
@@ -2341,9 +2341,9 @@ passive table."""
                                    field >= timestamp))
 
     @classmethod
-    def searchnewer(cls, timestamp, neg=False, new=False):
-        field = cls.tables.passive.lastseen if new else \
-            cls.tables.passive.firstseen
+    def searchnewer(cls, timestamp, neg=False, new=True):
+        field = cls.tables.passive.firstseen if new else \
+            cls.tables.passive.lastseen
         timestamp = utils.all2datetime(timestamp)
         return PassiveFilter(main=(field <= timestamp if neg else
                                    field > timestamp))

--- a/ivre/tools/ipinfo.py
+++ b/ivre/tools/ipinfo.py
@@ -210,7 +210,7 @@ def _disp_recs_tailf(flt, field):
                     db.passive.flt_and(
                         baseflt,
                         db.passive.searchnewer(prevtime,
-                                               new=field == 'lastseen'),
+                                               new=field == 'firstseen'),
                     ),
                     sort=[(field, 1)]):
                 if 'addr' in r:


### PR DESCRIPTION
When `new` is set to `True` (which is now the default, so that existing calls without specifying a value for `new` will return the same results), the field used to filter record is `firstseen`. When it is `False`, the field used is `lastseen`.