### PR TITLE
fix(db/sql): use SQLAlchemy literal-binds for PostgreSQL EXPLAIN

### DIFF
--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -111,12 +111,36 @@ class PostgresDB(SQLDB):
         return BulkInsert(self.db, size=size, retries=retries)
 
     def explain(self, req, **_):
-        req_comp = req.compile(dialect=postgresql.dialect())
-        arg_dic = {}
-        for k in req_comp.params:
-            arg_dic[k] = repr(req_comp.params[k])
-        req_cur = self.db.execute(text(f"EXPLAIN {req_comp.string % arg_dic}"))
-        return "\n".join(map(" ".join, req_cur.fetchall()))
+        """Return the PostgreSQL ``EXPLAIN`` output for a SQLAlchemy
+        query expression.
+
+        Parameter values are inlined into the SQL statement using
+        SQLAlchemy's per-type literal binding (``literal_binds``)
+        so each value goes through the column type's
+        ``literal_processor`` — strings get backslash-aware
+        single-quote escaping, bytes are emitted as ``E'\\x...'``,
+        datetimes are formatted with their proper PostgreSQL
+        cast, ``None`` is emitted as ``NULL``, booleans as ``TRUE``
+        / ``FALSE``, etc. This replaces an earlier approach that
+        used ``repr(value)`` to produce SQL literals, which only
+        coincidentally worked for plain strings and integers and
+        was brittle at best (e.g. ``repr(b"x")`` is ``b'x'``,
+        which is not valid PostgreSQL).
+
+        The compiled SQL is dispatched via ``exec_driver_sql`` so
+        that ``text()``'s bind-parameter parsing does not
+        reinterpret ``:`` characters that may appear inside string
+        literals or PostgreSQL ``::`` casts in the compiled
+        statement.
+        """
+        compiled = req.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+        sql = f"EXPLAIN {compiled}"
+        with self.db.connect() as conn:
+            rows = conn.exec_driver_sql(sql).fetchall()
+        return "\n".join(map(" ".join, rows))
 
 
 class BulkInsert:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-postgres = ["sqlalchemy<2", "psycopg2"]
+postgres = ["sqlalchemy>=1.4,<2", "psycopg2"]
 elasticsearch = ["elasticsearch", "elasticsearch-dsl"]
 gssapi-mongo = ["gssapi"]
 gssapi-http = ["pycurl"]

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1231,6 +1231,138 @@ class RegexComplexityTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# PostgresExplainTests -- defence-in-depth check that values
+# inlined into the ``EXPLAIN`` statement go through SQLAlchemy's
+# per-type literal binding, not Python ``repr``.
+# ---------------------------------------------------------------------
+
+
+try:
+    import sqlalchemy as _sqlalchemy  # type: ignore[import-untyped]
+    from sqlalchemy.dialects import (
+        postgresql as _sqlalchemy_postgresql,  # type: ignore[import-untyped]
+    )
+
+    _HAVE_SQLALCHEMY = True
+except ImportError:
+    _HAVE_SQLALCHEMY = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` extras)",
+)
+class PostgresExplainTests(unittest.TestCase):
+    """Tests for the literal-binds quoting path used by
+    ``ivre.db.sql.postgres.PostgresDB.explain``.
+
+    The previous implementation built the ``EXPLAIN`` statement
+    by ``%``-interpolating ``repr(value)`` for each parameter,
+    which only coincidentally produced valid SQL for plain
+    strings and integers. This class pins the new contract: each
+    bind goes through SQLAlchemy's per-type literal processor.
+    """
+
+    def _compile(self, query):
+        return str(
+            query.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _users_table():
+        sa = _sqlalchemy
+        meta = sa.MetaData()
+        return sa.Table(
+            "users",
+            meta,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String),
+            sa.Column("blob", sa.LargeBinary),
+            sa.Column("active", sa.Boolean),
+            sa.Column("created", sa.DateTime),
+        )
+
+    def test_string_with_single_quote_is_escaped(self):
+        # The classic SQL-injection payload arrives as a string
+        # value: SQLAlchemy's literal_processor must double the
+        # embedded ``'`` so the value remains a string literal.
+        sa = _sqlalchemy
+        users = self._users_table()
+        sql = self._compile(
+            sa.select(users).where(users.c.name == "'; DROP TABLE users; --")
+        )
+        self.assertIn("'''; DROP TABLE users; --'", sql)
+        self.assertNotIn("DROP TABLE users; --'", sql.split("'''", 1)[0])
+
+    def test_none_is_emitted_as_NULL(self):
+        # ``repr(None)`` is ``'None'`` (a Python literal, not SQL).
+        # The literal-binds path must emit ``NULL`` instead.
+        sa = _sqlalchemy
+        users = self._users_table()
+        sql = self._compile(sa.select(users).where(users.c.name.is_(None)))
+        self.assertIn("IS NULL", sql.upper())
+        self.assertNotIn("'None'", sql)
+
+    def test_boolean_is_emitted_as_true_false(self):
+        sa = _sqlalchemy
+        users = self._users_table()
+        sql = self._compile(sa.select(users).where(users.c.active.is_(True)))
+        # PG dialect emits ``true`` / ``false`` (lowercase) as
+        # native boolean literals; never the Python ``True``.
+        self.assertNotIn("'True'", sql)
+        self.assertIn("true", sql.lower())
+
+    def test_integer_passthrough(self):
+        sa = _sqlalchemy
+        users = self._users_table()
+        sql = self._compile(sa.select(users).where(users.c.id == 42))
+        # Integer literal goes through unquoted.
+        self.assertIn("= 42", sql)
+
+    def test_no_pyformat_placeholders_remain(self):
+        # The compile result must contain no ``%(name)s`` markers
+        # — every parameter must be inlined as a literal.
+        sa = _sqlalchemy
+        users = self._users_table()
+        sql = self._compile(
+            sa.select(users)
+            .where(users.c.name == "alice")
+            .where(users.c.id == 7)
+            .where(users.c.active.is_(True))
+        )
+        self.assertNotRegex(sql, r"%\(\w+\)s")
+
+    def test_explain_function_does_not_use_repr(self):
+        # White-box: pin that the executable code no longer
+        # interpolates ``repr(value)`` into the EXPLAIN statement,
+        # and that it uses ``literal_binds`` plus
+        # ``exec_driver_sql``. AST-based so the docstring's
+        # historical reference to ``repr(value)`` is ignored.
+        import ast
+        from inspect import getsource
+        from textwrap import dedent
+
+        from ivre.db.sql import postgres as pgmod
+
+        src = dedent(getsource(pgmod.PostgresDB.explain))
+        tree = ast.parse(src)
+        repr_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "repr"
+        ]
+        self.assertEqual(repr_calls, [], "explain() should not call repr()")
+        # Sanity: the new control-flow markers are present.
+        self.assertIn("literal_binds", src)
+        self.assertIn("exec_driver_sql", src)
+
+
+# ---------------------------------------------------------------------
 # UtilsTests -- moved verbatim from tests/tests.py::IvreTests.test_utils
 # ---------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ requires-dist = [
     { name = "sphinx-lint", marker = "extra == 'linting'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
     { name = "sphinxcontrib-httpdomain", marker = "extra == 'doc'" },
-    { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = "<2" },
+    { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=1.4,<2" },
 ]
 provides-extras = ["postgres", "elasticsearch", "gssapi-mongo", "gssapi-http", "screenshots", "mediawiki", "3d-traceroute", "plots", "ja3", "mcp", "linting", "doc"]
 


### PR DESCRIPTION
PostgresDB.explain() previously built the EXPLAIN statement by %-interpolating repr(value) for each query parameter. The reliance on repr() to produce a SQL-safe literal was brittle: it only coincidentally worked for plain strings and integers, and emitted Python-syntax that is not valid PostgreSQL for many other types — repr(b'x') is b'x', repr(None) is None, repr(datetime(...)) is a Python expression, etc.

Rewrite explain() to compile the SQLAlchemy query expression with compile_kwargs={'literal_binds': True} so every parameter goes through the column type's literal_processor (correct backslash-aware quoting for strings, NULL for None, native TRUE/FALSE for booleans, proper PostgreSQL casts for datetimes and binary data). Dispatch the resulting SQL via
Connection.exec_driver_sql() rather than text() so any ':' characters that survive inside string literals — or a PostgreSQL '::' cast — are not reinterpreted as
bind-parameter markers.

Bump the SQLAlchemy floor in the postgres extras to >=1.4 to guarantee Connection.exec_driver_sql() is available; the upper bound stays at <2 (the full SQLAlchemy 2.x migration is its own piece of work).

Tests: new PostgresExplainTests in tests/tests_no_backend.py (skipped when sqlalchemy is not installed) covers single-quote injection escaping, None -> NULL, boolean -> TRUE/FALSE, integer passthrough, the absence of any remaining %(name)s placeholders, and an AST-based white-box check that the function no longer calls repr().