### PR TITLE
iphost: display unsuccessful A/AAAA resolutions

### DIFF
--- a/ivre/tools/iphost.py
+++ b/ivre/tools/iphost.py
@@ -72,6 +72,18 @@ def disp_rec(r):
                 firstseen,
                 lastseen,
             ))
+        # Case of a A or AAAA request with no answer (i.e., no addr in r)
+        elif r['source'].startswith('A-') or r['source'].startswith('AAAA-'):
+            print('%s %s %s (%s, %s time%s, %s - %s)' % (
+                r['value'],
+                r['source'].split('-', 1)[0],
+                None,
+                ':'.join(r['source'].split('-')[1:]),
+                r['count'],
+                r['count'] > 1 and 's' or '',
+                firstseen,
+                lastseen,
+            ))
         else:
             utils.LOGGER.warning("Cannot display record %r", r)
 


### PR DESCRIPTION
I suggest that unsuccessful DNS resolutions of type A/AAAA would be displayed with `ivre iphost domain.example`. For instance:

```
$ ivre iphost --sub example
domain.example A None (8.8.8.8, 1 time, 2020-02-01 12:00:00.000000 - 2020-02-01 12:00:00.000000)
```

instead of 

```
$ ivre iphost --sub example
WARNING:ivre:Cannot display record {...}
```