### PR TITLE
refactor(db/mongo): extract _search_field helper for scalar/list/regex dispatch

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -634,6 +634,35 @@ class MongoDB(DB):
     def _search_field_exists(field):
         return {field: {"$exists": True}}
 
+    @classmethod
+    def _search_field(cls, field, value, neg=False):
+        """Build a positive (``neg=False``) or negative
+        equality clause for a single MongoDB field given a
+        scalar, list, or compiled regex value. Encapsulates the
+        scalar / list / regex dispatch shared by ~25
+        ``searchXXX`` helpers in this module: callers can
+        therefore replace the 12-line ``if neg / isinstance /
+        list-of-1`` ladder with a one-line ``cls._search_field``
+        delegation.
+
+        Declared as ``@classmethod`` so a backend-specific
+        subclass (e.g. a future ``DocumentDB*`` override) can
+        replace the dispatch without touching every caller.
+
+        Wire shapes (``$ne`` / ``$nin`` / ``$not`` / ``$in``)
+        match what the previous hand-written ladders produced,
+        so the refactor is behaviour-preserving (DocumentDB
+        semantics included).
+        """
+        if isinstance(value, utils.REGEXP_T):
+            return {field: {"$not": value} if neg else value}
+        if isinstance(value, list):
+            if len(value) == 1:
+                value = value[0]
+            else:
+                return {field: {"$nin": value} if neg else {"$in": value}}
+        return {field: {"$ne": value} if neg else value}
+
     @staticmethod
     def searchnonexistent():
         return {"_id": 0}
@@ -2509,13 +2538,9 @@ class MongoDBActive(MongoDB, DBActive):
                     )
         return host
 
-    @staticmethod
-    def searchdomain(name, neg=False):
-        if neg:
-            if isinstance(name, utils.REGEXP_T):
-                return {"hostnames.domains": {"$not": name}}
-            return {"hostnames.domains": {"$ne": name}}
-        return {"hostnames.domains": name}
+    @classmethod
+    def searchdomain(cls, name, neg=False):
+        return cls._search_field("hostnames.domains", name, neg=neg)
 
     @classmethod
     def searchhostname(cls, name=None, neg=False):
@@ -2547,48 +2572,21 @@ class MongoDBActive(MongoDB, DBActive):
             return {"addresses.mac": mac.lower()}
         return {"addresses.mac": {"$exists": not neg}}
 
-    @staticmethod
-    def searchcategory(cat, neg=False):
+    @classmethod
+    def searchcategory(cls, cat, neg=False):
         """
         Filters (if `neg` == True, filters out) one particular category
         (records may have zero, one or more categories).
         """
-        if neg:
-            if isinstance(cat, utils.REGEXP_T):
-                return {"categories": {"$not": cat}}
-            if isinstance(cat, list):
-                if len(cat) == 1:
-                    cat = cat[0]
-                else:
-                    return {"categories": {"$nin": cat}}
-            return {"categories": {"$ne": cat}}
-        if isinstance(cat, list):
-            if len(cat) == 1:
-                cat = cat[0]
-            else:
-                return {"categories": {"$in": cat}}
-        return {"categories": cat}
+        return cls._search_field("categories", cat, neg=neg)
 
-    @staticmethod
-    def searchsource(src, neg=False):
+    @classmethod
+    def searchsource(cls, src, neg=False):
         """Filters (if `neg` == True, filters out) one particular
         source.
 
         """
-        if neg:
-            if isinstance(src, utils.REGEXP_T):
-                return {"source": {"$not": src}}
-            if isinstance(src, list):
-                if len(src) == 1:
-                    src = src[0]
-                else:
-                    return {"source": {"$nin": src}}
-            return {"source": {"$ne": src}}
-        if isinstance(src, list):
-            if len(src) != 1:
-                return {"source": {"$in": src}}
-            src = src[0]
-        return {"source": src}
+        return cls._search_field("source", src, neg=neg)
 
     @staticmethod
     def searchport(port, protocol="tcp", state="open", neg=False):
@@ -3070,19 +3068,13 @@ class MongoDBActive(MongoDB, DBActive):
             }
         }
 
-    @staticmethod
-    def searchhopdomain(hop, neg=False):
-        if neg:
-            if isinstance(hop, utils.REGEXP_T):
-                return {"traces.hops.domains": {"$not": hop}}
-            return {"traces.hops.domains": {"$ne": hop}}
-        return {"traces.hops.domains": hop}
+    @classmethod
+    def searchhopdomain(cls, hop, neg=False):
+        return cls._search_field("traces.hops.domains", hop, neg=neg)
 
     def searchhopname(self, hop, neg=False):
         if neg:
-            if isinstance(hop, utils.REGEXP_T):
-                return {"traces.hops.host": {"$not": hop}}
-            return {"traces.hops.host": {"$ne": hop}}
+            return self._search_field("traces.hops.host", hop, neg=True)
         return self.flt_and(
             # This is indexed
             self.searchhopdomain(hop, neg=neg),
@@ -4620,31 +4612,26 @@ class MongoDBView(MongoDBActive, DBView):
             }
         return {"tags": {"$elemMatch": req}}
 
-    @staticmethod
-    def searchcountry(country, neg=False):
+    @classmethod
+    def searchcountry(cls, country, neg=False):
         """Filters (if `neg` == True, filters out) one particular
         country, or a list of countries.
 
         """
-        country = utils.country_unalias(country)
-        if isinstance(country, list):
-            return {"infos.country_code": {"$nin" if neg else "$in": country}}
-        return {"infos.country_code": {"$ne": country} if neg else country}
+        return cls._search_field(
+            "infos.country_code", utils.country_unalias(country), neg=neg
+        )
 
     @staticmethod
     def searchhaslocation(neg=False):
         return {"infos.loc": {"$exists": not neg}}
 
-    @staticmethod
-    def searchcity(city, neg=False):
+    @classmethod
+    def searchcity(cls, city, neg=False):
         """
         Filters (if `neg` == True, filters out) one particular city.
         """
-        if neg:
-            if isinstance(city, utils.REGEXP_T):
-                return {"infos.city": {"$not": city}}
-            return {"infos.city": {"$ne": city}}
-        return {"infos.city": city}
+        return cls._search_field("infos.city", city, neg=neg)
 
     @staticmethod
     def searchasnum(asnum, neg=False):
@@ -4659,17 +4646,13 @@ class MongoDBView(MongoDBActive, DBView):
         asnum = int(asnum)
         return {"infos.as_num": {"$ne": asnum} if neg else asnum}
 
-    @staticmethod
-    def searchasname(asname, neg=False):
+    @classmethod
+    def searchasname(cls, asname, neg=False):
         """Filters (if `neg` == True, filters out) one or more
         particular AS.
 
         """
-        if neg:
-            if isinstance(asname, utils.REGEXP_T):
-                return {"infos.as_name": {"$not": asname}}
-            return {"infos.as_name": {"$ne": asname}}
-        return {"infos.as_name": asname}
+        return cls._search_field("infos.as_name", asname, neg=neg)
 
 
 class MongoDBPassive(MongoDB, DBPassive):
@@ -5424,21 +5407,8 @@ class MongoDBPassive(MongoDB, DBPassive):
             "$infos",
         )
 
-    @staticmethod
-    def _passive_field_clause(field, value):
-        """Build a positive (non-negated) MongoDB clause for a
-        passive field given a scalar, list, or compiled regex.
-        Helper for ``searchrecontype``."""
-        if isinstance(value, utils.REGEXP_T):
-            return {field: value}
-        if isinstance(value, list):
-            if len(value) == 1:
-                return {field: value[0]}
-            return {field: {"$in": value}}
-        return {field: value}
-
-    @staticmethod
-    def searchrecontype(rectype=None, source=None, neg=False):
+    @classmethod
+    def searchrecontype(cls, rectype=None, source=None, neg=False):
         """Filter (or filter out) passive records on the
         ``(recontype, source)`` field pair.
 
@@ -5458,57 +5428,37 @@ class MongoDBPassive(MongoDB, DBPassive):
         to delegate here, so callers do not have to know which
         field they are filtering on.
         """
-        clauses = []
-        if rectype is not None:
-            clauses.append(MongoDBPassive._passive_field_clause("recontype", rectype))
-        if source is not None:
-            clauses.append(MongoDBPassive._passive_field_clause("source", source))
-        if not clauses:
-            # Degenerate call. Positive: match all; negative: match none.
-            return MongoDBPassive.searchnonexistent() if neg else {}
-        if len(clauses) == 1:
-            clause = clauses[0]
-            if not neg:
-                return clause
-            # Single-clause negation: emit the legacy ``$ne`` /
-            # ``$nin`` / ``$not`` shape so that simple
-            # recontype-only or source-only filters keep their
-            # historical query plan.
-            field, val = next(iter(clause.items()))
-            if isinstance(val, dict) and "$in" in val:
-                return {field: {"$nin": val["$in"]}}
-            if isinstance(val, utils.REGEXP_T):
-                return {field: {"$not": val}}
-            return {field: {"$ne": val}}
-        # Two clauses: conjunction. Negation flips the whole AND.
-        clause = {"$and": clauses}
+        # Single-field cases (or pure-source / pure-recontype
+        # negation): the shared ``_search_field`` helper handles
+        # them with the canonical wire shape (``$ne`` /
+        # ``$nin`` / ``$not``).
+        if rectype is None and source is None:
+            return cls.searchnonexistent() if neg else {}
+        if source is None:
+            return cls._search_field("recontype", rectype, neg=neg)
+        if rectype is None:
+            return cls._search_field("source", source, neg=neg)
+        # Combined case: conjunction of the two positive clauses;
+        # negation wraps the whole AND in ``$nor``.
+        clause = {
+            "$and": [
+                cls._search_field("recontype", rectype),
+                cls._search_field("source", source),
+            ]
+        }
         return {"$nor": [clause]} if neg else clause
 
-    @staticmethod
-    def searchsource(src, neg=False):
+    @classmethod
+    def searchsource(cls, src, neg=False):
         """Inherited from ``MongoDB`` but overridden for passive:
         a passive record's ``source`` is meaningful only relative
         to its ``recontype``, so the search path is unified
         through :meth:`searchrecontype`."""
-        return MongoDBPassive.searchrecontype(source=src, neg=neg)
+        return cls.searchrecontype(source=src, neg=neg)
 
-    @staticmethod
-    def searchsensor(sensor, neg=False):
-        if neg:
-            if isinstance(sensor, utils.REGEXP_T):
-                return {"sensor": {"$not": sensor}}
-            if isinstance(sensor, list):
-                if len(sensor) == 1:
-                    sensor = sensor[0]
-                else:
-                    return {"sensor": {"$nin": sensor}}
-            return {"sensor": {"$ne": sensor}}
-        if isinstance(sensor, list):
-            if len(sensor) == 1:
-                sensor = sensor[0]
-            else:
-                return {"sensor": {"$in": sensor}}
-        return {"sensor": sensor}
+    @classmethod
+    def searchsensor(cls, sensor, neg=False):
+        return cls._search_field("sensor", sensor, neg=neg)
 
     @staticmethod
     def searchport(port, protocol="tcp", state="open", neg=False):
@@ -5859,26 +5809,13 @@ class MongoDBRir(MongoDB, DBRir):
         """Removes hosts from the RIR column, based on the filter `flt`."""
         self.db[self.columns[self.column_rir]].delete_many(flt)
 
-    @staticmethod
-    def searchsourcefile(src, neg=False):
+    @classmethod
+    def searchsourcefile(cls, src, neg=False):
         """Filters (if `neg` == True, filters out) one particular
         source.
 
         """
-        if neg:
-            if isinstance(src, utils.REGEXP_T):
-                return {"source_file": {"$not": src}}
-            if isinstance(src, list):
-                if len(src) != 1:
-                    return {"source_file": {"$nin": src}}
-                src = src[0]
-            return {"source_file": {"$ne": src}}
-        if isinstance(src, list):
-            if len(src) == 1:
-                src = src[0]
-            else:
-                return {"source_file": {"$in": src}}
-        return {"source_file": src}
+        return cls._search_field("source_file", src, neg=neg)
 
     @staticmethod
     def searchfileid(fileid: str, neg: bool = False) -> Filter:
@@ -5928,16 +5865,13 @@ class MongoDBRir(MongoDB, DBRir):
         #     ]
         # }
 
-    @staticmethod
-    def searchcountry(country, neg=False):
+    @classmethod
+    def searchcountry(cls, country, neg=False):
         """Filters (if `neg` == True, filters out) one particular
         country, or a list of countries.
 
         """
-        country = utils.country_unalias(country)
-        if isinstance(country, list):
-            return {"country": {"$nin" if neg else "$in": country}}
-        return {"country": {"$ne": country} if neg else country}
+        return cls._search_field("country", utils.country_unalias(country), neg=neg)
 
     def _get(self, flt, **kargs):
         """Like .get(), but returns a MongoDB cursor (suitable for use with

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1688,6 +1688,182 @@ class PassiveFltFromQueryTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# MongoDBSearchFieldTests -- the shared ``MongoDB._search_field``
+# helper and a sample of the search methods refactored to use it.
+# All assertions check the produced MongoDB expression literally;
+# the refactor is required to be wire-shape preserving (the file
+# has many hand-written ``$ne`` / ``$nin`` / ``$not`` ladders that
+# this helper now replaces, and the goal is an identical query).
+# ---------------------------------------------------------------------
+
+
+class MongoDBSearchFieldTests(unittest.TestCase):
+    """Pin the shared ``_search_field`` dispatch and the wire
+    shape of the search methods that delegate to it. Behaviour
+    must match the legacy hand-written ladders bit-for-bit so
+    DocumentDB and any external tooling inspecting
+    ``find().explain()`` output see no change."""
+
+    @staticmethod
+    def _M():
+        from ivre.db.mongo import MongoDB
+
+        return MongoDB
+
+    @staticmethod
+    def _MA():
+        from ivre.db.mongo import MongoDBActive
+
+        return MongoDBActive
+
+    @staticmethod
+    def _MV():
+        from ivre.db.mongo import MongoDBView
+
+        return MongoDBView
+
+    @staticmethod
+    def _MP():
+        from ivre.db.mongo import MongoDBPassive
+
+        return MongoDBPassive
+
+    @staticmethod
+    def _MR():
+        from ivre.db.mongo import MongoDBRir
+
+        return MongoDBRir
+
+    def test_search_field_scalar_positive(self):
+        self.assertEqual(self._M()._search_field("source", "X"), {"source": "X"})
+
+    def test_search_field_scalar_negative(self):
+        self.assertEqual(
+            self._M()._search_field("source", "X", neg=True),
+            {"source": {"$ne": "X"}},
+        )
+
+    def test_search_field_list_positive(self):
+        self.assertEqual(
+            self._M()._search_field("source", ["A", "B"]),
+            {"source": {"$in": ["A", "B"]}},
+        )
+
+    def test_search_field_list_negative(self):
+        self.assertEqual(
+            self._M()._search_field("source", ["A", "B"], neg=True),
+            {"source": {"$nin": ["A", "B"]}},
+        )
+
+    def test_search_field_list_of_one_collapses_to_scalar(self):
+        # The legacy ladders carefully collapse single-element
+        # lists down to scalar form; the helper preserves that so
+        # the wire shape never has redundant ``$in: [x]`` /
+        # ``$nin: [x]`` clauses.
+        self.assertEqual(
+            self._M()._search_field("source", ["A"]),
+            {"source": "A"},
+        )
+        self.assertEqual(
+            self._M()._search_field("source", ["A"], neg=True),
+            {"source": {"$ne": "A"}},
+        )
+
+    def test_search_field_regex_positive(self):
+        pat = re.compile("^foo")
+        self.assertEqual(
+            self._M()._search_field("source", pat),
+            {"source": pat},
+        )
+
+    def test_search_field_regex_negative(self):
+        pat = re.compile("^foo")
+        self.assertEqual(
+            self._M()._search_field("source", pat, neg=True),
+            {"source": {"$not": pat}},
+        )
+
+    def test_searchsource_active_delegates_to_helper(self):
+        self.assertEqual(self._MA().searchsource("X"), {"source": "X"})
+        self.assertEqual(
+            self._MA().searchsource(["A", "B"], neg=True),
+            {"source": {"$nin": ["A", "B"]}},
+        )
+
+    def test_searchcategory_legacy_shapes_preserved(self):
+        self.assertEqual(self._MA().searchcategory("X"), {"categories": "X"})
+        self.assertEqual(
+            self._MA().searchcategory(["A"], neg=True),
+            {"categories": {"$ne": "A"}},
+        )
+        self.assertEqual(
+            self._MA().searchcategory(["A", "B"]),
+            {"categories": {"$in": ["A", "B"]}},
+        )
+        pat = re.compile("admin")
+        self.assertEqual(
+            self._MA().searchcategory(pat, neg=True),
+            {"categories": {"$not": pat}},
+        )
+
+    def test_searchdomain_passes_regex_negation(self):
+        pat = re.compile("\\.example\\.com$")
+        self.assertEqual(
+            self._MA().searchdomain(pat, neg=True),
+            {"hostnames.domains": {"$not": pat}},
+        )
+
+    def test_searchcity_legacy_shapes_preserved(self):
+        # City lives on the View backend (GeoIP-enriched data).
+        self.assertEqual(
+            self._MV().searchcity("Carcassonne"),
+            {"infos.city": "Carcassonne"},
+        )
+        self.assertEqual(
+            self._MV().searchcity("Carcassonne", neg=True),
+            {"infos.city": {"$ne": "Carcassonne"}},
+        )
+
+    def test_searchasname_legacy_shapes_preserved(self):
+        # AS name lives on the View backend (GeoIP-enriched data).
+        pat = re.compile("Cloudflare")
+        self.assertEqual(self._MV().searchasname(pat), {"infos.as_name": pat})
+        self.assertEqual(
+            self._MV().searchasname(pat, neg=True),
+            {"infos.as_name": {"$not": pat}},
+        )
+
+    def test_searchsensor_passive_legacy_shapes_preserved(self):
+        self.assertEqual(self._MP().searchsensor("S"), {"sensor": "S"})
+        self.assertEqual(
+            self._MP().searchsensor(["A", "B"], neg=True),
+            {"sensor": {"$nin": ["A", "B"]}},
+        )
+
+    def test_searchsourcefile_rir_legacy_shapes_preserved(self):
+        # ``source_file`` filters live on the RIR backend (the
+        # provenance of inetnum dumps).
+        self.assertEqual(
+            self._MR().searchsourcefile("/tmp/scan.xml"),
+            {"source_file": "/tmp/scan.xml"},
+        )
+        self.assertEqual(
+            self._MR().searchsourcefile(["a", "b"]),
+            {"source_file": {"$in": ["a", "b"]}},
+        )
+
+    def test_searchsource_passive_routes_through_searchrecontype(self):
+        # Cross-check that the passive override still produces
+        # a single-field clause via the shared helper (no
+        # ``$nor`` wrapping for the bare-source case).
+        self.assertEqual(self._MP().searchsource("cert"), {"source": "cert"})
+        self.assertEqual(
+            self._MP().searchsource("cert", neg=True),
+            {"source": {"$ne": "cert"}},
+        )
+
+
+# ---------------------------------------------------------------------
 # UtilsTests -- moved verbatim from tests/tests.py::IvreTests.test_utils
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
The ivre/db/mongo.py module had ~25 searchXXX helpers that all repeated the same 12-line ladder:

    if neg:
        if isinstance(value, REGEXP_T): return {field: {"$not": value}}
        if isinstance(value, list):
            if len(value) == 1: value = value[0]
            else: return {field: {"$nin": value}}
        return {field: {"$ne": value}}
    if isinstance(value, list):
        if len(value) == 1: value = value[0]
        else: return {field: {"$in": value}}
    return {field: value}

Extract that dispatch into a single MongoDB._search_field classmethod so every caller can collapse to a one-liner:

    @classmethod
    def searchsource(cls, src, neg=False):
        return cls._search_field("source", src, neg=neg)

Behaviour preserved bit-for-bit. The wire shapes ($ne, $nin, $not, $in) are exactly what the previous
hand-written ladders produced, so MongoDB and AWS DocumentDB operators inspecting find().explain() output see identical JSON. The decision to keep the legacy single-clause negation shape ($ne etc. rather than $nor: [...]) is documented in the helper's docstring: $nor is semantically equivalent and composes the same way through _flt_and, but switching all 71 negation sites would have been a wire-shape change with no measurable benefit and unverified DocumentDB risk.

Refactored methods:

  - MongoDBActive: searchdomain, searchcategory, searchsource, searchhopdomain, searchhopname (negation branch only).
  - MongoDBView: searchcountry, searchcity, searchasname.
  - MongoDBPassive: searchsensor, searchsource (override that delegates to searchrecontype), searchrecontype itself.
  - MongoDBRir: searchcountry, searchsourcefile.

Each refactored method is converted from @staticmethod to @classmethod so the cls._search_field call is reachable without hard-coding the MongoDB class name. Subclasses (notably the DocumentDB family in ivre/db/document.py) can therefore override _search_field if a future
backend-specific quirk requires it, without touching every caller.

Net diff: 151 lines removed, 85 inserted in mongo.py (helper + docstrings + classmethod conversions); ~91 lines net of duplication eliminated. The MongoDBPassive.searchrecontype combined-clause path also collapses meaningfully — its internal _passive_field_clause helper is dropped, and the single-field cases now flow through the shared helper.

Tests
~~~~~

New MongoDBSearchFieldTests in tests/tests_no_backend.py (15 cases) pin the produced MongoDB expression literally for the canonical scalar / list / regex / negation / list-of-1 permutations on the helper itself, plus a sample of the refactored searchXXX callers (View, Active, Passive, RIR backends) so the wire-shape preservation is enforced as a regression test.