### PR TITLE
Fix docker base image

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of IVRE.
-# Copyright 2011 - 2020 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2021 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "deb http://deb.debian.org/debian stable-backports main" >> /etc/apt/sources.list
 RUN apt-get -q update && \
     apt-get -qy --no-install-recommends install python3-pymongo python3-crypto \
-        python3-setuptools python3-bottle ca-certificates && \
+        python3-setuptools python3-bottle python3-openssl ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # IVRE


### PR DESCRIPTION
The (Debian) package python3-openssl was missing. Reported by @AxilleasMoukoulis on [gitter](https://gitter.im/cea-sec/ivre)