### PR TITLE
Flow: fields list and bugfixes in flowcli

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -4506,7 +4506,7 @@ class MongoDBFlowMeta(type):
         """
         Computes list_fields from meta_desc.
         """
-        list_fields = ['sports', 'codes']
+        list_fields = ['sports', 'codes', 'times']
         for proto, kinds in viewitems(meta_desc):
             for kind, values in viewitems(kinds):
                 if kind == 'keys':
@@ -4825,10 +4825,10 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
             {
                 fields: (field_1_value, field_2_value, ...),
                 count: count,
-                collected: [
+                collected: (
                     (collect_1_value, collect_2_value, ...),
                     ...
-                ]
+                )
             }
         Collected fields are unique.
         """
@@ -4841,9 +4841,22 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
         special_fields = {'src.addr': ['src_addr_0', 'src_addr_1'],
                           'dst.addr': ['dst_addr_0', 'dst_addr_1'],
                           'sport': ['sports']}
+
+        # Validate fields
+        for fields_list in (fields, collect_fields, sum_fields):
+            for f in fields_list:
+                # special fields can be shortcuts (ex: sport) and are not
+                # necessary valid fields
+                if f not in special_fields:
+                    flow.validate_field(f)
+
         # special fields that are not addresses will be translated again at
         # the end
         reverse_special_fields = {'sports': 'sport'}
+        # special fields that have been translated
+        # necessary to accept both already transformed and non transformed
+        # field
+        reversed_special_fields = set()
 
         # Compute the internal fields
         # internal_fields = [aggr fields, collect_fields, sum_fields]
@@ -4853,6 +4866,8 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
             for field in external_fields[i]:
                 if field in special_fields:
                     internal_fields[i].extend(special_fields[field])
+                    for t_field in special_fields[field]:
+                        reversed_special_fields.add(t_field)
                 else:
                     internal_fields[i].append(field)
 
@@ -4968,14 +4983,14 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
                     ]
                     del ext_entry[addr0]
                     del ext_entry[addr1]
-            # reverse special fields
+            # reverse special fields which have been reversed
             for key in list(ext_entry):
-                if key in reverse_special_fields:
+                if key in reversed_special_fields:
                     ext_entry[reverse_special_fields[key]] = ext_entry.pop(key)
             for key in list(ext_entry['_id']):
-                if key in reverse_special_fields:
+                if key in reversed_special_fields:
                     ext_entry['_id'][reverse_special_fields[key]] = \
-                        ext_entry['id'].pop(key)
+                        ext_entry['_id'].pop(key)
             # Format fields in a tuple ordered accordingly to fields argument
             res_fields_dict = ext_entry.pop('_id')
             res_fields = tuple(res_fields_dict.get(key) for key in fields)
@@ -4983,6 +4998,11 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
             res_count = ext_entry.pop('_count')
             # Format collected results in a set of tuples to avoid duplicates
             if ext_entry:
+                # Transforms collected list fields in tuples
+                for key in ext_entry:
+                    ext_entry[key] = [elt if not isinstance(elt, list)
+                                      else tuple(elt)
+                                      for elt in ext_entry[key]]
                 # This keeps the order of collected fields
                 res_collected = set(zip(*(ext_entry[key]
                                           for key in collect_fields)))
@@ -5468,7 +5488,8 @@ class MongoDBFlow(with_metaclass(MongoDBFlowMeta, MongoDB, DBFlow)):
             times_filter.setdefault('start', {})['$lt'] = before
         if precision:
             times_filter['duration'] = precision
-        flt = cls.flt_and(flt, {'times': {'$elemMatch': times_filter}})
+        if times_filter:
+            flt = cls.flt_and(flt, {'times': {'$elemMatch': times_filter}})
         return flt
 
     def to_graph(self, flt, limit=None, skip=None, orderby=None, mode=None,

--- a/tests/results-public-samples
+++ b/tests/results-public-samples
@@ -120,9 +120,13 @@ flow_daily_9_flows_udp/1056 = u'1'
 flow_daily_9_flows_udp/1063 = u'1'
 flow_daily_9 = u'21:00:00.000000'
 flow_elt_sip = {u'count': 1, u'cspkts': 4, u'scbytes': 2060, 'src_addr': '172.22.75.71', u'scpkts': 3, u'proto': u'udp', u'schema_version': 1, u'sports': [5062], u'csbytes': 2636, u'meta': {u'sip': {u'count': 4, u'request_body_len': 831, u'status_code': [100, 183, 200], u'status_msg': [u'OK', u'Session Progress', u'Trying'], u'uri': [u'sip:147@ims.mnc010.mcc208.3gppnetwork.org;user=phone', u'sip:pcgw-0006.imsgroup0-005.ach4isc02.ims.sfr.net:5062'], u'response_from': [u'"0360653674" <sip:+33360653674@ims.mnc010.mcc208.3gppnetwork.org;user=phone>'], u'request_to': [u'<sip:147@ims.mnc010.mcc208.3gppnetwork.org;user=phone>', u'<sip:147@ims.mnc010.mcc208.3gppnetwork.org;user=phone>;tag=524b656f-138860423163019-gm-po-lucentPCSF-021676'], u'response_body_len': 444, u'user_agent': [u'neufbox6 - r13507'], u'request_from': [u'"0360653674" <sip:+33360653674@ims.mnc010.mcc208.3gppnetwork.org;user=phone>'], u'response_to': [u'<sip:147@ims.mnc010.mcc208.3gppnetwork.org;user=phone>', u'<sip:147@ims.mnc010.mcc208.3gppnetwork.org;user=phone>;tag=524b656f-138860423163019-gm-po-lucentPCSF-021676'], u'method': [u'BYE', u'INVITE']}}, u'lastseen': '2014-01-01T19:23:51.578000', u'dport': 5060, 'dst_addr': '10.251.23.139', u'firstseen': '2014-01-01T19:23:51.036000', u'times': ['2014-01-01T19:00:00']}
-flow_top_flows = u'(10.0.0.1, 66.102.1.27, tcp, 25) | 33 '
-flow_top_pair = u'(192.168.122.214, 217.12.199.190) | 1726518 '
-flow_top_transport = u'(tcp, 443) | 3365145 '
+flow_top_flows = '(10.0.0.1, 66.102.1.27, tcp, 25) | 33 '
+flow_top_pair = '(192.168.122.214, 217.12.199.190) | 1726518 '
+flow_top_pair_api = [('tcp', 443, (49246,))]
+flow_top_sport = '(123) | 6 '
+flow_top_sport_api = []
+flow_top_transport = '(tcp, 443) | 3365145 '
+flow_top_transport_api = [('192.168.122.214', '131.188.40.189'), ('192.168.122.214', '158.58.170.34'), ('192.168.122.214', '193.23.244.244'), ('192.168.122.214', '217.12.199.190'), ('192.168.122.214', '93.184.215.200'), ('95.136.242.99', '109.0.74.75')]
 nmap_10-100_ports = 118
 nmap_20_ports = 1
 nmap_80_443_count = 108


### PR DESCRIPTION
`--fields` option without further argument prints the list of available fields. General fields have been hard coded (with a description of their meaning, I don't know if it's relevant...). Metadata fields are derived from already existing dictionaries.
General fields are meant to work with every backends, while metadata fields work only in MongoDB backend for now (and won't work with Neo4j). These fields can be used in filters, in field selector (`--fields` with arguments) and in topvalues.

Furthermore, fields used in filters, in `--fields` and in `topvalues` are now verified: you will get an error if you try to use an unavailable field. There are some special cases:
- `addr` field does not physically exist in databases. It is just a shortcut used in filters instead of `src.addr = X OR dst.addr = X`. As such, it's not listed in general fields, but it's allowed when used in filters.
- Previously, `sport` was an alternative name for `sports` in topvalues. However, this was not well handled and the use of the real field `sports` was impossible. It was also impossible to collect sports because it is internally stored as a list. This has been fixed: `sport` and `sports` can both be used in topvalues as aggregated or collected fields.