### PR TITLE
Add DNS queries towards honeypots in Ivre

### DIFF
--- a/zeek/ivre/passiverecon/__load__.zeek
+++ b/zeek/ivre/passiverecon/__load__.zeek
@@ -54,6 +54,7 @@ export {
         SSL_CLIENT,
         SSL_SERVER,
         DNS_ANSWER,
+        DNS_HONEYPOT_QUERY,
         FTP_CLIENT,
         FTP_SERVER,
         POP_CLIENT,
@@ -405,6 +406,17 @@ event ssl_established(c: connection) {
             ]);
             cacert = T;
         }
+    }
+}
+
+event dns_request(c: connection, msg: dns_msg, query: string, qtype: count, qclass: count) {
+    if (c$id$resp_h in HONEYPOTS) {
+        Log::write(LOG, [$ts=c$start_time,
+                         $uid=c$uid,
+                         $host=c$id$orig_h,
+                         $recon_type=DNS_HONEYPOT_QUERY,
+                         $source=fmt("%s/%d-%s-%s", get_port_transport_proto(c$id$resp_p), c$id$resp_p, DNS::query_types[qtype], DNS::classes[qclass]),
+                         $value=query]);
     }
 }
 


### PR DESCRIPTION
For honeypots, it seems interesting to log `DNS` requests issued by scans.
For that, this PR adds an event handler in the script `passiverecon` for zeek. It creates log entries for any `DNS` request to a honeypot address like the following:

```
16097XXXXX.XXXXXX       CAUtCH3aQK42vpZsa       X.X.X.X  -       PassiveRecon::DNS_HONEYPOT_QUERY        53-A-C_INTERNET testip.internet-census.org
```

where `X.X.X.X` is the source `IP` of the `DNS` request.
Once in `ivre`, this allows to query information about `DNS` scans:

```
$ ivre ipinfo X.X.X.X
WARNING:ivre:Cannot find Maxmind database files
         DNS_HONEYPOT_QUERY 53-A-C_INTERNET testip.internet-census.org (1 time) 2021-01-04 XX:XX:XX - 2021-01-04 XX:XX:XX
```

This PR also adds these entries in ivre view (using `ivre db2view`).