### PR TITLE
refactor(db/mongo): _search_field helper sweep round 2 + searchasnum:AS<n> fix on view

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -2544,14 +2544,12 @@ class MongoDBActive(MongoDB, DBActive):
 
     @classmethod
     def searchhostname(cls, name=None, neg=False):
-        if neg:
-            if name is None:
-                return {"hostnames.domains": {"$exists": False}}
-            if isinstance(name, utils.REGEXP_T):
-                return {"hostnames.name": {"$not": name}}
-            return {"hostnames.name": {"$ne": name}}
         if name is None:
-            return {"hostnames.domains": {"$exists": True}}
+            # ``hostnames.domains`` is the indexed field; gate on
+            # its existence rather than ``hostnames.name``'s.
+            return {"hostnames.domains": {"$exists": not neg}}
+        if neg:
+            return cls._search_field("hostnames.name", name, neg=True)
         return cls.flt_and(
             # This is indexed
             cls.searchdomain(name, neg=neg),
@@ -4638,18 +4636,17 @@ class MongoDBView(MongoDBActive, DBView):
         """
         return cls._search_field("infos.city", city, neg=neg)
 
-    @staticmethod
-    def searchasnum(asnum, neg=False):
+    @classmethod
+    def searchasnum(cls, asnum, neg=False):
         """Filters (if `neg` == True, filters out) one or more
-        particular AS number(s).
-
+        particular AS number(s). Accepts ``"AS1234"`` /
+        ``"1234"`` / ``1234`` / lists of either, plus regexes
+        \u2014 see :func:`_coerce_asnum`. Aligns the View backend's
+        input handling with the RIR backend's, so the
+        ``asnum:AS1234`` token from ``flt_from_query`` works
+        identically against both.
         """
-        if not isinstance(asnum, str) and hasattr(asnum, "__iter__"):
-            return {
-                "infos.as_num": {"$nin" if neg else "$in": [int(val) for val in asnum]}
-            }
-        asnum = int(asnum)
-        return {"infos.as_num": {"$ne": asnum} if neg else asnum}
+        return cls._search_field("infos.as_num", _coerce_asnum(asnum), neg=neg)
 
     @classmethod
     def searchasname(cls, asname, neg=False):
@@ -5470,8 +5467,8 @@ class MongoDBPassive(MongoDB, DBPassive):
     def searchsensor(cls, sensor, neg=False):
         return cls._search_field("sensor", sensor, neg=neg)
 
-    @staticmethod
-    def searchport(port, protocol="tcp", state="open", neg=False):
+    @classmethod
+    def searchport(cls, port, protocol="tcp", state="open", neg=False):
         """Filters (if `neg` == True, filters out) records on the specified
         protocol/port.
 
@@ -5480,7 +5477,7 @@ class MongoDBPassive(MongoDB, DBPassive):
             raise ValueError("Protocols other than TCP are not supported in passive")
         if state != "open":
             raise ValueError("Only open ports can be found in passive")
-        return {"port": {"$ne": port} if neg else port}
+        return cls._search_field("port", port, neg=neg)
 
     @staticmethod
     def searchservice(srv, port=None, protocol=None):
@@ -5581,8 +5578,10 @@ class MongoDBPassive(MongoDB, DBPassive):
             "value": useragent,
         }
 
-    @staticmethod
-    def searchdns(name=None, reverse=False, dnstype=None, subdomains=False, neg=False):
+    @classmethod
+    def searchdns(
+        cls, name=None, reverse=False, dnstype=None, subdomains=False, neg=False
+    ):
         res = {
             "recontype": "DNS_ANSWER",
         }
@@ -5592,22 +5591,7 @@ class MongoDBPassive(MongoDB, DBPassive):
                 if subdomains
                 else ("targetval" if reverse else "value")
             )
-            if isinstance(name, list):
-                if len(name) == 1:
-                    name = name[0]
-                elif neg:
-                    res[field] = {"$nin": name}
-                    name = None
-                else:
-                    name = {"$in": name}
-            if name is not None:
-                if neg:
-                    if isinstance(name, utils.REGEXP_T):
-                        res[field] = {"$not": name}
-                    else:
-                        res[field] = {"$ne": name}
-                else:
-                    res[field] = name
+            res.update(cls._search_field(field, name, neg=neg))
         if dnstype is not None:
             res["source"] = re.compile(f"^{dnstype.upper()}-")
         return res
@@ -5929,15 +5913,15 @@ class MongoDBRir(MongoDB, DBRir):
         """
         return cls._search_field("source_file", src, neg=neg)
 
-    @staticmethod
-    def searchfileid(fileid: str, neg: bool = False) -> Filter:
+    @classmethod
+    def searchfileid(cls, fileid, neg=False):
         """Filters (if `neg` == True, filters out) one particular
-        file id.
+        file id. Accepts a scalar (the typical operator-typed
+        SHA-256 hex digest), a list of digests, or a regex \u2014
+        delegated to :meth:`MongoDB._search_field`.
 
         """
-        if neg:
-            return {"source_hash": {"$ne": fileid}}
-        return {"source_hash": fileid}
+        return cls._search_field("source_hash", fileid, neg=neg)
 
     @classmethod
     def searchhost(cls, addr, neg=False):

--- a/pkg/runchecks
+++ b/pkg/runchecks
@@ -18,11 +18,11 @@
 
 # pip install -U '.[linting]'
 
-black -t py312 --check ./doc/conf.py ./tests/tests.py ./ivre/ ./pkg/stubs/ && echo "black OK"
+black -t py312 --check --extend-exclude="_version\.py" ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "black OK"
 
-flake8 --ignore=E402,E501,F401 ./doc/conf.py && flake8 --ignore=E203,E402,E501,W503 ./tests/tests.py && flake8 --ignore=E203,E501,E704,F821,W503 ./ivre/ && flake8 --ignore=E302,E305,E701,E704 ./pkg/stubs/*.pyi && echo "flake8 OK"
+flake8 --ignore=E402,E501,F401 ./doc/conf.py && flake8 --ignore=E203,E402,E501,W503 ./tests/tests.py ./tests/tests_no_backend.py && flake8 --ignore=E203,E501,E704,F821,W503 ./ivre/ && flake8 --ignore=E302,E305,E701,E704 ./pkg/stubs/*.pyi && echo "flake8 OK"
 
-bandit --severity-level high -r ./doc/conf.py ./tests/tests.py ./ivre/ ./pkg/stubs/ && echo "bandit OK"
+bandit --severity-level high -r ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "bandit OK"
 
 # TODO: remove --follow-imports=skip
 MYPYPATH=./pkg/stubs/ mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-decorators --disallow-untyped-defs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any ./ivre/{active,analyzer,data,parser,tags,tools,types}/*.py ./ivre/{__init__,activecli,config,flow,geoiputils,graphroute,keys,plugins,utils,zgrabout}.py && echo "mypy OK"
@@ -35,7 +35,7 @@ pylint -e all -d abstract-method,arguments-differ,attribute-defined-outside-init
 
 pylint -e all -d unused-argument,too-many-arguments,too-many-positional-arguments,missing-function-docstring,missing-class-docstring,missing-module-docstring,multiple-statements,invalid-name,too-few-public-methods ./pkg/stubs/*.pyi && echo "pylint stubs OK"
 
-isort --profile black --check-only ivre ./doc/conf.py ./tests/tests.py ./pkg/stubs/*.pyi && echo "isort OK"
+isort --profile black --check-only ivre ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./pkg/stubs/*.pyi && echo "isort OK"
 
 rstcheck -r ./doc/ && echo "rstcheck OK"
 if ! find ./doc/ -type f -name '*.rst' -print0 | xargs -0 grep '[[:space:]]$'; then echo "trailing spaces OK"; else echo "!! trailing spaces !!"; false; fi

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1813,6 +1813,82 @@ class MongoDBSearchFieldTests(unittest.TestCase):
             {"hostnames.domains": {"$not": pat}},
         )
 
+    def test_searchhostname_active_negation_shapes(self):
+        # ``MongoDBActive.searchhostname``'s ``neg=True`` branch is
+        # the canonical scalar/regex/None ladder over
+        # ``hostnames.name`` (None means "no hostnames at all" via
+        # ``hostnames.domains.$exists``). Pinned here so the
+        # round-2 helper migration of that branch stays
+        # wire-shape-identical.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhostname(neg=True),
+            {"hostnames.domains": {"$exists": False}},
+        )
+        self.assertEqual(
+            MA.searchhostname("host.example.com", neg=True),
+            {"hostnames.name": {"$ne": "host.example.com"}},
+        )
+        pat = re.compile(r"\.example\.com$")
+        self.assertEqual(
+            MA.searchhostname(pat, neg=True),
+            {"hostnames.name": {"$not": pat}},
+        )
+
+    def test_searchasnum_view_coercion_shapes(self):
+        # ``MongoDBView.searchasnum`` accepts ``"AS1234"``, ``"1234"``,
+        # ``1234``, lists thereof, and a regex. Pinning *before* the
+        # round-2 migration that aligns View on the same
+        # ``_coerce_asnum`` helper RIR uses.
+        MV = self._MV()
+        self.assertEqual(MV.searchasnum("AS1234"), {"infos.as_num": 1234})
+        self.assertEqual(MV.searchasnum("1234"), {"infos.as_num": 1234})
+        self.assertEqual(MV.searchasnum(1234), {"infos.as_num": 1234})
+        self.assertEqual(
+            MV.searchasnum(["AS1234", "AS5678"]),
+            {"infos.as_num": {"$in": [1234, 5678]}},
+        )
+        self.assertEqual(
+            MV.searchasnum("AS1234", neg=True),
+            {"infos.as_num": {"$ne": 1234}},
+        )
+        self.assertEqual(
+            MV.searchasnum(["AS1234", "AS5678"], neg=True),
+            {"infos.as_num": {"$nin": [1234, 5678]}},
+        )
+        pat = re.compile(r"^12")
+        self.assertEqual(MV.searchasnum(pat), {"infos.as_num": pat})
+
+    def test_searchfileid_rir_scalar_shapes(self):
+        # ``MongoDBRir.searchfileid`` is a degenerate scalar +
+        # ``$ne`` ladder today. Pinning the wire shape *before*
+        # the round-2 migration to ``_search_field`` (which
+        # additionally lets callers pass lists / regexes — the
+        # widening is deliberate and lossless for the legacy
+        # scalar callers).
+        MR = self._MR()
+        self.assertEqual(MR.searchfileid("abc123"), {"source_hash": "abc123"})
+        self.assertEqual(
+            MR.searchfileid("abc123", neg=True),
+            {"source_hash": {"$ne": "abc123"}},
+        )
+
+    def test_searchport_passive_shapes(self):
+        # ``MongoDBPassive.searchport`` is the canonical scalar +
+        # ``$ne`` ladder against the ``port`` field, with two
+        # ``raise ValueError`` paths for the (currently
+        # unsupported) ``protocol != "tcp"`` and
+        # ``state != "open"`` arguments. Pinned before the
+        # round-2 migration that lifts the scalar branch onto
+        # ``_search_field``.
+        MP = self._MP()
+        self.assertEqual(MP.searchport(443), {"port": 443})
+        self.assertEqual(MP.searchport(443, neg=True), {"port": {"$ne": 443}})
+        with self.assertRaises(ValueError):
+            MP.searchport(443, protocol="udp")
+        with self.assertRaises(ValueError):
+            MP.searchport(443, state="closed")
+
     def test_searchdns_passive_negation_shapes(self):
         # ``DBPassive.searchdomain`` / ``searchhostname`` /
         # ``searchdns`` accept ``neg=True`` (regression: the


### PR DESCRIPTION
Migrate five more ``MongoDB`` ``searchXXX`` methods to one-line ``cls._search_field(...)`` delegations, continuing round 1's extraction. Wire shapes pinned bit-for-bit by new and existing no-backend tests.

  - ``MongoDBRir.searchfileid``: 4 lines → 1 line. Convert ``@staticmethod`` to ``@classmethod``. The body was the scalar branch of ``_search_field``; the helper additionally accepts lists / regexes (deliberate widening; the legacy scalar wire shape stays identical).
  - ``MongoDBPassive.searchport``: 1-line shrink, family alignment win. Convert to ``@classmethod``. The two ``raise ValueError`` paths for ``protocol != "tcp"`` and ``state != "open"`` are preserved verbatim.
  - ``MongoDBView.searchasnum``: 5 → 1 line, plus a latent bug fix. Today the View backend does ``int(asnum)`` blindly, which crashes with ``ValueError: invalid literal for int()`` on the ``asnum:AS1234`` token that ``flt_from_query`` forwards from the web filter bar — the RIR backend already handles that input via ``_coerce_asnum``. Reuse the same helper on View so the two backends accept the same input shapes (string ``"AS1234"`` / ``"1234"`` / int / lists / regex). The pinning test added in this commit fails on the pre-refactor code with the exact ``ValueError``, and passes after the refactor.
  - ``MongoDBPassive.searchdns``: ~12 → 5 lines on the inner ladder. Convert to ``@classmethod``. The dns-specific field-name selection (``infos.domain`` vs ``targetval`` vs ``value`` etc.) and the ``recontype: DNS_ANSWER`` / ``source: ^<dnstype>-`` decorations stay; the scalar / list / list-of-1 / regex / neg ladder over the chosen field is now ``cls._search_field(field, name, neg=neg)``. Existing ``test_searchdns_passive_negation_shapes`` covers the full neg matrix; no new pin needed.
  - ``MongoDBActive.searchhostname``: 7 → 5 lines. The ``name is None`` branch (both pos and neg) is now a single ``$exists`` flip; the ``neg=True``-with-name branch delegates to ``_search_field("hostnames.name", name, neg=True)``. The positive branch's two-filter composition (indexed ``hostnames.domains`` + non-indexed ``hostnames.name``) stays unchanged.

Pinning tests added before the refactor in
``tests/tests_no_backend.py`` (so any regression surfaces in the same review):

  - ``test_searchhostname_active_negation_shapes`` (3 cases)
  - ``test_searchasnum_view_coercion_shapes`` (7 cases — fails on pre-refactor code with the bug above; passes after)
  - ``test_searchfileid_rir_scalar_shapes`` (2 cases)
  - ``test_searchport_passive_shapes`` (4 cases — including both ``raise ValueError`` paths)

Net: 28 insertions, 44 deletions in ``ivre/db/mongo.py``. Every remaining ``searchXXX`` in the file now falls into the "cannot reduce" bucket (range, dual-key compare, multi-field ``$elemMatch``, constants, or compositions thereof).