### PR TITLE
clean up docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     volumes:
       - ./mongodb:/data/db
       - ./mongoconfigdb:/data/configdb
-      - ./ivre.conf:/etc/ivre.conf:ro
     restart: always
     networks:
       - ivrenet
@@ -33,6 +32,8 @@ services:
     restart: always
     ports:
       - "80:80"
+    volumes:
+      - ./ivre.conf:/etc/ivre.conf:ro
     depends_on:
       - ivredb
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,22 +16,38 @@
 
 version: '3'
 services:
-  ivredb:
+  db:
+    container_name: ivre_db
     image: mongo
     volumes:
-      - ./var_lib_mongodb:/var/lib/mongodb
-      - ./var_log_mongodb:/var/log/mongodb
+      - ./mongodb:/data/db
+      - ./mongoconfigdb:/data/configdb
+      - ./ivre.conf:/etc/ivre.conf:ro
     restart: always
-  ivreweb:
+    networks:
+      - ivrenet
+
+  web:
+    container_name: ivre_web
     image: ivre/web
     restart: always
     ports:
       - "80:80"
     depends_on:
       - ivredb
-  ivreclient:
+    networks:
+      - ivrenet
+
+  client:
+    container_name: ivre_client
     image: ivre/client
     volumes:
       - ./ivre-share:/ivre-share
     depends_on:
       - ivredb
+    networks:
+      - ivrenet
+
+networks:
+  ivrenet:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ version: '3'
 services:
   db:
     container_name: ivre_db
-    image: mongo
+    image: mongo:4.2
     volumes:
       - ./mongodb:/data/db
       - ./mongoconfigdb:/data/configdb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,8 +32,6 @@ services:
     restart: always
     ports:
       - "80:80"
-    volumes:
-      - ./ivre.conf:/etc/ivre.conf:ro
     depends_on:
       - ivredb
     networks:

--- a/docker/ivre.conf
+++ b/docker/ivre.conf
@@ -1,0 +1,3 @@
+DB = "mongodb://ivredb/"
+WEB_GET_NOTEPAD_PAGES = ("localdokuwiki", ("/var/www/dokuwiki/data/pages",))
+# see https://doc.ivre.rocks/en/latest/install/config.html for more config options

--- a/docker/ivre.conf
+++ b/docker/ivre.conf
@@ -1,3 +1,0 @@
-DB = "mongodb://ivredb/"
-WEB_GET_NOTEPAD_PAGES = ("localdokuwiki", ("/var/www/dokuwiki/data/pages",))
-# see https://doc.ivre.rocks/en/latest/install/config.html for more config options


### PR DESCRIPTION
the current docker-compose file had the wrong paths for mongodb volumes included. This PR fixes the paths and cleans up the docker-compose file and also adds a sample ivre.conf to add additional configs like the CSRF protection URLs.
It also specifies a mongodb version instead of latest otherwise we would automatically use a newer major version on a pull which will break stuff as this needs to be a manual update of the db