### PR TITLE
XML/Nmap: discard `hostnames` tags outside `host`, fixes GH#1017

### DIFF
--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -1592,11 +1592,17 @@ argument (a dict object).
                     'addresses', {}).setdefault(
                         attrs['addrtype'], []).append(attrs['addr'])
         elif name == 'hostnames':
+            if self._curhost is None:
+                # We do not want to handle hostnames in hosthint tags,
+                # as they will be repeated inside an host tag
+                return
             if self._curhostnames is not None:
                 utils.LOGGER.warning("self._curhostnames should be None at "
                                      "this point (got %r)", self._curhostnames)
             self._curhostnames = []
         elif name == 'hostname':
+            if self._curhost is None:
+                return
             if self._curhostnames is None:
                 utils.LOGGER.warning("self._curhostnames should NOT be "
                                      "None at this point")
@@ -2067,6 +2073,8 @@ argument (a dict object).
                 self._addhost()
             self._curhost = None
         elif name == 'hostnames':
+            if self._curhost is None:
+                return
             self._curhost['hostnames'] = self._curhostnames
             self._curhostnames = None
         elif name == 'extraports':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -702,6 +702,9 @@ purposes to feed Elasticsearch view.
                 options.extend(["--masscan-probes", fname.split('-probe-')[1]])
             options.extend(["--", fname])
             res, _, err = RUN(options)
+            print("Inserting %r" % fname)
+            if res:
+                print("Error: %r" % err)
             self.assertEqual(res, 0)
             host_counter += sum(1 for _ in host_stored.finditer(err))
             scan_counter += sum(1 for _ in scan_stored.finditer(err))


### PR DESCRIPTION
Fixes #1017