### PR TITLE
DB/TinyDB: support TinyDB v4

### DIFF
--- a/requirements-tinydb.txt
+++ b/requirements-tinydb.txt
@@ -1,4 +1,4 @@
-tinydb<4
+tinydb
 cryptography
 pyOpenSSL>=16.1.0
 future

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         'bottle',
     ],
     extras_require={
-        'TinyDB (experimental)': ["tinydb<4"],
+        'TinyDB (experimental)': ["tinydb"],
         'PostgreSQL (experimental)': ["sqlalchemy", "psycopg2"],
         'Elasticsearch (experimental)': ["elasticsearch", "elasticsearch-dsl"],
         'GSSAPI authentication': ["python-krbV"],


### PR DESCRIPTION
Since msiemens/tinydb#313 has been fixed in release 4.1.0, IVRE can now support both TinyDB v3.x.x (for Python < 3.5) and TinyDB v4.x.x (for Python >= 3.5).