### PR TITLE
feat(web): drop JSONP support

### DIFF
--- a/ivre/web/app.py
+++ b/ivre/web/app.py
@@ -82,7 +82,6 @@ FilterParams = namedtuple(
         "skip",
         "limit",
         "fields",
-        "callback",
         "ipsasnumbers",
         "datesasstrings",
         "fmt",
@@ -102,26 +101,21 @@ def get_base(dbase):
         limit = config.WEB_LIMIT
     if config.WEB_MAXRESULTS is not None:
         limit = min(limit, config.WEB_MAXRESULTS)
-    callback = request.params.get("callback")
     # type of result
     ipsasnumbers = request.params.get("ipsasnumbers")
-    if callback:
-        fmt = "json"
-    else:
-        fmt = request.params.get("format") or "json"
-        if fmt not in set(["txt", "json", "ndjson"]):
-            fmt = "txt"
+    fmt = request.params.get("format") or "json"
+    if fmt not in {"txt", "json", "ndjson"}:
+        fmt = "txt"
     datesasstrings = request.params.get("datesasstrings")
     if fmt == "txt":
         response.set_header("Content-Type", "text/plain")
     elif fmt == "ndjson":
         response.set_header("Content-Type", "application/x-ndjson")
     else:
-        response.set_header("Content-Type", "application/javascript")
-    if callback is None:
-        response.set_header(
-            "Content-Disposition", f'attachment; filename="IVRE-results.{fmt}"'
-        )
+        response.set_header("Content-Type", "application/json")
+    response.set_header(
+        "Content-Disposition", f'attachment; filename="IVRE-results.{fmt}"'
+    )
     return FilterParams(
         flt,
         sortby,
@@ -129,7 +123,6 @@ def get_base(dbase):
         skip,
         limit,
         fields,
-        callback,
         ipsasnumbers,
         datesasstrings,
         fmt,
@@ -150,8 +143,6 @@ def get_nmap_action(subdb, action):
                       or "diffcats")
     :query str q: query (including limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results (forces "json"
-                        format)
     :query bool ipsasnumbers: to get IP addresses as numbers rather than as
                              strings
     :query bool datesasstrings: to get dates as strings rather than as
@@ -167,7 +158,7 @@ def get_nmap_action(subdb, action):
     preamble = "[\n"
     postamble = "]\n"
     if action == "timeline":
-        result, count = subdb.get_open_port_count(flt_params.flt)
+        result, _ = subdb.get_open_port_count(flt_params.flt)
         if request.params.get("modulo") is None:
 
             def r2time(r):
@@ -206,9 +197,8 @@ def get_nmap_action(subdb, action):
         preamble = '{"type": "GeometryCollection", "geometries": [\n'
         postamble = "]}\n"
         result = list(subdb.getlocations(flt_params.flt))
-        count = len(result)
     elif action == "countopenports":
-        result, count = subdb.get_open_port_count(flt_params.flt)
+        result, _ = subdb.get_open_port_count(flt_params.flt)
         if flt_params.ipsasnumbers:
 
             def r2res(r):
@@ -220,7 +210,7 @@ def get_nmap_action(subdb, action):
                 return [r["addr"], r.get("openports", {}).get("count", 0)]
 
     elif action == "ipsports":
-        result, count = subdb.get_ips_ports(flt_params.flt)
+        result, _ = subdb.get_ips_ports(flt_params.flt)
         if flt_params.ipsasnumbers:
 
             def r2res(r):
@@ -246,7 +236,7 @@ def get_nmap_action(subdb, action):
                 ]
 
     elif action == "onlyips":
-        result, count = subdb.get_ips(flt_params.flt)
+        result, _ = subdb.get_ips(flt_params.flt)
         if flt_params.ipsasnumbers:
 
             def r2res(r):
@@ -275,18 +265,15 @@ def get_nmap_action(subdb, action):
                 request.params.get("cat2"),
                 flt=flt_params.flt,
             )
-        count = 0
         result = {}
         if flt_params.ipsasnumbers:
             for res in output:
                 result.setdefault(res["addr"], []).append([res["port"], res["value"]])
-                count += 1
         else:
             for res in output:
                 result.setdefault(utils.int2ip(res["addr"]), []).append(
                     [res["port"], res["value"]]
                 )
-                count += 1
         result = result.items()
 
     if flt_params.fmt == "txt":
@@ -300,14 +287,6 @@ def get_nmap_action(subdb, action):
             yield f"{json.dumps(r2res(rec))}\n"
         return
 
-    if flt_params.callback is not None:
-        if count >= config.WEB_WARN_DOTS_COUNT:
-            yield (
-                'if(confirm("You are about to ask your browser to display %d '
-                "dots, which is a lot and might slow down, freeze or crash "
-                'your browser. Do you want to continue?")) {\n' % count
-            )
-        yield f"{flt_params.callback}(\n"
     yield preamble
 
     # hack to avoid a trailing comma
@@ -323,12 +302,7 @@ def get_nmap_action(subdb, action):
         yield "\n"
 
     yield postamble
-    if flt_params.callback is not None:
-        yield ");"
-        if count >= config.WEB_WARN_DOTS_COUNT:
-            yield "}\n"
-    else:
-        yield "\n"
+    yield "\n"
 
 
 @application.get("/<subdb:re:scans|view>/count")
@@ -339,7 +313,6 @@ def get_nmap_count(subdb):
     :param str subdb: database to query (must be "scans" or "view")
     :query str q: query (including limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :status 200: no error
     :status 400: invalid referer
     :>json int: count
@@ -348,9 +321,7 @@ def get_nmap_count(subdb):
     subdb = db.view if subdb == "view" else db.nmap
     flt_params = get_base(subdb)
     count = subdb.count(flt_params.flt)
-    if flt_params.callback is None:
-        return f"{count}\n"
-    return f"{flt_params.callback}({count});\n"
+    return f"{count}\n"
 
 
 @application.get("/<subdb:re:scans|view|passive|rir>/top/<field:path>")
@@ -363,7 +334,6 @@ def get_top(subdb, field):
     :param str field: (pseudo-)field to get top values (e.g., "service")
     :query str q: query (including limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :query bool ipsasnumbers: to get IP addresses as numbers rather than as
                              strings
     :query bool datesasstrings: to get dates as strings rather than as
@@ -405,10 +375,7 @@ def get_top(subdb, field):
         for rec in cursor:
             yield json.dumps({"label": rec["_id"], "value": rec["count"]})
         return
-    if flt_params.callback is None:
-        yield "[\n"
-    else:
-        yield f"{flt_params.callback}([\n"
+    yield "[\n"
     # hack to avoid a trailing comma
     cursor = iter(cursor)
     try:
@@ -419,10 +386,7 @@ def get_top(subdb, field):
         yield json.dumps({"label": rec["_id"], "value": rec["count"]})
         for rec in cursor:
             yield f",\n{json.dumps({'label': rec['_id'], 'value': rec['count']})}"
-    if flt_params.callback is None:
-        yield "\n]\n"
-    else:
-        yield "\n]);\n"
+    yield "\n]\n"
 
 
 @application.get("/<subdb:re:scans|view|passive|rir>/distinct/<field:path>")
@@ -435,7 +399,6 @@ def get_distinct(subdb, field):
     :param str field: (pseudo-)field to get distinct values (e.g., "service")
     :query str q: query (including limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :query bool ipsasnumbers: to get IP addresses as numbers rather than as
                              strings
     :query bool datesasstrings: to get dates as strings rather than as
@@ -465,10 +428,7 @@ def get_distinct(subdb, field):
         for rec in cursor:
             yield f"{json.dumps(rec)}\n"
         return
-    if flt_params.callback is None:
-        yield "[\n"
-    else:
-        yield f"{flt_params.callback}([\n"
+    yield "[\n"
     # hack to avoid a trailing comma
     cursor = iter(cursor)
     try:
@@ -479,10 +439,7 @@ def get_distinct(subdb, field):
         yield json.dumps(rec)
         for rec in cursor:
             yield f",\n{json.dumps(rec)}"
-    if flt_params.callback is None:
-        yield "\n]\n"
-    else:
-        yield "\n]);\n"
+    yield "\n]\n"
 
 
 def _convert_datetime_value(value):
@@ -520,7 +477,6 @@ def get_nmap(subdb):
     :param str subdb: database to query (must be "scans" or "view")
     :query str q: query (including limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :query bool ipsasnumbers: to get IP addresses as numbers rather than as
                              strings
     :query bool datesasstrings: to get dates as strings rather than as
@@ -548,27 +504,15 @@ def get_nmap(subdb):
 
     if flt_params.unused:
         msg = f"Option{'s' if len(flt_params.unused) > 1 else ''} not understood: {', '.join(flt_params.unused)}"
-        if flt_params.callback is not None:
-            yield webutils.js_alert("param-unused", "warning", msg)
         utils.LOGGER.warning(msg)
-    elif flt_params.callback is not None:
-        yield webutils.js_del_alert("param-unused")
 
     if config.DEBUG:
-        msg1 = f"filter: {subdb.flt2str(flt_params.flt)!r}"
-        msg2 = f"user: {webutils.get_user()!r}"
-        utils.LOGGER.debug(msg1)
-        utils.LOGGER.debug(msg2)
-        if flt_params.callback is not None:
-            yield webutils.js_alert("filter", "info", msg1)
-            yield webutils.js_alert("user", "info", msg2)
+        utils.LOGGER.debug("filter: %r", subdb.flt2str(flt_params.flt))
+        utils.LOGGER.debug("user: %r", webutils.get_user())
 
     version_mismatch = {}
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "[\n"
-    else:
-        yield f"{flt_params.callback}([\n"
+    if flt_params.fmt == "json":
+        yield "[\n"
     # XXX-WORKAROUND-PGSQL
     # for rec in result:
     for i, rec in enumerate(result):
@@ -619,11 +563,8 @@ def get_nmap(subdb):
         # XXX-WORKAROUND-PGSQL
         if flt_params.limit and i + 1 >= flt_params.limit:
             break
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "\n]\n"
-    else:
-        yield "\n]);\n"
+    if flt_params.fmt == "json":
+        yield "\n]\n"
 
     messages = {
         1: lambda count: (
@@ -634,12 +575,7 @@ def get_nmap(subdb):
         ),
     }
     for mismatch, count in version_mismatch.items():
-        message = messages[mismatch](count)
-        if flt_params.callback is not None:
-            yield webutils.js_alert(
-                f"version-mismatch-{(mismatch + 1) // 2}", "warning", message
-            )
-        utils.LOGGER.warning(message)
+        utils.LOGGER.warning(messages[mismatch](count))
 
 
 #
@@ -737,21 +673,17 @@ def get_flow():
     """Get special values from Nmap & View databases
 
     :query str q: query (including limit/skip, orderby, etc.)
-    :query str callback: callback to use for JSONP results
     :query str action: can be set to "details"
     :status 200: no error
     :status 400: invalid referer
     :>json object: results
 
     """
-    callback = request.params.get("callback")
+    response.set_header("Content-Type", "application/json")
+    response.set_header(
+        "Content-Disposition", 'attachment; filename="IVRE-results.json"'
+    )
     action = request.params.get("action", "")
-    if callback is None:
-        response.set_header(
-            "Content-Disposition", 'attachment; filename="IVRE-results.json"'
-        )
-    else:
-        yield f"{callback}(\n"
     utils.LOGGER.debug("Params: %r", dict(request.params))
     query = json.loads(request.params.get("q", "{}"))
     limit = query.get("limit", config.WEB_GRAPH_LIMIT)
@@ -809,8 +741,7 @@ def get_flow():
                 before=before,
             )
     yield json.dumps(res, default=utils.serialize)
-    if callback is not None:
-        yield ");\n"
+    yield "\n"
 
 
 #
@@ -824,17 +755,13 @@ def get_ipdata(addr):
     """Returns (estimated) geographical and AS data for a given IP address.
 
     :param str addr: IP address to query
-    :query str callback: callback to use for JSONP results
     :status 200: no error
     :status 400: invalid referer
     :>json object: the result values
 
     """
-    callback = request.params.get("callback")
-    result = json.dumps(db.data.infos_byip(addr))
-    if callback is None:
-        return f"{result}\n"
-    return f"{callback}({result});\n"
+    response.set_header("Content-Type", "application/json")
+    return f"{json.dumps(db.data.infos_byip(addr))}\n"
 
 
 #
@@ -924,7 +851,6 @@ def get_passive():
 
     :query str q: query (only used for limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :query bool ipsasnumbers: to get IP addresses as numbers rather than as
                              strings
     :query bool datesasstrings: to get dates as strings rather than as
@@ -947,11 +873,8 @@ def get_passive():
         sort=flt_params.sortby,
         fields=flt_params.fields,
     )
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "[\n"
-    else:
-        yield f"{flt_params.callback}([\n"
+    if flt_params.fmt == "json":
+        yield "[\n"
     # XXX-WORKAROUND-PGSQL
     # for rec in result:
     for i, rec in enumerate(result):
@@ -978,11 +901,8 @@ def get_passive():
             )
         if flt_params.limit and i + 1 >= flt_params.limit:
             break
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "\n]\n"
-    else:
-        yield "\n]);\n"
+    if flt_params.fmt == "json":
+        yield "\n]\n"
 
 
 @application.get("/passive/count")
@@ -992,7 +912,6 @@ def get_passive_count():
 
     :query str q: query (only used for limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :status 200: no error
     :status 400: invalid referer
     :>json int: count
@@ -1000,9 +919,7 @@ def get_passive_count():
     """
     flt_params = get_base(db.passive)
     count = db.passive.count(flt_params.flt)
-    if flt_params.callback is None:
-        return f"{count}\n"
-    return f"{flt_params.callback}({count});\n"
+    return f"{count}\n"
 
 
 #
@@ -1017,7 +934,6 @@ def get_rir():
 
     :query str q: query (only used for limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :query str format: "json" (the default) or "ndjson"
     :status 200: no error
     :status 400: invalid referer
@@ -1031,11 +947,8 @@ def get_rir():
         sort=flt_params.sortby,
         fields=flt_params.fields,
     )
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "[\n"
-    else:
-        yield f"{flt_params.callback}([\n"
+    if flt_params.fmt == "json":
+        yield "[\n"
     for i, rec in enumerate(result):
         try:
             del rec["_id"]
@@ -1050,11 +963,8 @@ def get_rir():
             )
         if flt_params.limit and i + 1 >= flt_params.limit:
             break
-    if flt_params.callback is None:
-        if flt_params.fmt == "json":
-            yield "\n]\n"
-    else:
-        yield "\n]);\n"
+    if flt_params.fmt == "json":
+        yield "\n]\n"
 
 
 @application.get("/rir/count")
@@ -1064,7 +974,6 @@ def get_rir_count():
 
     :query str q: query (only used for limit/skip and sort)
     :query str f: filter
-    :query str callback: callback to use for JSONP results
     :status 200: no error
     :status 400: invalid referer
     :>json int: count
@@ -1072,9 +981,7 @@ def get_rir_count():
     """
     flt_params = get_base(db.rir)
     count = db.rir.count(flt_params.flt)
-    if flt_params.callback is None:
-        return f"{count}\n"
-    return f"{flt_params.callback}({count});\n"
+    return f"{count}\n"
 
 
 # Auth check route for nginx auth_request — always registered so that

--- a/ivre/web/base.py
+++ b/ivre/web/base.py
@@ -23,12 +23,12 @@ This module exists to break the cyclic import between ``app`` and
 so they live here where neither module is imported.
 """
 
+import json
 from functools import wraps
 
 from bottle import Bottle, request, response
 
 from ivre import config, utils
-from ivre.web import utils as webutils
 
 application = Bottle()
 
@@ -37,6 +37,7 @@ application = Bottle()
 def add_security_headers():
     response.set_header("X-Frame-Options", "DENY")
     response.set_header("Content-Security-Policy", "frame-ancestors 'none'")
+    response.set_header("X-Content-Type-Options", "nosniff")
 
 
 def check_referer(func):
@@ -52,10 +53,12 @@ def check_referer(func):
 
     def _die(referer):
         utils.LOGGER.critical("Invalid Referer header [%r]", referer)
-        response.set_header("Content-Type", "application/javascript")
+        response.set_header("Content-Type", "application/json")
         response.status = "400 Bad Request"
-        return webutils.js_alert(
-            "referer", "error", "Invalid Referer header. Check your configuration."
+        return json.dumps(
+            {
+                "error": "Invalid Referer header. Check your configuration.",
+            }
         )
 
     @wraps(func)

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -26,7 +26,6 @@ import functools
 import os
 import re
 import shlex
-import sys
 
 try:
     import MySQLdb  # type: ignore
@@ -39,27 +38,6 @@ except ImportError:
 from bottle import request  # type: ignore
 
 from ivre import config, utils
-
-
-def js_alert(ident, level, message):
-    """This function returns a string containing JS code to
-    generate an alert message.
-
-    """
-    message = message.replace('"', '\\"')
-    return (
-        f'try {{add_message("{ident}", "{level}", "{message}");}}\n'
-        f'catch(err) {{alert("{level.upper()}: {message}");}}\n'
-    )
-
-
-def js_del_alert(ident):
-    """This function returns a string containing JS code to
-    remove an alert message.
-
-    """
-    return 'try {del_message("%s");} catch(err) {}\n' % ident
-
 
 GET_NOTEPAD_PAGES = {}
 
@@ -129,8 +107,9 @@ def query_from_params(params):
     returns the query as a list of three elements list: [boolean
     `neg`, `param`, `value`].
 
-    This function will write an error message and abort the CGI if an
-    error occurs with `shlex.split()`.
+    Raises ``ValueError`` if `shlex.split()` fails on the query string;
+    the caller is expected to surface the error via Bottle (typically
+    as HTTP 400).
 
     """
     try:
@@ -146,14 +125,6 @@ def query_from_params(params):
             )
         ]
     except ValueError as exc:
-        sys.stdout.write(
-            js_alert(
-                "param-parsing",
-                "warning",
-                "Parameter parsing error. Check the server's logs "
-                "for more information.",
-            )
-        )
         utils.LOGGER.critical("Parameter parsing error [%s (%r)]", exc, exc)
         raise ValueError("Parameter parsing error") from exc
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -717,6 +717,112 @@ class ScreenshotContainmentTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# JSONP-removal regressions
+# ---------------------------------------------------------------------
+
+
+class JsonpDroppedTests(unittest.TestCase):
+    """Regression tests asserting that JSONP support has been removed
+    from the Web API.
+
+    JSONP existed to allow cross-origin GETs by wrapping JSON
+    responses as ``callback(...);`` JavaScript. Modern setups serve
+    the IVRE Web UI from the same origin as the API, making JSONP
+    unnecessary; the wrapping itself is a class of MIME-confusion
+    risk (the response Content-Type was ``application/javascript``,
+    so any reflected data could potentially be interpreted as
+    script). Removing JSONP closes Finding 3 of the security review.
+    """
+
+    @staticmethod
+    def _read_py(module) -> str:
+        """Read a Python module's source via its imported file path.
+
+        Reading from a hard-coded ``ivre/`` filesystem path would fail
+        in CI where ``install.sh`` renames the in-tree ``ivre/``
+        directory to ``ivre_bak/`` to force tests to use the installed
+        package. Going through ``module.__file__`` finds the source
+        regardless of layout.
+        """
+        path = inspect.getsourcefile(module)
+        assert path is not None, f"no source file for {module!r}"
+        with open(path, encoding="utf8") as fdesc:
+            return fdesc.read()
+
+    @staticmethod
+    def _read_static(relpath: str) -> str:
+        """Read a file under ``web/static/`` relative to the repo
+        root. The ``web/`` tree is not renamed by ``install.sh``, so
+        the ``__file__`` of this test module still gives a usable
+        repo root."""
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(repo_root, relpath), encoding="utf8") as fdesc:
+            return fdesc.read()
+
+    def test_app_py_has_no_callback_query_param(self) -> None:
+        """``ivre/web/app.py`` no longer reads ``request.params.get(
+        "callback")``, no longer threads a ``callback`` field through
+        ``FilterParams``, and no longer emits ``callback(...);``
+        wrappers."""
+        from ivre.web import app
+
+        src = self._read_py(app)
+        # The query parameter is gone:
+        self.assertNotIn('request.params.get("callback")', src)
+        self.assertNotIn("flt_params.callback", src)
+        # No JSONP wrapper expressions like `f"{callback}(` remain:
+        self.assertIsNone(
+            re.search(r'f"\{[a-zA-Z_.]*callback[a-zA-Z_.]*\}\(', src),
+            "JSONP wrapper expression must not remain in app.py",
+        )
+        # The Content-Type lie (application/javascript for JSON
+        # responses) is gone too. The `/config` route legitimately
+        # emits JS via <script src=...>, so we accept at most one
+        # occurrence (the `/config` route).
+        self.assertLessEqual(
+            src.count('"application/javascript"'),
+            1,
+            "Only the /config route may set Content-Type: " "application/javascript",
+        )
+
+    def test_filter_params_has_no_callback_field(self) -> None:
+        """The ``FilterParams`` namedtuple no longer carries a
+        ``callback`` field."""
+        from ivre.web.app import FilterParams
+
+        self.assertNotIn("callback", FilterParams._fields)
+
+    def test_js_alert_helpers_removed(self) -> None:
+        """``js_alert`` and ``js_del_alert`` (which produced inline
+        JS snippets to be embedded in JSONP responses) are gone."""
+        from ivre.web import utils as webutils
+
+        self.assertFalse(hasattr(webutils, "js_alert"))
+        self.assertFalse(hasattr(webutils, "js_del_alert"))
+
+    def test_angularjs_callers_use_plain_json(self) -> None:
+        """The three AngularJS ``$.ajax`` JSONP callers (graph.js,
+        filters.js x2) have been migrated to plain JSON. They are
+        same-origin so JSONP is unnecessary."""
+        for relpath in (
+            "web/static/ivre/graph.js",
+            "web/static/ivre/filters.js",
+        ):
+            src = self._read_static(relpath)
+            self.assertNotIn('dataType: "jsonp"', src, msg=relpath)
+            self.assertNotIn('jsonp: "callback"', src, msg=relpath)
+
+    def test_security_headers_include_nosniff(self) -> None:
+        """``X-Content-Type-Options: nosniff`` is set on every
+        response by the Bottle ``after_request`` hook."""
+        from ivre.web import base
+
+        src = self._read_py(base)
+        self.assertIn("X-Content-Type-Options", src)
+        self.assertIn("nosniff", src)
+
+
+# ---------------------------------------------------------------------
 # RIR HTTP backend / MCP tool tests
 # ---------------------------------------------------------------------
 

--- a/web/static/ivre/filters.js
+++ b/web/static/ivre/filters.js
@@ -116,8 +116,7 @@ var Filter = (function() {
             $.ajax({
                 url: "cgi/view/count?q=" +
                     encodeURIComponent(this.query),
-                jsonp: "callback",
-                dataType: "jsonp",
+                dataType: "json",
                 beforeSend: function() {
 		    filterobject.count = undefined;
                 },
@@ -133,8 +132,7 @@ var Filter = (function() {
             if(this.callbacks.get_results.length > 0) {
                 $.ajax({
                     url: "cgi/view?q=" + encodeURIComponent(this.query),
-                    jsonp: "callback",
-                    dataType: "jsonp",
+                    dataType: "json",
                     beforeSend: function() {
                         filterobject._call_callbacks(
                                 filterobject.callbacks.pre_get_results

--- a/web/static/ivre/graph.js
+++ b/web/static/ivre/graph.js
@@ -50,8 +50,7 @@ var Graph = (function() {
 	    this.container.css("display", "inline");
 	    $.ajax({
 		url: this.get_url(),
-		jsonp: "callback",
-		dataType: "jsonp",
+		dataType: "json",
 		success: function(data) {
 		    graphobject.draw.call(graphobject, data);
 		}


### PR DESCRIPTION
The ?callback= query parameter wrapped read-route responses as ``callback(...);`` to support cross-origin reads via <script src=...>. Modern setups serve the IVRE Web UI from the same origin as the API (via ivre httpd or a reverse proxy), making JSONP unnecessary. Removing it eliminates a class of MIME-confusion / response-as-script risks.

- Strip ?callback= handling from every route in ivre/web/app.py and drop the field from FilterParams.
- Fix the Content-Type lie: application/javascript -> application/json on the JSON path (the /config route, which is genuinely a script loaded via <script src=>, keeps application/javascript).
- Add X-Content-Type-Options: nosniff to add_security_headers (defence-in-depth against MIME sniffing).
- Drop the js_alert / js_del_alert helpers in ivre/web/utils.py and every call site in app.py: they produced inline JS embedded in JSONP responses to surface server-side warnings, which has no recipient under plain JSON.
- check_referer's _die() now returns HTTP 400 with a JSON body instead of an "application/javascript" snippet that called add_message().
- query_from_params no longer writes a JS snippet to stdout (which never reached the response under WSGI anyway) before raising ValueError.
- Migrate the three AngularJS JSONP callers (graph.js, filters.js do_count and do_get_results) to plain dataType: "json"; same-origin so no other change needed.
- Drop the ":query str callback:" lines from every route docstring.
- Add JsonpDroppedTests in tests_no_backend.py asserting the callback field is gone, no JSONP wrapper expressions remain in app.py, the helpers are gone, AngularJS callers use plain JSON, and the nosniff header is set.