### PR TITLE
Deprecate use of term slave

### DIFF
--- a/doc/install/agents.rst
+++ b/doc/install/agents.rst
@@ -18,10 +18,10 @@ On the "master", install IVRE following the
 ``screen``, ``tmux`` or ``nohup`` if you want to be able to "detach"
 from the ``agent`` script (which is not a daemon).
 
-On the "slave(s)", the ``agent`` script must be deployed, together with
+On the "remotehost(s)", the ``agent`` script must be deployed, together with
 ``nmap``, and ``rsync``.
 
-Run the slave(s)
+Run the remotehost(s)
 ----------------
 
 The computer running IVRE (the "master") needs to be able to access via


### PR DESCRIPTION
Please consider removing the term slave.
Some alternatives might be:
 - minion
 - operative
 - node
 - worker
 - replica
 - drone
 - handler
 - steward
 - emissary
 - doer
 - mason
 - coordinator
 - conscript

Also consider adoption of a contributor covenant:
https://www.contributor-covenant.org/

Thanks.