### PR TITLE
ci: add DocumentDB compatibility workflow

### DIFF
--- a/.github/workflows/documentdb.yml
+++ b/.github/workflows/documentdb.yml
@@ -1,0 +1,135 @@
+# This file is part of IVRE.
+# Copyright 2011 - 2026 Pierre LALET <pierre@droids-corp.org>
+#
+# IVRE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IVRE is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+
+# AWS DocumentDB compatibility check.
+#
+# DocumentDB is "almost first class" — operators deploying IVRE
+# on AWS-managed DocumentDB get every feature except full-text
+# search (the backend has no text-index facility and no ``$text``
+# operator). The four ``DocumentDB*`` classes in
+# ``ivre/db/document.py`` subclass the regular ``MongoDB*``
+# backends and set ``is_documentdb = True`` so the matching
+# workarounds in ``ivre/db/mongo.py`` (cursor-timeout flag,
+# ``$floor`` aggregation substitution, text-index omission)
+# activate.
+#
+# This workflow exercises every code path gated on
+# ``is_documentdb`` by selecting the ``DocumentDB*`` classes via
+# the ``documentdb://`` URL scheme and running the regular
+# backend test suite against MongoDB 5.0 — the API level AWS
+# DocumentDB currently claims compatibility with. Pinning to
+# 5.0 (rather than the newest 7.0/8.0) catches accidental use
+# of post-5.0 operators that would fail on a real DocumentDB
+# instance even though they work on upstream MongoDB.
+#
+# Limitations: vanilla MongoDB 5.0 still implements a superset
+# of AWS DocumentDB's surface — every operator AWS chose to
+# leave out of their reimplementation is still present here. So
+# this workflow catches IVRE-side regressions (a deleted
+# ``is_documentdb`` branch, a typo in a ``$floor``
+# substitution) but not new AWS-DocumentDB-specific gaps. A
+# real-AWS-DocumentDB CI lane is out of scope (no free tier,
+# no current sponsor); a separate workflow targeting
+# Microsoft's open-source DocumentDB project (a
+# PostgreSQL-based MongoDB-compatible engine — different
+# product from AWS DocumentDB despite the name collision) is
+# tracked separately. See E4.11 in the roadmap.
+
+name: DocumentDB compatibility tests
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
+jobs:
+  documentdb:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # One Python / MongoDB pair is enough for compat coverage:
+        # the workflow's purpose is to exercise the
+        # ``is_documentdb`` branches, not to repeat the full
+        # ``mongodb`` matrix. Pin to MongoDB 5.0 — the API level
+        # AWS DocumentDB currently claims compatibility with —
+        # so accidental use of post-5.0 operators is caught
+        # here even when the upstream ``mongodb`` job
+        # (``7.0`` / ``8.0``) lets them through.
+        python-version: ['3.12']
+        mongodb-version: ['5.0']
+
+    steps:
+
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Use Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.12.1
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+
+    - name: Install IVRE
+      uses: ./.github/actions/install
+
+    # Force the ``DocumentDB*`` classes by swapping the URL
+    # scheme. Same connection target (the local MongoDB above);
+    # only the class hierarchy IVRE selects changes.
+    - name: Configure IVRE to use the DocumentDB backend classes
+      run: |
+        echo 'DB = "documentdb:///ivre"' >> ~/.ivre.conf
+        cat ~/.ivre.conf | grep -E '^DB '
+
+    - run: python -c 'import json, pymongo; print(json.dumps(pymongo.MongoClient().server_info(), indent=4))'
+
+    - name: Confirm IVRE picked the DocumentDB classes
+      run: |
+        python -c "
+        from ivre.db import db
+        for purpose in ['nmap', 'view', 'passive', 'flow']:
+            backend = getattr(db, purpose)
+            assert backend.is_documentdb, (
+                f'{purpose} backend {type(backend).__name__} does not set '
+                'is_documentdb=True — check the documentdb:// scheme '
+                'dispatch in ivre/db/__init__.py'
+            )
+            print(f'{purpose}: {type(backend).__name__} is_documentdb=True')
+        "
+
+    - name: Initialize IVRE databases
+      run: for cli in ipinfo scancli view flowcli; do ivre $cli --init < /dev/null; done
+
+    # ``--exclude 15_rir`` mirrors the main mongodb job (RIR has
+    # its own dedicated job there). ``IVRE_BACKEND_FLAVOR`` adds
+    # the additional skips listed in ``BACKEND_FLAVORS`` and
+    # gates the inline ``searchtext`` block in
+    # ``test_50_view`` (DocumentDB has no ``$text``).
+    - run: cd tests && python tests.py --exclude 15_rir
+      env:
+        CI: true
+        DB: mongo
+        IVRE_BACKEND_FLAVOR: documentdb
+
+    - run: cat /tmp/webserver.log
+      if: failure()

--- a/ivre/db/document.py
+++ b/ivre/db/document.py
@@ -16,9 +16,89 @@
 # You should have received a copy of the GNU General Public License
 # along with IVRE. If not, see <http://www.gnu.org/licenses/>.
 
-"""This sub-module contains functions to interact with the Amazon
-DocumentDB databases.
+"""IVRE backend for AWS DocumentDB.
 
+DocumentDB speaks the MongoDB wire protocol but its query
+engine is a re-implementation that lacks a small set of
+operators IVRE relies on elsewhere; the four classes in this
+module subclass the regular ``MongoDB*`` backends and set
+``is_documentdb = True`` so the matching workarounds in
+``ivre.db.mongo`` activate.
+
+Selected by a ``DB = "documentdb://...`` URL in
+``ivre.conf``; the connection-string options are otherwise
+identical to the ``mongodb://`` scheme.
+
+Supported / unsupported surface
+-------------------------------
+
+* **Supported (everything else).** Every IVRE query path that
+  is not explicitly listed below works the same way it does on
+  upstream MongoDB. That includes regex matches (``$regex``),
+  conjunction / disjunction / negation
+  (``$and`` / ``$or`` / ``$nor``, ``$ne`` / ``$nin`` /
+  ``$not``), ``$elemMatch``, the aggregation pipeline used by
+  ``topvalues`` (with the ``$floor`` workaround applied
+  automatically — see below), and the geospatial operators
+  used by the world-map widget.
+
+* **Not supported: full-text search.** DocumentDB has neither
+  a text-index facility nor a ``$text`` operator, so
+  ``MongoDBView.searchtext`` (the backend behind
+  ``ivre view --search`` and the ``/cgi/view?q=text:...``
+  filter) cannot run. ``DocumentDBView`` therefore inherits
+  ``MongoDBActive.indexes`` (which contain no text index)
+  rather than ``MongoDBView.indexes`` (which does), and the
+  test suite skips the corresponding assertions when the
+  ``IVRE_BACKEND_FLAVOR=documentdb`` environment variable is
+  set. Callers that need free-text search on DocumentDB
+  deployments should pre-filter via the structured fields
+  exposed by the regular search helpers (host, port,
+  service, product, hostname, domain, ...).
+
+* **Worked around: missing aggregation operators.** The
+  ``$floor`` aggregation operator is not available on
+  DocumentDB; ``MongoDBActive.topvalues`` and
+  ``MongoDBPassive.topvalues`` substitute a
+  ``$subtract / $divide / $mod`` equivalent when
+  ``self.is_documentdb`` is true.
+
+* **Worked around: cursor-timeout semantics.** DocumentDB
+  does not honour ``no_cursor_timeout=True`` on long-running
+  cursors the way MongoDB does; the schema-migration cursor
+  in ``ivre.db.mongo.MongoDB`` flips the flag based on
+  ``is_documentdb``.
+
+CI coverage
+-----------
+
+The ``documentdb.yml`` workflow exercises every code path
+gated on ``is_documentdb`` by running the regular test suite
+with ``DB_*`` configured to ``documentdb://...`` URLs against
+**MongoDB 5.0** — the API level AWS DocumentDB currently
+claims compatibility with. Pinning to 5.0 (rather than the
+newest 7.0/8.0 used by the upstream ``mongodb`` workflow)
+catches accidental use of post-5.0 operators that would fail
+on a real DocumentDB instance even though they work on
+upstream MongoDB. Beyond that, the workflow catches
+regressions in the IVRE-side workarounds (a deleted
+``is_documentdb`` branch, a typo in the substituted
+expression, a missing ``is_documentdb`` flag on a new
+subclass).
+
+It does **not** prove that an operator IVRE assumes to be
+available on AWS DocumentDB actually is — vanilla MongoDB 5.0
+still implements a superset of AWS DocumentDB's surface (every
+operator AWS chose to leave out of their reimplementation is
+still present here). Closing that gap fully would require a
+real AWS DocumentDB cluster in CI, which is **not currently
+planned** (no free tier, no sponsor); see E4.11 in the
+roadmap. A separate workflow targeting Microsoft's
+open-source DocumentDB project (a PostgreSQL-based MongoDB-
+compatible engine that powers Azure Cosmos DB's MongoDB API,
+unrelated to AWS DocumentDB despite the name collision) is
+tracked alongside as another supported deployment target for
+operators running IVRE on cloud-native infrastructure.
 """
 
 from ivre.db.mongo import (
@@ -36,7 +116,10 @@ class DocumentDBNmap(MongoDBNmap):
 
 class DocumentDBView(MongoDBView):
     is_documentdb = True
-    # DocumentDB has no support for text indexes
+    # DocumentDB has no support for text indexes (no ``"text"``
+    # index type, no ``$text`` operator). Inherit the
+    # ``MongoDBActive`` index list, which omits the text index
+    # the ``MongoDBView`` set adds.
     indexes = MongoDBActive.indexes
     schema_migrations_indexes = MongoDBActive.schema_migrations_indexes
 
@@ -46,4 +129,4 @@ class DocumentDBPassive(MongoDBPassive):
 
 
 class DocumentDBFlow(MongoDBFlow):
-    pass
+    is_documentdb = True

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -3301,8 +3301,13 @@ class MongoDBActive(MongoDB, DBActive):
             addr = {"$add": ["$addr_1", 0x7FFF000100000000]}
             specialproj = {"_id": 0}
             if self.is_documentdb:
-                # AWS DocumentDB lacks $floor aggregation operator,
-                # just like MongoDB < 3.2
+                # AWS DocumentDB lacks the ``$floor`` aggregation
+                # operator (the original "just like MongoDB < 3.2"
+                # comment predates DocumentDB's claimed MongoDB
+                # 5.0 compatibility level — this branch may be
+                # removable once we have a real-DocumentDB CI
+                # lane to verify; for now the workaround is
+                # cheap and safe).
                 specialproj["addr"] = {
                     "$subtract": [
                         {"$divide": [addr, 2 ** (32 - mask)]},
@@ -5238,8 +5243,13 @@ class MongoDBPassive(MongoDB, DBPassive):
             addr = {"$add": ["$addr_1", 0x7FFF000100000000]}
             specialproj = {"_id": 0}
             if self.is_documentdb:
-                # AWS DocumentDB lacks $floor aggregation operator,
-                # just like MongoDB < 3.2
+                # AWS DocumentDB lacks the ``$floor`` aggregation
+                # operator (the original "just like MongoDB < 3.2"
+                # comment predates DocumentDB's claimed MongoDB
+                # 5.0 compatibility level — this branch may be
+                # removable once we have a real-DocumentDB CI
+                # lane to verify; for now the workaround is
+                # cheap and safe).
                 specialproj["addr"] = {
                     "$subtract": [
                         {"$divide": [addr, 2 ** (32 - mask)]},

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4792,8 +4792,11 @@ class IvreTests(unittest.TestCase):
         self.assertTrue(all(len(d) == ncolumns for d in data))
         self.check_value("view_features_versions_noyieldall_FRDE_ndata", len(data))
 
-        # Full-text
-        if DATABASE == "mongo":
+        # Full-text. Skipped on the AWS DocumentDB flavour: the
+        # backend has no text-index facility and no ``$text``
+        # operator. ``MongoDBView.searchtext`` would fail at
+        # query time on a real DocumentDB instance.
+        if DATABASE == "mongo" and BACKEND_FLAVOR != "documentdb":
             self.check_value(
                 "view_count_text_honeypot",
                 ivre.db.db.view.count(ivre.db.db.view.searchtext("honeypot")),
@@ -5072,6 +5075,24 @@ DATABASES = {
     ],
 }
 
+# Additional per-flavour exclusions layered on top of ``DATABASES``.
+# Set via the ``IVRE_BACKEND_FLAVOR`` env var to flag a Mongo-wire
+# backend whose surface differs from upstream MongoDB. Today the
+# only flavour is ``documentdb`` (AWS DocumentDB), which uses the
+# Mongo wire protocol but lacks full-text indexes (no ``$text``
+# operator and no ``"text"`` index type). Tests that depend on
+# those features are skipped when this flavour is set.
+BACKEND_FLAVORS = {
+    "documentdb": [
+        # ``MongoDBView.searchtext`` exercises ``$text`` /
+        # text-index features; DocumentDB has neither.
+        # The text-search assertions live inside ``test_50_view``,
+        # so we cannot skip the whole test method — instead the
+        # block at the call site checks ``BACKEND_FLAVOR`` and
+        # short-circuits.
+    ],
+}
+
 
 def parse_args():
     global SAMPLES, USE_COVERAGE
@@ -5109,8 +5130,9 @@ def parse_args():
 
 
 def parse_env():
-    global DATABASE, ELASTIC_INSERT_TEMPO
+    global DATABASE, BACKEND_FLAVOR, ELASTIC_INSERT_TEMPO
     DATABASE = os.getenv("DB")
+    BACKEND_FLAVOR = os.getenv("IVRE_BACKEND_FLAVOR")
     for test in DATABASES.get(DATABASE, []):
         test = "test_%s" % test
         setattr(
@@ -5118,6 +5140,15 @@ def parse_env():
             test,
             unittest.skip("Deactivated for database %r" % DATABASE)(
                 getattr(IvreTests, test),
+            ),
+        )
+    for test in BACKEND_FLAVORS.get(BACKEND_FLAVOR, []):
+        test = "test_%s" % test
+        setattr(
+            IvreTests,
+            test,
+            unittest.skip("Deactivated for backend flavour %r" % BACKEND_FLAVOR)(
+                getattr(IvreTests, test)
             ),
         )
     # Elasticsearch insertion is asynchronous, this hack "ensures" the


### PR DESCRIPTION
The four DocumentDB* classes in ivre/db/document.py have shipped without CI coverage since they were introduced. Every regression in the IVRE-side workarounds gated on is_documentdb (cursor-timeout flag, $floor aggregation substitution, text-index omission) has so far been verified-in-prod-only by AWS-deployed operators.

This change adds a documentdb.yml workflow that exercises all four DocumentDB* backends on every push / PR. The approach: drop a DB = 'documentdb:///ivre' line into ~/.ivre.conf so IVRE selects the DocumentDB* class hierarchy via the URL-scheme dispatch in
ivre/db/__init__.py, then run the regular backend test suite against MongoDB 5.0 — the API level AWS DocumentDB currently claims compatibility with. Pinning to 5.0 (rather than the newest 7.0/8.0 the upstream mongodb workflow uses) catches accidental use of post-5.0 operators that would fail on a real DocumentDB instance even though they work on upstream MongoDB. Beyond that, the workflow catches regressions in the workarounds themselves (a deleted branch, a typo in the substituted expression, a missing is_documentdb flag on a new subclass).

It does not prove that an operator IVRE assumes to be available on AWS DocumentDB actually is — vanilla MongoDB 5.0 still implements a superset of AWS DocumentDB's surface. A real-AWS-DocumentDB CI lane is not currently planned (no free tier; would need a long-lived AWS test account and sponsor budget); operators wanting full-fidelity
verification can run the suite against their own DocumentDB cluster.

The workflow runs a single matrix entry (Python 3.12, MongoDB 5.0). The compat surface is small enough that the upstream 'mongodb' matrix's coverage of multiple Python and MongoDB versions does not need to be repeated here.

Test-suite plumbing:

- tests/tests.py gains an IVRE_BACKEND_FLAVOR env var read at parse time, layered on top of the existing DATABASES exclusion table. A new BACKEND_FLAVORS dict declares per-flavour skips; today the only flavour is documentdb.
- The inline test_50_view block that exercises MongoDBView.searchtext ($text operator, text index) now gates on BACKEND_FLAVOR != 'documentdb'. DocumentDB has neither and would fail at query time.
- The workflow's pre-flight step asserts every backend selected by DB=documentdb:// carries is_documentdb=True. This caught a latent gap on DocumentDBFlow (which inherited is_documentdb=False from MongoDB); fixed in this commit.

Documentation:

- The module docstring of ivre/db/document.py now spells out the supported / unsupported / worked-around surface with cross-references to the relevant workarounds in ivre/db/mongo.py.
- The $floor workaround comments in ivre/db/mongo.py note that the original 'just like MongoDB < 3.2' claim predates DocumentDB's current MongoDB-5.0 compatibility level — the branch may be removable; one-shot manual audit on a real DocumentDB 5.x cluster is enough to decide.