### PR TITLE
[Mongodb] Fix Mongo schema migrations warning to use session with no_cursor_timeout

### DIFF
--- a/ivre/active/data.py
+++ b/ivre/active/data.py
@@ -462,13 +462,6 @@ def merge_scanner_scripts(
     return curscript
 
 
-def format_nuclei_output(nuclei: dict[str, Any]) -> str:
-    output = "[%(severity)s] %(name)s found at %(url)s" % nuclei
-    if "favicon-hash" in nuclei:
-        output += " (favicon hash: %s)" % nuclei["favicon-hash"]
-    return output
-
-
 def merge_nuclei_scripts(
     curscript: NmapScript, script: NmapScript, script_id: str
 ) -> NmapScript:
@@ -479,7 +472,7 @@ def merge_nuclei_scripts(
         )
 
     def nuclei_output(nuclei: dict[str, Any], script_id: str) -> str:
-        return format_nuclei_output(nuclei)
+        return "[%(severity)s] %(name)s found at %(url)s" % nuclei
 
     return _merge_scripts(curscript, script, script_id, nuclei_equals, nuclei_output)
 

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -56,7 +56,6 @@ from ivre import config, flow, nmapout, passive, utils, xmlnmap
 from ivre.active.cpe import add_cpe_values
 from ivre.active.data import (
     add_hostname,
-    format_nuclei_output,
     handle_http_content,
     handle_http_headers,
     handle_tlsx_result,
@@ -3243,26 +3242,18 @@ class DBNmap(DBActive):
                     name += " (%s)" % rec["matcher_name"]
                     nuclei_data["matcher-name"] = rec["matcher_name"]
                 nuclei_data["name"] = name
-                extracted_results = None
                 for key in ["curl-command", "extracted-results", "matcher-status"]:
                     if key in rec:
                         nuclei_data[key] = rec[key]
-                        if key == "extracted-results":
-                            extracted_results = rec[key]
                     elif (alt_key := key.replace("-", "_")) in rec:
                         nuclei_data[key] = rec[alt_key]
-                        if key == "extracted-results":
-                            extracted_results = rec[alt_key]
-                if rec.get("template") == "favicon-detect" and extracted_results:
-                    # nuclei already provides the favicon hash in extracted results
-                    nuclei_data["favicon-hash"] = extracted_results[0]
                 for key in ["host", "path", "request"]:
                     if key in rec:
                         nuclei_data[key] = rec[key]
                 scripts = [
                     {
                         "id": "%s-nuclei" % (rec["type"]),
-                        "output": format_nuclei_output(nuclei_data),
+                        "output": "[%s] %s found at %s" % (rec["severity"], name, url),
                         "nuclei": [nuclei_data],
                     },
                 ]


### PR DESCRIPTION
### Change:  

- Removes the PyMongo warning by aligning with driver expectations: servers can close non-session cursors after 30 minutes even with no_cursor_timeout=True.
  - Keeps long-running migration cursors alive more reliably, reducing the risk of mid-run CursorNotFound from idle session timeouts on the server.
  - Ensures the read cursor and its subsequent update/delete operations share the same server session, improving consistency and lowering the chance of partial progress if the server prunes unused cursors.
  - Provides a clean fallback: if the server doesn’t support sessions (e.g., DocumentDB or older setups), it transparently degrades to the previous behavior without breaking.

**ivre view --update-schema**
`/usr/local/lib64/python3.11/site-packages/pymongo/synchronous/collection.py:1920: UserWarning: use an explicit session with no_cursor_timeout=True otherwise the cursor may still timeout after 30 minutes, for more info see https://mongodb.com/docs/v4.4/reference/
  method/cursor.noCursorTimeout/#session-idle-timeout-overrides-nocursortimeout
    return Cursor(self, *args, **kwargs)`


### Tech details:

  - ivre/db/mongo.py: start a client session (fallback to nullcontext on failure), wrap the migration cursor in that context, and pass the session to both the find() and _migrate_update_record() calls so long-running migrations keep their cursor alive.
  - ivre/db/mongo.py: allow _migrate_update_record() to accept an optional session and propagate it to update/delete operations; import nullcontext for the fallback path.