### PR TITLE
View: Fix errors when a malformed manuf file is used

### DIFF
--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -1313,6 +1313,8 @@ def _read_wireshark_manuf_db():
         if not line:
             return
         line = line.strip()
+        if not line:
+            return
         try:
             addr, manuf, comment = line.split('\t', 2)
         except ValueError:
@@ -1322,7 +1324,6 @@ def _read_wireshark_manuf_db():
                 LOGGER.warning('Cannot parse a line from Wireshark '
                                'manufacturer database [%r].', line,
                                exc_info=True)
-                print("XXX", repr(line))
                 return
             comment = None
         if '/' in addr:
@@ -1331,7 +1332,12 @@ def _read_wireshark_manuf_db():
         else:
             mask = (addr.count(':') + 1) * 8
         addr += ':00' * (5 - addr.count(':'))
-        addr = _mac2int(addr)
+        try:
+            addr = _mac2int(addr)
+        except ValueError:
+            LOGGER.warning('Cannot parse a line from Wireshark '
+                           'manufacturer database [%r].', line)
+            return
         if (
                 _WIRESHARK_MANUF_DB_LAST_ADDR and
                 _WIRESHARK_MANUF_DB_LAST_ADDR[-1] != addr - 1


### PR DESCRIPTION
On a MacOS laptop, I still have an issue with the manuf file (accessible here: https://server.vruello.fr/manuf) despite #826.

The error is:
```
file "Projects/ivre/venv/bin/ivre", line 88, in <module>
    main()
  File "Projects/ivre/venv/bin/ivre", line 60, in main
    tools.get_command(next(iter(possible_commands)))()
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/tools/view.py", line 191, in main
    displayfunction(cursor)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/tools/view.py", line 174, in displayfunction
    displayhosts(cursor, out=sys.stdout)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/nmapout.py", line 176, in displayhosts
    displayhost(record, out=out, **kargs)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/nmapout.py", line 138, in displayhost
    manuf = utils.mac2manuf(addr)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1373, in mac2manuf
    last_addr, values = get_wireshark_manuf_db()
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1368, in get_wireshark_manuf_db
    _read_wireshark_manuf_db()
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1357, in _read_wireshark_manuf_db
    parse_line(line[:-1])
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1334, in parse_line
    addr = _mac2int(addr)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1295, in _mac2int
    for i, v in enumerate(int(v, 16) for v in value.split(':'))
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1294, in <genexpr>
    v << (40 - 8 * i)
  File "Projects/ivre/venv/lib/python2.7/site-packages/ivre/utils.py", line 1295, in <genexpr>
    for i, v in enumerate(int(v, 16) for v in value.split(':'))
ValueError: invalid literal for int() with base 16: '00-00-0C-07-AC'
```

This PR fixes that.
