### PR TITLE
Modified function ivre ipdata --download

### DIFF
--- a/.travis/ivre.conf
+++ b/.travis/ivre.conf
@@ -28,7 +28,7 @@ IPDATA_URLS = {
     'https://ivre.rocks/data/tests/db/GeoLite2-ASN.tar.gz',
     'GeoLite2-ASN-CSV.zip':
     'https://ivre.rocks/data/tests/db/GeoLite2-ASN-CSV.zip',
-    'iso3166.csv': 'https://ivre.rocks/data/tests/db/iso3166.csv',
+    'iso3166.csv': 'https://dev.maxmind.com/csv-files/codes/iso3166.csv',
     'BGP.raw': 'https://ivre.rocks/data/tests/db/data-raw-table',
 }
 NMAP_SCAN_TEMPLATES["default"]["pings"] = []

--- a/ivre/geoiputils.py
+++ b/ivre/geoiputils.py
@@ -199,8 +199,11 @@ def download_all(verbose: bool = False) -> None:
             sys.stdout.write("Downloading %s to %s: " % (url, outfile))
             sys.stdout.flush()
         with open(outfile, "wb") as wdesc:
-            udesc = opener.open(url)
-            wdesc.write(udesc.read())
+            try:
+                udesc = opener.open(url)
+                wdesc.write(udesc.read())
+            except Exception as e:
+                utils.LOGGER.warning(e, exc_info=True)
             if verbose:
                 sys.stdout.write("done.\n")
     if verbose:

--- a/ivre/geoiputils.py
+++ b/ivre/geoiputils.py
@@ -202,10 +202,10 @@ def download_all(verbose: bool = False) -> None:
             try:
                 udesc = opener.open(url)
                 wdesc.write(udesc.read())
+                if verbose:
+                    sys.stdout.write("done.\n")
             except Exception as e:
                 utils.LOGGER.warning(e, exc_info=True)
-            if verbose:
-                sys.stdout.write("done.\n")
     if verbose:
         sys.stdout.write("Unpacking: ")
         sys.stdout.flush()


### PR DESCRIPTION
### IVRE Version
Insert here the output of the command ivre version, displayed as code. For example:

```
$ ivre version
IVRE - Network recon framework
Copyright 2011 - 2020 Pierre LALET <pierre@droids-corp.org>
Version 0.9.16

Python 3.9.1+ (default, Feb  5 2021, 13:46:56) 
[GCC 10.2.1 20210110]

Linux kali 5.10.0-kali3-amd64 #1 SMP Debian 5.10.13-1kali1 (2021-02-08) x86_64

Dependencies:
    Python module pymongo: 3.11.4
    Python module sqlalchemy: 1.3.22
    Python module psycopg2: 2.8.6 (dt dec pq3 ext lo64)
    Python module cryptography: 3.3.2
    Python module krbV: missing
    Python module PIL: 8.1.0
    Python module MySQLdb: 1.4.4
    Python module dbus: 1.2.16
    Python module matplotlib: 3.3.4
    Python module bottle: 0.12.19
    Python module OpenSSL: 20.0.1
    Python module tinydb: 3.15.2
```

### Summary

Ivre fails to download the file iso3166.csv, returns a 404 and aborts further downloads.

### Expected behavior

The download link has been updated, and an exception control has been added, if one of the links fails it will continue downloading the rest and the user will be able to add by hand the ones that may be missing.

### How to reproduce

sudo ivre ipdata --download

### More

The error:

![image](https://user-images.githubusercontent.com/16885065/119959443-4b12d800-bfa4-11eb-8ef4-193b9c544ddb.png)

Best approach:

![image](https://user-images.githubusercontent.com/16885065/119959362-3b938f00-bfa4-11eb-948f-a1a1dec5cea7.png)

