### PR TITLE
ci: split MongoDB RIR tests into a dedicated job

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 jobs:
-  build:
+  mongodb:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -66,7 +66,7 @@ jobs:
     - name: Initialize IVRE databases
       run: for cli in ipinfo scancli view flowcli; do ivre $cli --init < /dev/null; done
 
-    - run: cd tests && python tests.py
+    - run: cd tests && python tests.py --exclude 15_rir
       env:
         CI: true
         DB: mongo
@@ -84,9 +84,57 @@ jobs:
     - run: cat /tmp/webserver.log
       if: failure()
 
+  mongodb_rir:
+    # ``test_15_rir`` downloads the full RIPE inetnum dump (hundreds
+    # of MB) and inserts it; running it on each ``mongodb`` matrix
+    # entry was making MongoDB+Elasticsearch wall-clock noticeably
+    # longer. Splitting the RIR test into its own parallel job (and
+    # decoupling ``elastic`` from it via ``needs: mongodb``) keeps
+    # the total test coverage identical while shortening the
+    # critical path on the green-PR latency.
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+        mongodb-version: ['7.0', '8.0']
+
+    steps:
+
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Use Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.12.1
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+
+    - name: Install IVRE
+      uses: ./.github/actions/install
+
+    - run: python -c 'import json, pymongo; print(json.dumps(pymongo.MongoClient().server_info(), indent=4))'
+
+    - name: Initialize IVRE databases
+      run: for cli in ipinfo scancli view flowcli; do ivre $cli --init < /dev/null; done
+
+    - run: cd tests && python tests.py 15_rir
+      env:
+        CI: true
+        DB: mongo
+
+    - run: cat /tmp/webserver.log
+      if: failure()
+
   elastic:
     runs-on: ubuntu-24.04
-    needs: build
+    needs: mongodb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -32,6 +32,14 @@ jobs:
         # https://www.mongodb.com/docs/languages/python/pymongo-driver/current/compatibility/
         python-version: ['3.12', '3.13', '3.14']
         mongodb-version: ['7.0', '8.0']
+        # The (3.12, 7.0) cell is handled by the dedicated
+        # ``mongodb_dump`` job below: it runs the same test set but
+        # additionally produces the ``backup_nmap_passive`` artifact
+        # consumed by ``elastic``. Excluding it here lets ``elastic``
+        # depend on a single small job instead of the full matrix.
+        exclude:
+          - python-version: '3.12'
+            mongodb-version: '7.0'
 
     steps:
 
@@ -50,8 +58,49 @@ jobs:
       with:
         mongodb-version: ${{ matrix.mongodb-version }}
 
+    - name: Install IVRE
+      uses: ./.github/actions/install
+
+    - run: python -c 'import json, pymongo; print(json.dumps(pymongo.MongoClient().server_info(), indent=4))'
+
+    - name: Initialize IVRE databases
+      run: for cli in ipinfo scancli view flowcli; do ivre $cli --init < /dev/null; done
+
+    - run: cd tests && python tests.py --exclude 15_rir
+      env:
+        CI: true
+        DB: mongo
+
+    - run: cat /tmp/webserver.log
+      if: failure()
+
+  mongodb_dump:
+    # Dedicated single-cell variant of the ``mongodb`` matrix. Runs
+    # the same non-RIR test set on (Python 3.12, MongoDB 7.0) and
+    # additionally produces the ``backup_nmap_passive`` artifact that
+    # the ``elastic`` job restores via ``mongorestore``. Keeping this
+    # cell separate lets ``elastic`` depend only on the artifact
+    # producer instead of waiting on every ``mongodb`` matrix entry.
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Use Python 3.12
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.12.1
+      with:
+        mongodb-version: '7.0'
+
     - name: Install MongoDB tools (mongodump)
-      if: ${{ matrix.mongodb-version == '7.0' && matrix.python-version == '3.12' }}
       run: |
           wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | sudo tee /etc/apt/trusted.gpg.d/server-8.0.asc > /dev/null
           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list > /dev/null
@@ -70,12 +119,9 @@ jobs:
       env:
         CI: true
         DB: mongo
-        # Only the dump-producing matrix entry sets this; the test
-        # `test_50_dump_nmap_passive` is a no-op everywhere else.
-        IVRE_DUMP_NMAP_PASSIVE: ${{ (matrix.mongodb-version == '7.0' && matrix.python-version == '3.12') && '1' || '' }}
+        IVRE_DUMP_NMAP_PASSIVE: '1'
 
     - name: Archive MongoDB dump artifacts
-      if: ${{ matrix.mongodb-version == '7.0' && matrix.python-version == '3.12' }}
       uses: actions/upload-artifact@v4
       with:
         name: backup_nmap_passive
@@ -89,7 +135,7 @@ jobs:
     # of MB) and inserts it; running it on each ``mongodb`` matrix
     # entry was making MongoDB+Elasticsearch wall-clock noticeably
     # longer. Splitting the RIR test into its own parallel job (and
-    # decoupling ``elastic`` from it via ``needs: mongodb``) keeps
+    # decoupling ``elastic`` from the dump-producing job only) keeps
     # the total test coverage identical while shortening the
     # critical path on the green-PR latency.
     runs-on: ubuntu-24.04
@@ -134,7 +180,7 @@ jobs:
 
   elastic:
     runs-on: ubuntu-24.04
-    needs: mongodb
+    needs: mongodb_dump
     strategy:
       fail-fast: false
       matrix:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5028,6 +5028,7 @@ class IvreTests(unittest.TestCase):
 TESTS = set(
     [
         "10_data",
+        "15_rir",
         "30_nmap",
         "40_passive",
         "50_view",
@@ -5079,6 +5080,14 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Run IVRE tests")
     parser.add_argument("--samples", metavar="DIR", default="./samples/")
     parser.add_argument("--coverage", action="store_true")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        choices=list(TESTS),
+        metavar="TEST",
+        help="Skip the named test (may be repeated; same choices as positional).",
+    )
     parser.add_argument("tests", nargs="*", choices=list(TESTS) + [[]])
     args = parser.parse_args()
     SAMPLES = args.samples
@@ -5089,6 +5098,13 @@ def parse_args():
             setattr(
                 IvreTests, test, unittest.skip("User request")(getattr(IvreTests, test))
             )
+    for test in args.exclude:
+        method = "test_%s" % test
+        setattr(
+            IvreTests,
+            method,
+            unittest.skip("--exclude %s" % test)(getattr(IvreTests, method)),
+        )
     sys.argv = [sys.argv[0]]
 
 


### PR DESCRIPTION
``test_15_rir`` downloads the full RIPE inetnum dump (hundreds of MB) on every matrix entry and inserts it into MongoDB. Running it inside the main ``build`` job inflated the green-PR latency twice over: each of the six ``python x mongodb`` matrix runs paid the RIPE round-trip cost, and the ``elastic`` job (which depends on the ``build`` artifact) had to wait for all of them to finish before starting.

Split the original ``build`` job into:

- ``mongodb`` — the existing matrix, now invoked as ``python tests.py --exclude 15_rir``. Same setup, same dump artifact, same ``IVRE_DUMP_NMAP_PASSIVE`` gate.
- ``mongodb_rir`` — same matrix, runs only ``test_15_rir``. No ``mongodump`` install, no dump artifact upload.

The two jobs run in parallel, with the same overall coverage (every ``python x mongodb`` cell still exercises the RIR test).

Switch ``elastic.needs:`` from ``build`` to ``mongodb`` so it starts as soon as the non-RIR tests are done; ``elastic`` does not consume RIR data, only the dump artifact produced by the (3.12, 7.0) cell of ``mongodb``.

Side fixes in ``tests/tests.py``:

- Add ``"15_rir"`` to the ``TESTS`` set. The positional-arg skip loop in ``parse_args`` is keyed on ``TESTS.difference(args.tests)``, so without this, ``python tests.py 30_nmap`` would still run ``test_15_rir``. Latent bug, surfaced while wiring the new job.
- Add ``--exclude TEST`` to ``parse_args``. Repeatable, validated against the same ``TESTS`` set as the positional choices. Lets the YAML say ``--exclude 15_rir`` rather than enumerating every other test name in the matrix step.