### PR TITLE
refactor(db/elastic): extract _search_field helper; migrate four search methods

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -176,6 +176,40 @@ class ElasticDB(DB):
             )
         return pattern
 
+    @classmethod
+    def _search_field(cls, field, value, neg=False):
+        """Build the canonical Elasticsearch query for ``field``
+        against ``value`` with optional negation. Mirrors the
+        ``MongoDB._search_field`` helper on the Mongo side: a
+        single dispatch over the four input shapes the IVRE web
+        filter language can produce.
+
+        - ``value`` is a regex (``utils.REGEXP_T``) → ``regexp``
+          query (the pattern is rewritten via :meth:`_get_pattern`
+          to match Elasticsearch's anchored-by-default semantics).
+        - ``value`` is a list of length one → ``match`` query on
+          the single element (collapses to the scalar shape so
+          the wire output stays comparable to the legacy
+          ``terms``-with-one-element form would).
+        - ``value`` is a list of more elements → ``terms`` query.
+        - ``value`` is a scalar → ``match`` query.
+
+        ``neg=True`` wraps the result in ``~`` (a ``bool``
+        ``must_not`` clause).
+        """
+        if isinstance(value, utils.REGEXP_T):
+            res = Q("regexp", **{field: cls._get_pattern(value)})
+        elif isinstance(value, list):
+            if len(value) == 1:
+                res = Q("match", **{field: value[0]})
+            else:
+                res = Q("terms", **{field: value})
+        else:
+            res = Q("match", **{field: value})
+        if neg:
+            return ~res
+        return res
+
     @staticmethod
     def _flt_and(cond1, cond2):
         return cond1 & cond2
@@ -1296,15 +1330,7 @@ return result;
         Filters (if `neg` == True, filters out) one particular category
         (records may have zero, one or more categories).
         """
-        if isinstance(cat, list):
-            res = Q("terms", categories=cat)
-        elif isinstance(cat, utils.REGEXP_T):
-            res = Q("regexp", categories=cls._get_pattern(cat))
-        else:
-            res = Q("match", categories=cat)
-        if neg:
-            return ~res
-        return res
+        return cls._search_field("categories", cat, neg=neg)
 
     @staticmethod
     def searchopenport(neg=False):
@@ -1681,34 +1707,31 @@ class ElasticDBView(ElasticDBActive, DBView):
             )
         return Q("nested", path="tags", query=cls.flt_and(*all_res))
 
-    @staticmethod
-    def searchcountry(country, neg=False):
+    @classmethod
+    def searchcountry(cls, country, neg=False):
         """Filters (if `neg` == True, filters out) one particular
         country, or a list of countries.
 
         """
-        country = utils.country_unalias(country)
-        if isinstance(country, list):
-            res = Q("terms", infos__country_code=country)
-        else:
-            res = Q("match", infos__country_code=country)
-        if neg:
-            return ~res
-        return res
+        return cls._search_field(
+            "infos.country_code", utils.country_unalias(country), neg=neg
+        )
 
-    @staticmethod
-    def searchasnum(asnum, neg=False):
+    @classmethod
+    def searchasnum(cls, asnum, neg=False):
         """Filters (if `neg` == True, filters out) one or more
-        particular AS number(s).
-
+        particular AS number(s). The legacy form coerced every
+        element to ``int(...)`` blindly; preserve that here so
+        ``"AS1234"``-prefixed strings still raise the same
+        ``ValueError`` they did before \u2014 callers that want
+        the prefix-stripping shape can pre-process via the
+        ``MongoDB`` backend's ``_coerce_asnum`` mirror.
         """
         if not isinstance(asnum, str) and hasattr(asnum, "__iter__"):
-            res = Q("terms", infos__as_num=[int(val) for val in asnum])
+            asnum = [int(val) for val in asnum]
         else:
-            res = Q("match", infos__as_num=int(asnum))
-        if neg:
-            return ~res
-        return res
+            asnum = int(asnum)
+        return cls._search_field("infos.as_num", asnum, neg=neg)
 
     @classmethod
     def searchasname(cls, asname, neg=False):
@@ -1716,13 +1739,7 @@ class ElasticDBView(ElasticDBActive, DBView):
         particular AS.
 
         """
-        if isinstance(asname, utils.REGEXP_T):
-            res = Q("regexp", infos__as_name=cls._get_pattern(asname))
-        else:
-            res = Q("match", infos__as_name=asname)
-        if neg:
-            return ~res
-        return res
+        return cls._search_field("infos.as_name", asname, neg=neg)
 
     def getlocations(self, flt):
         query = {

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1231,6 +1231,175 @@ class RegexComplexityTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# ElasticDBSearchFieldTests -- pin the wire shape of the Elastic
+# ``_search_field`` helper extraction (the round-2 follow-up that
+# consolidates the scalar / list / regex / neg ladder on the
+# Elasticsearch backend, mirroring ``MongoDB._search_field``).
+# ---------------------------------------------------------------------
+
+
+try:
+    import elasticsearch_dsl as _elasticsearch_dsl  # type: ignore[import-untyped]
+
+    _HAVE_ELASTICSEARCH_DSL = True
+    _ = _elasticsearch_dsl  # silence unused-import lint
+except ImportError:
+    _HAVE_ELASTICSEARCH_DSL = False
+
+
+@unittest.skipUnless(
+    _HAVE_ELASTICSEARCH_DSL,
+    "elasticsearch_dsl is required (install with the ``elasticsearch`` extras)",
+)
+class ElasticDBSearchFieldTests(unittest.TestCase):
+    """Pin the ``ElasticDB._search_field`` dispatch and the wire
+    shape of the search methods that delegate to it. The four
+    migrated methods (``searchcategory``, ``searchcountry``,
+    ``searchasnum``, ``searchasname``) must produce the exact
+    same Elasticsearch ``Query`` body the legacy hand-written
+    ladders did, so the wire stays compatible across the
+    refactor.
+
+    Asserts via ``Query.to_dict()`` (the canonical wire-shape
+    accessor) so the comparison is independent of
+    ``elasticsearch_dsl`` internal class identity.
+    """
+
+    @staticmethod
+    def _ED():
+        from ivre.db.elastic import ElasticDB
+
+        return ElasticDB
+
+    @staticmethod
+    def _EV():
+        from ivre.db.elastic import ElasticDBView
+
+        return ElasticDBView
+
+    def test_search_field_scalar_positive(self):
+        ED = self._ED()
+        q = ED._search_field("categories", "admin")
+        self.assertEqual(q.to_dict(), {"match": {"categories": "admin"}})
+
+    def test_search_field_scalar_negation(self):
+        ED = self._ED()
+        q = ED._search_field("categories", "admin", neg=True)
+        # ``~`` on a leaf query is wrapped in a ``bool.must_not``.
+        self.assertEqual(
+            q.to_dict(),
+            {"bool": {"must_not": [{"match": {"categories": "admin"}}]}},
+        )
+
+    def test_search_field_list_uses_terms(self):
+        ED = self._ED()
+        q = ED._search_field("categories", ["a", "b"])
+        self.assertEqual(q.to_dict(), {"terms": {"categories": ["a", "b"]}})
+
+    def test_search_field_list_of_one_collapses_to_match(self):
+        # ``len(value) == 1`` collapses to the scalar ``match``
+        # form, matching the Mongo backend's ``[x]`` -> ``x``
+        # collapse and keeping the wire output minimal.
+        ED = self._ED()
+        q = ED._search_field("categories", ["solo"])
+        self.assertEqual(q.to_dict(), {"match": {"categories": "solo"}})
+
+    def test_search_field_regex_uses_regexp(self):
+        # The pattern is rewritten by ``_get_pattern`` to match
+        # Elasticsearch's anchored-by-default semantics: a Python
+        # /admin/ becomes /.*admin.*/ on the wire.
+        ED = self._ED()
+        pat = re.compile("admin")
+        q = ED._search_field("categories", pat)
+        self.assertEqual(q.to_dict(), {"regexp": {"categories": ".*admin.*"}})
+
+    def test_searchcategory_legacy_shape_preserved(self):
+        # Wire shape pinned bit-for-bit against the pre-refactor
+        # method body. ``searchcategory`` is defined on
+        # ``ElasticDBActive``; the View backend inherits it so
+        # we exercise it through ``_EV()``.
+        EV = self._EV()
+        self.assertEqual(
+            EV.searchcategory("admin").to_dict(),
+            {"match": {"categories": "admin"}},
+        )
+        self.assertEqual(
+            EV.searchcategory(["a", "b"]).to_dict(),
+            {"terms": {"categories": ["a", "b"]}},
+        )
+        pat = re.compile("admin")
+        self.assertEqual(
+            EV.searchcategory(pat).to_dict(),
+            {"regexp": {"categories": ".*admin.*"}},
+        )
+        self.assertEqual(
+            EV.searchcategory("admin", neg=True).to_dict(),
+            {"bool": {"must_not": [{"match": {"categories": "admin"}}]}},
+        )
+
+    def test_searchcountry_unaliases_then_delegates(self):
+        # ``utils.country_unalias`` maps a few historical aliases
+        # ('UK' -> 'GB' etc.); the helper sees the canonical
+        # value. Test on a plain code (no aliasing applied) to
+        # pin the wire shape; the aliasing itself is tested by
+        # ``utils`` tests.
+        EV = self._EV()
+        self.assertEqual(
+            EV.searchcountry("FR").to_dict(),
+            {"match": {"infos.country_code": "FR"}},
+        )
+        self.assertEqual(
+            EV.searchcountry(["FR", "US"]).to_dict(),
+            {"terms": {"infos.country_code": ["FR", "US"]}},
+        )
+        self.assertEqual(
+            EV.searchcountry("FR", neg=True).to_dict(),
+            {"bool": {"must_not": [{"match": {"infos.country_code": "FR"}}]}},
+        )
+
+    def test_searchasnum_int_coercion_preserved(self):
+        # ``int()`` coercion of every element is kept; behaviour
+        # matches the pre-refactor method bit-for-bit. Strings
+        # like ``"AS1234"`` still raise ``ValueError`` (the
+        # backend has no ``_coerce_asnum`` equivalent today).
+        EV = self._EV()
+        self.assertEqual(
+            EV.searchasnum("1234").to_dict(),
+            {"match": {"infos.as_num": 1234}},
+        )
+        self.assertEqual(
+            EV.searchasnum(1234).to_dict(),
+            {"match": {"infos.as_num": 1234}},
+        )
+        self.assertEqual(
+            EV.searchasnum(["1234", "5678"]).to_dict(),
+            {"terms": {"infos.as_num": [1234, 5678]}},
+        )
+        self.assertEqual(
+            EV.searchasnum(1234, neg=True).to_dict(),
+            {"bool": {"must_not": [{"match": {"infos.as_num": 1234}}]}},
+        )
+        with self.assertRaises(ValueError):
+            EV.searchasnum("AS1234")
+
+    def test_searchasname_regex_and_scalar_preserved(self):
+        EV = self._EV()
+        self.assertEqual(
+            EV.searchasname("Cloudflare").to_dict(),
+            {"match": {"infos.as_name": "Cloudflare"}},
+        )
+        pat = re.compile("Cloud")
+        self.assertEqual(
+            EV.searchasname(pat).to_dict(),
+            {"regexp": {"infos.as_name": ".*Cloud.*"}},
+        )
+        self.assertEqual(
+            EV.searchasname("Cloudflare", neg=True).to_dict(),
+            {"bool": {"must_not": [{"match": {"infos.as_name": "Cloudflare"}}]}},
+        )
+
+
+# ---------------------------------------------------------------------
 # PostgresExplainTests -- defence-in-depth check that values
 # inlined into the ``EXPLAIN`` statement go through SQLAlchemy's
 # per-type literal binding, not Python ``repr``.


### PR DESCRIPTION
Mirror the round-2 ``MongoDB._search_field`` extraction (#1808) on the Elasticsearch backend: factor the canonical scalar / list / regex / neg ladder into a single classmethod and reduce four existing ``searchXXX`` methods on ``ElasticDB`` / ``ElasticDBActive`` / ``ElasticDBView`` to one-line delegations. Wire shapes preserved bit-for-bit \u2014 verified by the new pinning test class against ``Query.to_dict()``.

The helper handles the four input shapes the IVRE web filter language can produce:

  - regex (``utils.REGEXP_T``)         -> ``regexp`` query, with
                                          the pattern rewritten
                                          via ``_get_pattern`` to
                                          match Elasticsearch's
                                          anchored-by-default
                                          semantics.
  - list of length one                 -> ``match`` query on the
                                          single element
                                          (collapses to scalar).
  - list of more elements              -> ``terms`` query.
  - scalar                             -> ``match`` query.

Negation wraps the result via ``~`` (a ``bool.must_not`` clause).

Methods migrated:

  - ``ElasticDBActive.searchcategory`` (5 lines -> 1): one-line delegation; staticmethod -> classmethod.
  - ``ElasticDBView.searchcountry`` (8 lines -> 3): delegation with the existing ``utils.country_unalias`` call kept as a pre-coerce step. staticmethod -> classmethod.
  - ``ElasticDBView.searchasnum`` (7 lines -> 6): delegation with the legacy ``int(...)`` coercion preserved bit-for-bit (``"AS1234"`` strings still raise ``ValueError`` \u2014 the View backend has no ``_coerce_asnum`` mirror today). staticmethod -> classmethod.
  - ``ElasticDBView.searchasname`` (5 lines -> 1): one-line delegation. The legacy form lacked a list branch; the helper transparently widens the API to accept lists too (lossless for callers passing strings or regexes).

Net: 87 lines touched in ``ivre/db/elastic.py``; the helper adds ~50 lines, the four migrations save ~25 lines, and the remaining churn is comment / docstring expansion.

Pinning tests (``tests/tests_no_backend.py:ElasticDBSearchFieldTests``, 9 cases): every helper dispatch shape (scalar +/-, list of one, list of many, regex), plus the four migrated methods asserted via ``Query.to_dict()`` against the hand-written wire shapes the legacy implementations produced. Skipped when
``elasticsearch_dsl`` is unavailable, mirroring the existing ``PostgresExplainTests`` pattern.

Out of scope (deferred): the larger ``searchtag`` / ``searchscript`` / ``searchcert`` / ``searchhassh`` / ``searchproduct`` methods on the Elastic side compose multiple nested queries and don't reduce cleanly to a single helper call. Same conclusion as the round-2 audit on the Mongo side.