### PR TITLE
Active: fix SharePoint detection

### DIFF
--- a/ivre/active/data.py
+++ b/ivre/active/data.py
@@ -578,9 +578,9 @@ Masscan or Zgrab(2).
         script = {
             'id': 'http-app',
             'output': 'SharePoint: path %s, version %s' % (path, version),
-            'http-app': {'path': path,
-                         'application': 'SharePoint',
-                         'version': version},
+            'http-app': [{'path': path,
+                          'application': 'SharePoint',
+                          'version': version}],
         }
         try:
             cur_script = next(s for s in port.get('scripts', [])


### PR DESCRIPTION
The `http-app` script had an invalid structure that caused the second bug reported in #1020 (and would probably cause other bugs too).