### PR TITLE
Fix Ivre on Windows

### DIFF
--- a/ivre/db/maxmind.py
+++ b/ivre/db/maxmind.py
@@ -25,6 +25,7 @@ files.
 import codecs
 from functools import reduce
 import os
+import sys
 import struct
 
 
@@ -341,6 +342,9 @@ class MaxMindDBData(DBData):
 
     def __init__(self, url):
         self.basepath = url.path
+        if sys.platform == 'win32' and self.basepath.startswith('/'):
+            # Strip the leading / for Windows
+            self.basepath = self.basepath[1:]
         self.reload_files()
 
     def reload_files(self):

--- a/ivre/tools/version.py
+++ b/ivre/tools/version.py
@@ -38,7 +38,11 @@ def main():
     print()
     print("Python %s" % sys.version)
     print()
-    print(' '.join(str(elt) for elt in os.uname()))
+    try:
+        print(' '.join(str(elt) for elt in os.uname()))
+    except AttributeError:
+        # Windows OS don't have os.uname()
+        print(sys.platform)
     print()
     print("Dependencies:")
     for module in ['Crypto', 'pymongo', 'py2neo', 'sqlalchemy', 'psycopg2',

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -790,7 +790,7 @@ def hash_file(fname, hashtype="sha1"):
                 if exc.errno != errno.ENOENT:
                     raise
         result = hashlib.new(hashtype)
-        for data in iter(lambda: fdesc.read(1048576), ""):
+        for data in iter(lambda: fdesc.read(1048576), b""):
             result.update(data)
         return result.hexdigest()
 


### PR DESCRIPTION
Some quick fixes to allow Ivre to run on Windows:
- on Windows, os.uname() does not exists, use sys.platform (guaranteed to exist)
- a leading "/" prevent maxmind db extraction, strip it on Windows (there might be a better way to do it)
- Fix the alternate hashing method: .read return bytes therefore returns b"" and not ""