### PR TITLE
fix(web): regex complexity budget for user-supplied $regex

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -234,6 +234,22 @@ WEB_WARN_DOTS_COUNT = 20000
 WEB_GET_NOTEPAD_PAGES = None
 WEB_LIMIT = 10
 WEB_GRAPH_LIMIT = 1000
+# Maximum length, in characters, of a user-supplied regex literal
+# (the inner pattern of a ``/.../[flags]`` value reaching
+# ``ivre.web.utils.str2regexp``). Enforced before the pattern is
+# parsed, as defence-in-depth on top of the server-side
+# ``MONGODB_QUERY_TIMEOUT_MS`` cap and the regexploit-based
+# ReDoS analyser. Set to ``None`` to disable the length check.
+WEB_REGEX_MAX_LENGTH: int | None = 1000
+# Maximum allowed regexploit "starriness" — the depth of nested
+# unbounded repetition that an attacker can drive through
+# backtracking. ``2`` matches the regexploit CLI default
+# (``starriness > 2`` is reported); the canonical exponential
+# ReDoS shapes (``(a+)+x``, ``(.*)*x``, ``(a|a)*x``, ...) all
+# come in at ``starriness >= 11`` so a limit of ``2`` rejects
+# them while accepting realistic operator-typed regex. Set to
+# ``None`` to disable the ReDoS check.
+WEB_REGEX_STARRINESS_LIMIT: int | None = 2
 # access control disabled by default:
 WEB_INIT_QUERIES: dict[str, str] = {}
 # Warning: None means no access control, and is equivalent to "full"

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -36,10 +36,139 @@ except ImportError:
 
 
 from bottle import request  # type: ignore
+from regexploit.ast.sre import SreOpParser  # type: ignore[import-untyped]
+from regexploit.redos import find as _regexploit_find  # type: ignore[import-untyped]
 
 from ivre import config, utils
 
 GET_NOTEPAD_PAGES = {}
+
+
+_REGEX_BUDGET_DEFAULT: object = object()
+
+
+def validate_regex_complexity(
+    pattern: str,
+    *,
+    max_length: int | None | object = _REGEX_BUDGET_DEFAULT,
+    starriness_limit: int | None | object = _REGEX_BUDGET_DEFAULT,
+) -> None:
+    """Validate a user-supplied regex pattern against the
+    ``WEB_REGEX_*`` complexity budget.
+
+    Raises ``ValueError`` if either budget is exceeded. The
+    function is designed to run before user-supplied regex
+    literals (e.g. arriving via the Web API ``q=`` parameter) are
+    compiled or forwarded to ``$regex``, as defence-in-depth on
+    top of the server-side ``MONGODB_QUERY_TIMEOUT_MS`` cap.
+
+    Two rules are enforced:
+
+      1. ``len(pattern) <= max_length`` — bounds the size of the
+         pattern fed to the analyser, the regex compiler and the
+         database.
+      2. The pattern's regexploit "starriness" must not exceed
+         ``starriness_limit``. starriness is the depth of nested
+         unbounded repetition that an attacker can drive through
+         backtracking; it is the standard exploitability metric
+         for nested-quantifier and alternation-overlap ReDoS
+         (``(a+)+x``, ``(a|a)*x``, ``(?:.*)*x``, ...). The
+         analysis is performed by the ``regexploit`` library
+         (Doyensec, Apache-2.0), which builds an AST from
+         CPython's own ``sre_parse`` output and searches for
+         pumping sequences with a "killer" suffix.
+
+    Defaults for ``max_length`` and ``starriness_limit`` are
+    pulled from ``ivre.config.WEB_REGEX_MAX_LENGTH`` /
+    ``ivre.config.WEB_REGEX_STARRINESS_LIMIT`` when the argument
+    is not passed. Passing the argument explicitly as ``None``
+    disables that specific check (this distinction matters for
+    callers that want to ignore the operator-configured default).
+
+    Note: regexploit's own dependence on ``sre_parse`` (which is
+    deprecated in CPython 3.11+ but still functional) is the only
+    reason this validator is not entirely future-proof. If
+    ``sre_parse`` is removed in a future Python release,
+    regexploit will need to migrate to ``re._parser`` first.
+    """
+    if not isinstance(pattern, str):
+        return
+
+    if max_length is _REGEX_BUDGET_DEFAULT:
+        max_length = config.WEB_REGEX_MAX_LENGTH
+    if starriness_limit is _REGEX_BUDGET_DEFAULT:
+        starriness_limit = config.WEB_REGEX_STARRINESS_LIMIT
+
+    if (
+        max_length is not None
+        and isinstance(max_length, int)
+        and len(pattern) > max_length
+    ):
+        raise ValueError(
+            f"Regex exceeds maximum length ({len(pattern)} > {max_length})"
+        )
+
+    if starriness_limit is None:
+        return
+
+    try:
+        parsed = SreOpParser().parse_sre(pattern)
+    except re.error as exc:
+        # Surface the same error class Python's ``re.compile``
+        # would have raised; it converts to a 400 in Bottle.
+        raise ValueError(f"Invalid regex pattern: {exc}") from exc
+
+    if parsed is None:
+        # Empty / no-op pattern; nothing to analyse.
+        return
+
+    if not isinstance(starriness_limit, int):
+        return
+
+    for finding in _regexploit_find(parsed):
+        if finding.starriness > starriness_limit:
+            raise ValueError(
+                "Regex pattern is vulnerable to ReDoS "
+                f"(starriness={finding.starriness}, "
+                f"limit={starriness_limit})"
+            )
+
+
+def _validate_user_regex(value: object) -> None:
+    """Validate a user-supplied ``str2regexp`` argument against the
+    ``WEB_REGEX_*`` complexity budget.
+
+    Only values that ``utils.str2regexp`` would interpret as a
+    regex (``"/.../[flags]"`` syntax) are checked. Plain string
+    values, the special ``"-"`` sentinel honoured by
+    ``str2regexpnone``, and non-string inputs pass through
+    unchanged. ``ValueError`` is raised on overflow; callers in
+    this module rely on Bottle's default 400-on-ValueError
+    behaviour to surface the rejection to the client.
+    """
+    if not isinstance(value, str):
+        return
+    if not value.startswith("/"):
+        return
+    inner = value[1:]
+    # Mirror the ``str2regexp`` rsplit so we validate the inner
+    # pattern rather than the trailing ``/flags`` block.
+    if "/" in inner:
+        inner, _flags = inner.rsplit("/", 1)
+    validate_regex_complexity(inner)
+
+
+def str2regexp(value: str) -> str | re.Pattern[str]:
+    """Validating wrapper over ``utils.str2regexp`` for inputs
+    arriving from the network. See ``_validate_user_regex``."""
+    _validate_user_regex(value)
+    return utils.str2regexp(value)  # type: ignore[no-any-return]
+
+
+def str2regexpnone(value: str) -> str | re.Pattern[str] | bool:
+    """Validating wrapper over ``utils.str2regexpnone``."""
+    _validate_user_regex(value)
+    return utils.str2regexpnone(value)  # type: ignore[no-any-return]
 
 
 def get_notepad_pages_localdokuwiki(pagesdir="/var/lib/dokuwiki/data/pages"):
@@ -291,33 +420,23 @@ def flt_from_query(dbase, query, base_flt=None):
                     flt, dbase.searchcountopenports(minn=vals[0], maxn=vals[1], neg=neg)
                 )
         elif param == "hostname":
-            flt = dbase.flt_and(
-                flt, dbase.searchhostname(utils.str2regexp(value), neg=neg)
-            )
+            flt = dbase.flt_and(flt, dbase.searchhostname(str2regexp(value), neg=neg))
         elif param == "domain":
-            flt = dbase.flt_and(
-                flt, dbase.searchdomain(utils.str2regexp(value), neg=neg)
-            )
+            flt = dbase.flt_and(flt, dbase.searchdomain(str2regexp(value), neg=neg))
         elif param == "category":
-            flt = dbase.flt_and(
-                flt, dbase.searchcategory(utils.str2regexp(value), neg=neg)
-            )
+            flt = dbase.flt_and(flt, dbase.searchcategory(str2regexp(value), neg=neg))
         elif param == "country" and hasattr(dbase, "searchcountry"):
             flt = dbase.flt_and(
                 flt, dbase.searchcountry(utils.str2list(value.upper()), neg=neg)
             )
         elif param == "city" and hasattr(dbase, "searchcity"):
-            flt = dbase.flt_and(flt, dbase.searchcity(utils.str2regexp(value), neg=neg))
+            flt = dbase.flt_and(flt, dbase.searchcity(str2regexp(value), neg=neg))
         elif param == "asnum" and hasattr(dbase, "searchasnum"):
             flt = dbase.flt_and(flt, dbase.searchasnum(utils.str2list(value), neg=neg))
         elif param == "asname" and hasattr(dbase, "searchasname"):
-            flt = dbase.flt_and(
-                flt, dbase.searchasname(utils.str2regexp(value), neg=neg)
-            )
+            flt = dbase.flt_and(flt, dbase.searchasname(str2regexp(value), neg=neg))
         elif param == "source":
-            flt = dbase.flt_and(
-                flt, dbase.searchsource(utils.str2regexp(value), neg=neg)
-            )
+            flt = dbase.flt_and(flt, dbase.searchsource(str2regexp(value), neg=neg))
         elif param == "timerange":
             flt = dbase.flt_and(
                 flt,
@@ -345,28 +464,26 @@ def flt_from_query(dbase, query, base_flt=None):
                 req, port = value.split(":", 1)
                 port = int(port)
                 flt = dbase.flt_and(
-                    flt, dbase.searchservice(utils.str2regexpnone(req), port=port)
+                    flt, dbase.searchservice(str2regexpnone(req), port=port)
                 )
             else:
-                flt = dbase.flt_and(
-                    flt, dbase.searchservice(utils.str2regexpnone(value))
-                )
+                flt = dbase.flt_and(flt, dbase.searchservice(str2regexpnone(value)))
         elif not neg and param == "product" and ":" in value:
             product = value.split(":", 2)
             if len(product) == 2:
                 flt = dbase.flt_and(
                     flt,
                     dbase.searchproduct(
-                        product=utils.str2regexpnone(product[1]),
-                        service=utils.str2regexpnone(product[0]),
+                        product=str2regexpnone(product[1]),
+                        service=str2regexpnone(product[0]),
                     ),
                 )
             else:
                 flt = dbase.flt_and(
                     flt,
                     dbase.searchproduct(
-                        product=utils.str2regexpnone(product[1]),
-                        service=utils.str2regexpnone(product[0]),
+                        product=str2regexpnone(product[1]),
+                        service=str2regexpnone(product[0]),
                         port=int(product[2]),
                     ),
                 )
@@ -376,18 +493,18 @@ def flt_from_query(dbase, query, base_flt=None):
                 flt = dbase.flt_and(
                     flt,
                     dbase.searchproduct(
-                        product=utils.str2regexpnone(product[1]),
-                        version=utils.str2regexpnone(product[2]),
-                        service=utils.str2regexpnone(product[0]),
+                        product=str2regexpnone(product[1]),
+                        version=str2regexpnone(product[2]),
+                        service=str2regexpnone(product[0]),
                     ),
                 )
             else:
                 flt = dbase.flt_and(
                     flt,
                     dbase.searchproduct(
-                        product=utils.str2regexpnone(product[1]),
-                        version=utils.str2regexpnone(product[2]),
-                        service=utils.str2regexpnone(product[0]),
+                        product=str2regexpnone(product[1]),
+                        version=str2regexpnone(product[2]),
+                        service=str2regexpnone(product[0]),
                         port=int(product[3]),
                     ),
                 )
@@ -396,14 +513,14 @@ def flt_from_query(dbase, query, base_flt=None):
             if len(value) == 1:
                 flt = dbase.flt_and(
                     flt,
-                    dbase.searchscript(name=utils.str2regexp(value[0]), neg=neg),
+                    dbase.searchscript(name=str2regexp(value[0]), neg=neg),
                 )
             else:
                 flt = dbase.flt_and(
                     flt,
                     dbase.searchscript(
-                        name=utils.str2regexp(value[0]),
-                        output=utils.str2regexp(value[1]),
+                        name=str2regexp(value[0]),
+                        output=str2regexp(value[1]),
                         neg=neg,
                     ),
                 )
@@ -417,7 +534,7 @@ def flt_from_query(dbase, query, base_flt=None):
         elif not neg and param == "authhttp":
             flt = dbase.flt_and(flt, dbase.searchhttpauth())
         elif not neg and param == "banner":
-            flt = dbase.flt_and(flt, dbase.searchbanner(utils.str2regexp(value)))
+            flt = dbase.flt_and(flt, dbase.searchbanner(str2regexp(value)))
         elif not neg and param == "cookie":
             flt = dbase.flt_and(flt, dbase.searchcookie(value))
         elif not neg and param == "file":
@@ -427,13 +544,13 @@ def flt_from_query(dbase, query, base_flt=None):
                 value = value.split(":", 1)
                 if len(value) == 1:
                     flt = dbase.flt_and(
-                        flt, dbase.searchfile(fname=utils.str2regexp(value[0]))
+                        flt, dbase.searchfile(fname=str2regexp(value[0]))
                     )
                 else:
                     flt = dbase.flt_and(
                         flt,
                         dbase.searchfile(
-                            fname=utils.str2regexp(value[1]),
+                            fname=str2regexp(value[1]),
                             scripts=value[0].split(","),
                         ),
                     )
@@ -450,7 +567,7 @@ def flt_from_query(dbase, query, base_flt=None):
         elif not neg and param == "geovision":
             flt = dbase.flt_and(flt, dbase.searchgeovision())
         elif param == "httptitle":
-            flt = dbase.flt_and(flt, dbase.searchhttptitle(utils.str2regexp(value)))
+            flt = dbase.flt_and(flt, dbase.searchhttptitle(str2regexp(value)))
         elif not neg and param == "nfs":
             flt = dbase.flt_and(flt, dbase.searchnfs())
         elif not neg and param in {"nis", "yp"}:
@@ -461,9 +578,7 @@ def flt_from_query(dbase, query, base_flt=None):
             flt = dbase.flt_and(flt, dbase.searchmysqlemptypwd())
         elif not neg and param == "sshkey":
             if value:
-                flt = dbase.flt_and(
-                    flt, dbase.searchsshkey(output=utils.str2regexp(value))
-                )
+                flt = dbase.flt_and(flt, dbase.searchsshkey(output=str2regexp(value)))
             else:
                 flt = dbase.flt_and(flt, dbase.searchsshkey())
         elif not neg and param.startswith("sshkey."):
@@ -477,7 +592,7 @@ def flt_from_query(dbase, query, base_flt=None):
                     except (ValueError, TypeError):
                         pass
                 else:
-                    value = utils.str2regexp(value)
+                    value = str2regexp(value)
                 flt = dbase.flt_and(flt, dbase.searchsshkey(**{subfield: value}))
             else:
                 add_unused(neg, param, value)
@@ -508,7 +623,7 @@ def flt_from_query(dbase, query, base_flt=None):
                         cacert=cacert,
                         neg=neg,
                         **{
-                            subfield: utils.str2regexp(value),
+                            subfield: str2regexp(value),
                         },
                     ),
                 )
@@ -519,7 +634,7 @@ def flt_from_query(dbase, query, base_flt=None):
                         cacert=cacert,
                         neg=neg,
                         **{
-                            f"pk{subfield[7:]}": utils.str2regexp(value),
+                            f"pk{subfield[7:]}": str2regexp(value),
                         },
                     ),
                 )
@@ -530,35 +645,29 @@ def flt_from_query(dbase, query, base_flt=None):
                 flt = dbase.flt_and(flt, dbase.searchhttphdr())
             elif ":" in value:
                 name, value = value.split(":", 1)
-                name = utils.str2regexp(name.lower())
-                value = utils.str2regexp(value)
+                name = str2regexp(name.lower())
+                value = str2regexp(value)
                 flt = dbase.flt_and(flt, dbase.searchhttphdr(name=name, value=value))
             else:
                 flt = dbase.flt_and(
-                    flt, dbase.searchhttphdr(name=utils.str2regexp(value.lower()))
+                    flt, dbase.searchhttphdr(name=str2regexp(value.lower()))
                 )
         elif not neg and param == "httpapp":
             if value is None:
                 flt = dbase.flt_and(flt, dbase.searchhttpapp())
             elif ":" in value:
-                name, version = (
-                    utils.str2regexp(string) for string in value.split(":", 1)
-                )
+                name, version = (str2regexp(string) for string in value.split(":", 1))
                 flt = dbase.flt_and(
                     flt, dbase.searchhttpapp(name=name, version=version)
                 )
             else:
-                flt = dbase.flt_and(
-                    flt, dbase.searchhttpapp(name=utils.str2regexp(value))
-                )
+                flt = dbase.flt_and(flt, dbase.searchhttpapp(name=str2regexp(value)))
         elif not neg and param == "owa":
             flt = dbase.flt_and(flt, dbase.searchowa())
         elif param == "phpmyadmin":
             flt = dbase.flt_and(flt, dbase.searchphpmyadmin())
         elif not neg and param.startswith("smb."):
-            flt = dbase.flt_and(
-                flt, dbase.searchsmb(**{param[4:]: utils.str2regexp(value)})
-            )
+            flt = dbase.flt_and(flt, dbase.searchsmb(**{param[4:]: str2regexp(value)}))
         elif not neg and param.startswith("ntlm."):
             key = {
                 "name": "Target_Name",
@@ -573,9 +682,7 @@ def flt_from_query(dbase, query, base_flt=None):
             }
             flt = dbase.flt_and(
                 flt,
-                dbase.searchntlm(
-                    **{key.get(param[5:], param[5:]): utils.str2regexp(value)}
-                ),
+                dbase.searchntlm(**{key.get(param[5:], param[5:]): str2regexp(value)}),
             )
         elif not neg and param == "smbshare":
             flt = dbase.flt_and(
@@ -598,7 +705,7 @@ def flt_from_query(dbase, query, base_flt=None):
             flt = dbase.flt_and(
                 flt,
                 dbase.searchja3client(
-                    value_or_hash=(None if value is None else utils.str2regexp(value)),
+                    value_or_hash=(None if value is None else str2regexp(value)),
                     neg=neg,
                 ),
             )
@@ -606,7 +713,7 @@ def flt_from_query(dbase, query, base_flt=None):
             flt = dbase.flt_and(
                 flt,
                 dbase.searchja4client(
-                    value=(None if value is None else utils.str2regexp(value)),
+                    value=(None if value is None else str2regexp(value)),
                     neg=neg,
                 ),
             )
@@ -615,9 +722,7 @@ def flt_from_query(dbase, query, base_flt=None):
                 # There are no additional arguments
                 flt = dbase.flt_and(flt, dbase.searchja3server(neg=neg))
             else:
-                split = [
-                    utils.str2regexp(v) if v else None for v in value.split(":", 1)
-                ]
+                split = [str2regexp(v) if v else None for v in value.split(":", 1)]
                 if len(split) == 1:
                     # Only a JA3 server is given
                     flt = dbase.flt_and(
@@ -642,14 +747,14 @@ def flt_from_query(dbase, query, base_flt=None):
                 flt = dbase.flt_and(flt, dbase.searchjarm(neg=neg))
             else:
                 flt = dbase.flt_and(
-                    flt, dbase.searchjarm(value=utils.str2regexp(value), neg=neg)
+                    flt, dbase.searchjarm(value=str2regexp(value), neg=neg)
                 )
         elif not neg and param in {"hassh", "hassh-client", "hassh-server"}:
             server = {"hassh": None, "hassh-client": False, "hassh-server": True}[param]
             flt = dbase.flt_and(
                 flt,
                 dbase.searchhassh(
-                    value_or_hash=(None if value is None else utils.str2regexp(value)),
+                    value_or_hash=(None if value is None else str2regexp(value)),
                     server=server,
                 ),
             )
@@ -657,16 +762,16 @@ def flt_from_query(dbase, query, base_flt=None):
             if value:
                 flt = dbase.flt_and(
                     flt,
-                    dbase.searchuseragent(useragent=utils.str2regexp(value), neg=neg),
+                    dbase.searchuseragent(useragent=str2regexp(value), neg=neg),
                 )
             else:
                 flt = dbase.flt_and(flt, dbase.searchuseragent())
         # OS fingerprint
         elif not neg and param == "os":
-            flt = dbase.flt_and(flt, dbase.searchos(utils.str2regexp(value)))
+            flt = dbase.flt_and(flt, dbase.searchos(str2regexp(value)))
         # device types
         elif not neg and param in {"devicetype", "devtype"}:
-            flt = dbase.flt_and(flt, dbase.searchdevicetype(utils.str2regexp(value)))
+            flt = dbase.flt_and(flt, dbase.searchdevicetype(str2regexp(value)))
         elif not neg and param in {"netdev", "networkdevice"}:
             flt = dbase.flt_and(flt, dbase.searchnetdev())
         elif not neg and param == "phonedev":
@@ -687,7 +792,7 @@ def flt_from_query(dbase, query, base_flt=None):
                 flt,
                 dbase.searchscript(
                     name="ike-info",
-                    values={f"vendor_ids.{param[14:]}": utils.str2regexp(value)},
+                    values={f"vendor_ids.{param[14:]}": str2regexp(value)},
                 ),
             )
         elif not neg and param == "ike.notification":
@@ -695,7 +800,7 @@ def flt_from_query(dbase, query, base_flt=None):
                 flt,
                 dbase.searchscript(
                     name="ike-info",
-                    values={"notification_type": utils.str2regexp(value)},
+                    values={"notification_type": str2regexp(value)},
                 ),
             )
         # sort
@@ -749,9 +854,9 @@ def flt_from_query(dbase, query, base_flt=None):
             else:
                 params = value.split(":", 1)
                 words = (
-                    [utils.str2regexp(elt) for elt in params[0].split(",")]
+                    [str2regexp(elt) for elt in params[0].split(",")]
                     if "," in params[0]
-                    else utils.str2regexp(params[0])
+                    else str2regexp(params[0])
                 )
                 if len(params) == 1:
                     flt = dbase.flt_and(
@@ -782,7 +887,7 @@ def flt_from_query(dbase, query, base_flt=None):
                 cpe_kwargs = {}
                 cpe_fields = ["cpe_type", "vendor", "product", "version"]
                 for field, cpe_arg in zip(cpe_fields, value.split(":", 3)):
-                    cpe_kwargs[field] = utils.str2regexp(cpe_arg)
+                    cpe_kwargs[field] = str2regexp(cpe_arg)
                 flt = dbase.flt_and(flt, dbase.searchcpe(**cpe_kwargs))
             else:
                 flt = dbase.flt_and(flt, dbase.searchcpe())
@@ -792,14 +897,14 @@ def flt_from_query(dbase, query, base_flt=None):
                     tag_val, tag_info = value.split(":", 1)
                     tag = {}
                     if tag_val:
-                        tag["value"] = utils.str2regexp(tag_val)
+                        tag["value"] = str2regexp(tag_val)
                     if tag_info:
-                        tag["info"] = utils.str2regexp(tag_info)
+                        tag["info"] = str2regexp(tag_info)
                     flt = dbase.flt_and(flt, dbase.searchtag(tag, neg=neg))
                 else:
                     flt = dbase.flt_and(
                         flt,
-                        dbase.searchtag({"value": utils.str2regexp(value)}, neg=neg),
+                        dbase.searchtag({"value": str2regexp(value)}, neg=neg),
                     )
             else:
                 flt = dbase.flt_and(flt, dbase.searchtag(neg=neg))
@@ -906,7 +1011,7 @@ def parse_arg(data):
         return {k: parse_arg(v) for k, v in data.items()}
     try:
         func = {
-            "regexp": utils.str2regexp,
+            "regexp": str2regexp,
             "datetime": datetime.datetime.fromtimestamp,
         }[data["f"]]
     except KeyError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ dependencies = [
     "pymongo>=4.10",
     "pyOpenSSL>=16.1.0",
     "bottle",
+    # Static ReDoS analyser (Doyensec). Used by
+    # ``ivre.web.utils.validate_regex_complexity`` to reject
+    # user-supplied regex literals that would exhibit catastrophic
+    # backtracking when forwarded to MongoDB's ``$regex``. Pure
+    # Python, no transitive dependencies, Apache-2.0 licensed.
+    "regexploit>=1.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1050,6 +1050,187 @@ class RirMcpToolsTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# RegexComplexityTests -- defence-in-depth budget for user-supplied
+# regex literals reaching MongoDB ``$regex``.
+# ---------------------------------------------------------------------
+
+
+class RegexComplexityTests(unittest.TestCase):
+    """Tests for ``ivre.web.utils.validate_regex_complexity`` and
+    the ``ivre.web.utils.str2regexp`` / ``str2regexpnone``
+    wrappers.
+
+    The validator is the regexploit-based ReDoS analyser sitting
+    in front of ``re.compile()`` and MongoDB's ``$regex``. It
+    complements the server-side ``MONGODB_QUERY_TIMEOUT_MS`` cap
+    put in place earlier: where the timeout bounds the worst-case
+    wall clock, this budget rejects patterns proven exploitable
+    by static analysis before they get a chance to run.
+    """
+
+    @staticmethod
+    def _validator():
+        return ivre.web.utils.validate_regex_complexity
+
+    def test_short_simple_regex_passes(self):
+        # Realistic patterns operators submit through the Web API.
+        validate = self._validator()
+        for ok in [
+            "^foo$",
+            "cdn\\.cloudflare\\.com",
+            "^192\\.168\\.",
+            "(GET|POST) ",
+            "[a-z]+",
+            "abc{2,5}",
+            "foo|bar|baz",
+            "a*b*c*d*e*f*",
+        ]:
+            with self.subTest(pattern=ok):
+                validate(ok)
+
+    def test_non_string_input_is_a_no_op(self):
+        # Defensive: callers may forward arbitrary JSON values.
+        validate = self._validator()
+        validate(None)  # type: ignore[arg-type]
+        validate(42)  # type: ignore[arg-type]
+
+    def test_length_cap(self):
+        validate = self._validator()
+        long_pattern = "a" * 200
+        validate(long_pattern, max_length=200)
+        with self.assertRaises(ValueError):
+            validate(long_pattern, max_length=199)
+
+    def test_length_cap_can_be_disabled(self):
+        validate = self._validator()
+        validate("x" * 100_000, max_length=None)
+
+    def test_starriness_check_can_be_disabled(self):
+        validate = self._validator()
+        # An exploitable pattern: regexploit reports starriness 11.
+        validate("(a+)+x", starriness_limit=None)
+
+    def test_starriness_threshold_is_tunable(self):
+        validate = self._validator()
+        # ``a*b*`` is non-exploitable (no killer); regexploit
+        # reports starriness 0 so even a strict limit accepts it.
+        validate("a*b*", starriness_limit=0)
+        # Adversarial example: ``(a+)+x`` is starriness 11.
+        with self.assertRaises(ValueError):
+            validate("(a+)+x", starriness_limit=2)
+
+    def test_canonical_evil_regexes_rejected(self):
+        # Classic nested-quantifier ReDoS shapes with a
+        # ``killer`` suffix — regexploit detects the pumping
+        # sequence in each.
+        validate = self._validator()
+        for evil in [
+            "(a+)+x",
+            "(a*)*x",
+            "(.*)*x",
+            "(?:a+)+x",
+            "(?:.*)+x",
+            "(.+)*x",
+            "(.*)+x",
+            # Quantified alternative with matching character
+            # class — regexploit picks this one up via its
+            # branch-expansion pass.
+            "([0-9]|[0-9]+)+x",
+            # The original Finding 5 report's example.
+            ".*(.*)*.*(.*)*.*(.*)*x",
+            "(?P<bad>a+)+x",
+        ]:
+            with self.subTest(pattern=evil):
+                with self.assertRaises(ValueError):
+                    validate(evil)
+
+    def test_known_limitations_are_pinned(self):
+        # Static analysis of regex ReDoS is undecidable in the
+        # general case; both regexploit and the previous
+        # hand-rolled walker have blind spots. The most notable
+        # is alternation-with-equal-branches (``(a|a)*x``,
+        # ``(a|aa)+x``): regexploit's branch expansion does not
+        # detect the pumping sequence here. The
+        # ``MONGODB_QUERY_TIMEOUT_MS`` server-side cap is the
+        # backstop for these cases. This test pins the contract
+        # so callers do not silently rely on a broader check.
+        validate = self._validator()
+        for limitation in ["(a|a)*x", "(a|aa)+x", "(\\w|\\d)+x"]:
+            with self.subTest(pattern=limitation):
+                # Should NOT raise — regexploit accepts these.
+                validate(limitation)
+
+    def test_unkilled_nested_quantifier_is_not_rejected(self):
+        # ``(a+)+`` and ``(.*)*`` without a killer suffix are
+        # *not* exploitable in practice — any input matches at
+        # the first attempt without backtracking. regexploit
+        # accepts them by design; the previous syntactic walker
+        # was over-conservative here. This test pins the new
+        # contract.
+        validate = self._validator()
+        validate("(a+)+")
+        validate("(a*)*")
+        validate("(.*)*")
+
+    def test_named_groups_are_walked(self):
+        # ``(?P<name>...)`` should be analysed normally; both
+        # benign and malicious named-group patterns work.
+        validate = self._validator()
+        validate("(?P<host>[a-z]+)\\.example")
+        with self.assertRaises(ValueError):
+            validate("(?P<bad>a+)+x")
+
+    def test_lookaround_is_walked(self):
+        validate = self._validator()
+        validate("foo(?=bar)")
+        validate("foo(?!bar)")
+        validate("(?<=foo)bar")
+        validate("(?<!foo)bar")
+
+    def test_invalid_regex_raises_value_error(self):
+        # Malformed patterns surface as ``ValueError`` (which
+        # Bottle turns into 400) rather than ``re.error``.
+        validate = self._validator()
+        for bad in ["[abc", "foo(", "(?P<bad)", "*invalid"]:
+            with self.subTest(pattern=bad):
+                with self.assertRaises(ValueError):
+                    validate(bad)
+
+    def test_web_wrapper_validates_regex_input(self):
+        webutils = ivre.web.utils
+
+        self.assertEqual(webutils.str2regexp("plain"), "plain")
+        # Valid regex passes through and yields a compiled pattern.
+        compiled = webutils.str2regexp("/^foo$/")
+        self.assertTrue(hasattr(compiled, "pattern"))
+        # Exploitable regex is rejected.
+        with self.assertRaises(ValueError):
+            webutils.str2regexp("/(a+)+x/")
+        # Length cap (use a freshly large pattern to exceed the
+        # default).
+        with self.assertRaises(ValueError):
+            webutils.str2regexp(
+                "/" + ("a" * (ivre.config.WEB_REGEX_MAX_LENGTH + 1)) + "/"
+            )
+
+    def test_web_wrapper_str2regexpnone_passes_dash_through(self):
+        webutils = ivre.web.utils
+
+        self.assertIs(webutils.str2regexpnone("-"), False)
+        with self.assertRaises(ValueError):
+            webutils.str2regexpnone("/(a+)+x/")
+
+    def test_web_wrapper_handles_trailing_flags(self):
+        webutils = ivre.web.utils
+
+        # Flags suffix should be stripped before length checks; a
+        # very long flags suffix would otherwise inflate ``len``.
+        compiled = webutils.str2regexp("/foo/i")
+        self.assertTrue(hasattr(compiled, "pattern"))
+        self.assertEqual(compiled.flags & re.IGNORECASE, re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------
 # UtilsTests -- moved verbatim from tests/tests.py::IvreTests.test_utils
 # ---------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -710,6 +710,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "pymongo" },
     { name = "pyopenssl" },
+    { name = "regexploit" },
 ]
 
 [package.optional-dependencies]
@@ -786,6 +787,7 @@ requires-dist = [
     { name = "pylint", marker = "extra == 'linting'" },
     { name = "pymongo", specifier = ">=4.10" },
     { name = "pyopenssl", specifier = ">=16.1.0" },
+    { name = "regexploit", specifier = ">=1.0,<2" },
     { name = "rstcheck", extras = ["sphinx"], marker = "extra == 'linting'" },
     { name = "scapy", marker = "extra == 'ja3'" },
     { name = "sphinx", marker = "extra == 'doc'" },
@@ -1888,6 +1890,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
     { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
     { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
+name = "regexploit"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/4c/fc58c4892615496d632404633d07ea098e075c68afeb0e0536e21c9babee/regexploit-1.0.0.tar.gz", hash = "sha256:1abd5f6a92fd0959ddf13c5e84246935d21c5cd173e8d38bcf58c24eb24cd36f", size = 72704, upload-time = "2021-03-11T14:32:38.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/0a/90dc0759b72d2d1b726dbcdbca2d044cd048f8089936f69c40dca474975f/regexploit-1.0.0-py3-none-any.whl", hash = "sha256:71918acbd0134989cf3928577f3e5a6e0ab1a57891293dc83bfef198fc9949c2", size = 79818, upload-time = "2021-03-11T14:32:37.392Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
User-supplied regex literals reaching MongoDB's `$regex` were covered server-side by the 30s `MONGODB_QUERY_TIMEOUT_MS` cap landed earlier, but the client side had no budget — an adversary could still force the server to spend that full budget per query.

This change wires Doyensec's `regexploit` (Apache-2.0) static ReDoS analyser into a new validator in
`ivre/web/utils.py::validate_regex_complexity`, and routes all 44 call sites of `utils.str2regexp` / `utils.str2regexpnone` in `ivre/web/utils.py` through validating wrappers (`str2regexp` / `str2regexpnone`) defined in the same module. The wrappers are also installed in `parse_arg`'s `regexp` function dispatcher.

regexploit walks the CPython `sre_parse` AST and computes a 'starriness' score that captures the depth of nested unbounded repetition reachable through backtracking. The validator rejects any pattern with starriness above
`WEB_REGEX_STARRINESS_LIMIT` (default 2, matching the regexploit CLI default). Nested-quantifier ReDoS shapes with a 'killer' suffix — `(a+)+x`, `(.*)*x`, `(?:.*)+x`,
`.*(.*)*.*(.*)*.*(.*)*x`, ... — all come in at starriness >= 11 so a limit of 2 rejects them while accepting realistic operator-typed regex (and even bare unkilled `(a+)+` forms, which are not exploitable in practice).

A separate length cap (`WEB_REGEX_MAX_LENGTH`, default 1000) bounds the size of the pattern fed to the analyser, the regex compiler and the database.

Both knobs accept `None` to opt out; callers can also override per-call via keyword arguments. The validator is web-specific: it lives in `ivre.web.utils` rather than `ivre.utils` so it does not get applied to trusted internal callers of `str2regexp`.

Tests:
  - 15-case `RegexComplexityTests` in `tests/tests_no_backend.py` covers the canonical ReDoS shapes (rejected), realistic patterns (accepted), the length cap, the starriness threshold, and the alternation- with-equal-branches shapes that regexploit (and any peer tool we surveyed) does not catch — that contract is pinned so callers do not silently rely on a broader check.
