### PR TITLE
Update elastic.py

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -94,7 +94,7 @@ class ElasticDB(DB):
                         "dynamic_templates": [
                             {"strings": {
                                 "match_mapping_type": "string",
-                                "mapping": {"type": "keyword"},
+                                "mapping": {"type": "keyword", "ignore_above": 32000},
                             }},
                         ],
                     }

--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -94,6 +94,9 @@ class ElasticDB(DB):
                         "dynamic_templates": [
                             {"strings": {
                                 "match_mapping_type": "string",
+                                # prevent RequestError exceptions when
+                                # one term's UTF-8 encoding is bigger
+                                # than the max length 32766
                                 "mapping": {"type": "keyword", "ignore_above": 32000},
                             }},
                         ],


### PR DESCRIPTION
For fixing elasticsearch.exceptions.RequestError: RequestError(400, u'illegal_argument_exception', u'Document contains at least one immense term in field="ports.scripts.output" (whose UTF8 encoding is longer than the max length 32766),