### PR TITLE
[Nuclei] Add nuclei favicon hash detection and formatted output

### DIFF
--- a/ivre/active/data.py
+++ b/ivre/active/data.py
@@ -462,6 +462,13 @@ def merge_scanner_scripts(
     return curscript
 
 
+def format_nuclei_output(nuclei: dict[str, Any]) -> str:
+    output = "[%(severity)s] %(name)s found at %(url)s" % nuclei
+    if "favicon-hash" in nuclei:
+        output += " (favicon hash: %s)" % nuclei["favicon-hash"]
+    return output
+
+
 def merge_nuclei_scripts(
     curscript: NmapScript, script: NmapScript, script_id: str
 ) -> NmapScript:
@@ -472,7 +479,7 @@ def merge_nuclei_scripts(
         )
 
     def nuclei_output(nuclei: dict[str, Any], script_id: str) -> str:
-        return "[%(severity)s] %(name)s found at %(url)s" % nuclei
+        return format_nuclei_output(nuclei)
 
     return _merge_scripts(curscript, script, script_id, nuclei_equals, nuclei_output)
 


### PR DESCRIPTION
**First step**

* Introduce a shared Nuclei output formatter to append favicon hashes when available.
* Parse `extracted-results` from the `favicon-detect` template (handling both hyphen and underscore keys), store the mmh3 value as `favicon-hash`, and expose it in the script output.
* Ensure consistent Nuclei script results by reusing the formatter across active data merging and DB storage paths.

**Final goal**
Mimic Shodan’s `http.favicon.hash` filter.

**Next step**
Add favicon-related filtering keyword support (CLI + Web).


**Sample:**
<img width="774" height="130" alt="image" src="https://github.com/user-attachments/assets/bbd97fc0-972a-402c-b7e4-45d5618ec23b" />
