### PR TITLE
[Web] Fix CPE subview (popover issue)

### DIFF
--- a/web/static/templates/subview-cpes.html
+++ b/web/static/templates/subview-cpes.html
@@ -48,17 +48,14 @@
               <div class="col-md-5">
                 <div class="row result-cpe-item"
                      ng-repeat="version in ::product.data">
-                  <div class="col-md-12">
+                  <!-- Column for version name -->
+                  <div class="col-md-10">
                     <a
-                       data-html="true"
-                       data-title="{{::version.tooltitle}}"
-                       data-content="{{::version.toolcontent}}"
-		       data-container="body"
                        class="clickable"
                        ng-click="set_cpe_param(type, vendor, product, version)"
-                       popover>
+                       >
                       {{::version.pretty_name}}
-		    </a>
+                    </a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Updated web/static/templates/subview-cpes.html to fix the broken popover behavior and restore proper visibility of the version column. 
The markup has been simplified, popover/tooltitle attributes removed, the version column resized to col-md-10

**Before:**

<img width="359" height="48" alt="ivre_cpe_issue" src="https://github.com/user-attachments/assets/59b90aeb-5c54-4f32-878e-bcc95a0e097a" />

**After:**
<img width="356" height="54" alt="image" src="https://github.com/user-attachments/assets/7fe2d88f-4342-444e-affc-24e6a3268446" />

