### PR TITLE
security: mitigate CVE-2015-9251 in vendored jQuery (ajaxConvert)

### DIFF
--- a/web/static/jq/jquery.js
+++ b/web/static/jq/jquery.js
@@ -7554,6 +7554,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432 / CVE-2015-9251)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
## Summary

Applies the upstream jQuery mitigation for [gh-2432](https://github.com/jquery/jquery/issues/2432) / **CVE-2015-9251** in the bundled file `web/static/jq/jquery.js`.

Cross-domain Ajax responses could be handled as executable script when the inferred `dataType` was `script`. This change skips converting to `script` when the request is cross-domain, mirroring the fix in jQuery commit [2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49). Explicit `dataType: 'script'` still behaves as before.

## References
- [CVE-2015-9251 (NVD)](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
