### PR TITLE
Adding nmap --top-ports option in nmapopt.py

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -73,6 +73,7 @@ NMAP_SCAN_TEMPLATES = {
         # "resolve": 1,
         # "verbosity": 2,
         # "ports": None,
+        # "top_ports": None,
         "host_timeout": "15m",  # default value: None
         "script_timeout": "2m",  # default value: None
         "scripts_categories": ['default', 'discovery',

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -59,9 +59,7 @@ class Scan(object):
         self.top_ports=top_ports
         self.host_timeout = host_timeout
         self.script_timeout = script_timeout
-        if not self.ports :
-            self.ports = None
-        if self.ports is not None:
+        if self.ports:
             self.top_ports = None
         if scripts_categories is None:
             self.scripts_categories = []

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -127,7 +127,7 @@ class Scan(object):
             options.append('-%s' % ('v' * self.verbosity))
         options.extend(NMAP_OPT_PORTS.get(self.ports, ['-p', self.ports]))
         if self.top_ports is not None:
-                options.extend(['--top-ports', self.top_ports])
+            options.extend(['--top-ports', self.top_ports])
         if self.host_timeout is not None:
             options.extend(['--host-timeout', self.host_timeout])
         if self.script_timeout is not None:

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -56,7 +56,7 @@ class Scan(object):
         self.resolve = resolve
         self.verbosity = verbosity
         self.ports = ports
-        self.top_ports=top_ports
+        self.top_ports = top_ports
         self.host_timeout = host_timeout
         self.script_timeout = script_timeout
         if self.ports:

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -127,7 +127,7 @@ class Scan(object):
             options.append('-%s' % ('v' * self.verbosity))
         options.extend(NMAP_OPT_PORTS.get(self.ports, ['-p', self.ports]))
         if self.top_ports is not None:
-            options.extend(['--top-ports', self.top_ports])
+            options.extend(['--top-ports', str(self.top_ports)])
         if self.host_timeout is not None:
             options.extend(['--host-timeout', self.host_timeout])
         if self.script_timeout is not None:

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -44,7 +44,7 @@ NMAP_OPT_PORTS = {
 
 class Scan(object):
     def __init__(self, nmap="nmap", pings='SE', scans='SV', osdetect=True,
-                 traceroute=True, resolve=1, verbosity=2, ports=None,
+                 traceroute=True, resolve=1, verbosity=2, ports=None, top_ports=None,
                  host_timeout=None, script_timeout=None,
                  scripts_categories=None, scripts_exclude=None,
                  scripts_force=None, extra_options=None):
@@ -56,8 +56,13 @@ class Scan(object):
         self.resolve = resolve
         self.verbosity = verbosity
         self.ports = ports
+        self.top_ports=top_ports
         self.host_timeout = host_timeout
         self.script_timeout = script_timeout
+        if not self.ports :
+            self.ports = None
+        if self.ports is not None:
+            self.top_ports = None
         if scripts_categories is None:
             self.scripts_categories = []
         else:
@@ -123,6 +128,8 @@ class Scan(object):
         if self.verbosity:
             options.append('-%s' % ('v' * self.verbosity))
         options.extend(NMAP_OPT_PORTS.get(self.ports, ['-p', self.ports]))
+        if self.top_ports is not None:
+                options.extend(['--top-ports', self.top_ports])
         if self.host_timeout is not None:
             options.extend(['--host-timeout', self.host_timeout])
         if self.script_timeout is not None:

--- a/ivre/nmapopt.py
+++ b/ivre/nmapopt.py
@@ -44,8 +44,8 @@ NMAP_OPT_PORTS = {
 
 class Scan(object):
     def __init__(self, nmap="nmap", pings='SE', scans='SV', osdetect=True,
-                 traceroute=True, resolve=1, verbosity=2, ports=None, top_ports=None,
-                 host_timeout=None, script_timeout=None,
+                 traceroute=True, resolve=1, verbosity=2, ports=None,
+                 top_ports=None, host_timeout=None, script_timeout=None,
                  scripts_categories=None, scripts_exclude=None,
                  scripts_force=None, extra_options=None):
         self.nmap = nmap


### PR DESCRIPTION
I implemented, the --top-ports option for nmap in the nmapopt.py file, added some logical checks against the -p option.

to use it, just add in the variable NMAP_SCAN_TEMPLATES of your ivre config file the option "top_ports" as below
```bash
NMAP_SCAN_TEMPLATES = {
    "cyslab": {
        # Commented values are default values and to not need to be
        # specified:
         "nmap": "nmap",
         "pings": "n",
         "scans": "V",
         "osdetect": False,
         "traceroute": False,
        # "resolve": 1,
         "verbosity": 0,
        # "ports":'1-1000',
	 "top_ports": "100",
         "ports": "",
         "host_timeout": "15m",  # default value: None
         "script_timeout": "2m",  # default value: None
         "scripts_categories": ['default',], # 'discovery',
        #                       'auth'],  # default value: None
        # "scripts_exclude": ['broadcast', 'brute', 'dos',
        #                    'exploit', 'external', 'fuzzer',
        #                    'intrusive'],  # default value: None
        # "scripts_force": None,
        # "extra_options": ["--top-ports 100",]
    }
}
```

the command below should produce the following result : 
```bash
$ ivre runscans --network 192.168.1.0/24 --nmap-template cyslab --output CommandLine

nmap -Pn -sC -sV --top-ports 100 --host-timeout 15m --script-timeout 2m
```

Fixes #1041.