### PR TITLE
[Mongodb] Add explicit MongoDB sessions to silence no_cursor_timeout warning

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -360,20 +360,17 @@ class MongoDB(DB):
                 utils.LOGGER.info("  ... Done.")
             utils.LOGGER.info("Migrating records...")
             updated = False
-            session = None
             session_ctx = nullcontext()
             if not self.is_documentdb:
                 try:
-                    session = self.db_client.start_session()
+                    session_ctx = self.db_client.start_session()
                 except pymongo.errors.PyMongoError:
                     utils.LOGGER.debug(
                         "Cannot start a MongoDB session for migration cursor; "
                         "continuing without it",
                         exc_info=True,
                     )
-                else:
-                    session_ctx = session
-            with session_ctx:
+            with session_ctx as session:
                 # unlimited find()!
                 for i, record in enumerate(
                     self.db[self.columns[colnum]]


### PR DESCRIPTION
### Change:
Removes the PyMongo warning by aligning with driver expectations: servers can close non-session cursors after 30 minutes even with no_cursor_timeout=True.
Keeps long-running migration cursors alive more reliably, reducing the risk of mid-run CursorNotFound from idle session timeouts on the server.
Ensures the read cursor and its subsequent update/delete operations share the same server session, improving consistency and lowering the chance of partial progress if the server prunes unused cursors.
Provides a clean fallback: if the server doesn’t support sessions (e.g., DocumentDB or older setups), it transparently degrades to the previous behavior without breaking.

ivre view --update-schema
`/usr/local/lib64/python3.11/site-packages/pymongo/synchronous/collection.py:1920: UserWarning: use an explicit session with no_cursor_timeout=True otherwise the cursor may still timeout after 30 minutes, for more info see https://mongodb.com/docs/v4.4/reference/ method/cursor.noCursorTimeout/#session-idle-timeout-overrides-nocursortimeout return Cursor(self, *args, **kwargs)`

### Tech details:
  - ivre/db/mongo.py: start a client session (fallback to nullcontext), run the migration cursor inside it, and pass that session through find() and _migrate_update_record() so long-running migrations keep cursors alive.
  - ivre/db/mongo.py: _migrate_update_record() now accepts an optional session and propagates it to downstream operations; migration updates that mix records now call insert_or_update_mix(..., session=session), and insert_or_update_mix/get_one both accept/use an optional session to keep     all reads/writes in the same server session.
