### PR TITLE
fix(utils): get_cert_info works on pyOpenSSL 26.x (X509.get_extension removed)

### DIFF
--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -2282,14 +2282,32 @@ if USE_PYOPENSSL:
         # ``X509.get_extension(i)`` was deprecated in pyOpenSSL 23.3
         # and removed in pyOpenSSL 26.x; route the lookup through
         # ``cryptography`` instead via the ``X509.to_cryptography``
-        # bridge (available since pyOpenSSL 17.1).
+        # bridge (available since pyOpenSSL 17.1). The bridge re-parses
+        # the DER through ``cryptography``'s strict ASN.1 parser, which
+        # rejects malformed (but real-world-observed) certificates that
+        # pyOpenSSL's looser parser used to tolerate -- e.g.
+        # ``InvalidVersion: 3 is not a valid X509 version``,
+        # ``ValueError: error parsing asn1 value: ParseError ...
+        # Time::UtcTime``, ``BasicConstraints::ca`` ``EncodedDefault``,
+        # ``DuplicateExtension``. Catch broadly here: a failure of
+        # SAN extraction must not skip the pubkey / serial / dates
+        # block below (downstream consumers, notably
+        # ``ivre getmoduli``, rely on ``result["pubkey"]["exponent"]``
+        # being populated even for not-quite-spec-compliant certs).
+        san_ext = None
         try:
             san_ext = data.to_cryptography().extensions.get_extension_for_class(
                 _x509.SubjectAlternativeName
             )
         except _x509.ExtensionNotFound:
             pass
-        else:
+        except Exception:
+            LOGGER.info(
+                "Cannot parse certificate via cryptography for SAN lookup: %r",
+                result["subject_text"],
+                exc_info=True,
+            )
+        if san_ext is not None:
             try:
                 result["san"] = [_format_san_general_name(gn) for gn in san_ext.value]
             except Exception:

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -53,6 +53,7 @@ from urllib.parse import urlparse
 from urllib.request import build_opener
 
 try:
+    from cryptography import x509 as _x509
     from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
     from OpenSSL import crypto as osslc
 except ImportError:
@@ -2233,6 +2234,33 @@ if USE_PYOPENSSL:
             components.append((k, v))
         return "/".join(f"{kv[0]}={kv[1]}" for kv in components), dict(components)
 
+    def _format_san_general_name(name: "_x509.GeneralName") -> str:
+        """Format a single ``cryptography.x509`` ``GeneralName`` (one
+        entry of a ``SubjectAlternativeName`` extension) the same way
+        ``str(<pyOpenSSL X509Extension>)`` used to render it -- the
+        OpenSSL CLI ``v2i_GENERAL_NAME`` form, e.g. ``DNS:...``,
+        ``IP Address:...``, ``email:...``, ``URI:...``.
+
+        Pinned by ``CertExtensionFormatTests`` in
+        ``tests/tests_no_backend.py``. Mirrors RFC 5280 4.2.1.6
+        ``GeneralName`` choices.
+        """
+        if isinstance(name, _x509.DNSName):
+            return f"DNS:{name.value}"
+        if isinstance(name, _x509.IPAddress):
+            return f"IP Address:{name.value}"
+        if isinstance(name, _x509.RFC822Name):
+            return f"email:{name.value}"
+        if isinstance(name, _x509.UniformResourceIdentifier):
+            return f"URI:{name.value}"
+        if isinstance(name, _x509.DirectoryName):
+            return f"DirName:{name.value.rfc4514_string()}"
+        if isinstance(name, _x509.RegisteredID):
+            return f"Registered ID:{name.value.dotted_string}"
+        if isinstance(name, _x509.OtherName):
+            return f"othername:{name.type_id.dotted_string}"
+        return str(name)
+
     def get_cert_info(cert: bytes) -> dict[str, Any]:
         """Extract info from a certificate (hash values, issuer, subject,
             algorithm) in an handy-to-index-and-query form.
@@ -2251,20 +2279,26 @@ if USE_PYOPENSSL:
             return result
         result["subject_text"], result["subject"] = _parse_subject(data.get_subject())
         result["issuer_text"], result["issuer"] = _parse_subject(data.get_issuer())
-        for i in range(data.get_extension_count()):
-            ext = data.get_extension(i)
-            if ext.get_short_name() == b"subjectAltName":
-                try:
-                    # XXX str() / encoding
-                    result["san"] = [x.strip() for x in str(ext).split(", ")]
-                except Exception:
-                    LOGGER.warning(
-                        "Cannot decode subjectAltName %r for %r",
-                        ext,
-                        result["subject_text"],
-                        exc_info=True,
-                    )
-                break
+        # ``X509.get_extension(i)`` was deprecated in pyOpenSSL 23.3
+        # and removed in pyOpenSSL 26.x; route the lookup through
+        # ``cryptography`` instead via the ``X509.to_cryptography``
+        # bridge (available since pyOpenSSL 17.1).
+        try:
+            san_ext = data.to_cryptography().extensions.get_extension_for_class(
+                _x509.SubjectAlternativeName
+            )
+        except _x509.ExtensionNotFound:
+            pass
+        else:
+            try:
+                result["san"] = [_format_san_general_name(gn) for gn in san_ext.value]
+            except Exception:
+                LOGGER.warning(
+                    "Cannot decode subjectAltName %r for %r",
+                    san_ext,
+                    result["subject_text"],
+                    exc_info=True,
+                )
         result["self_signed"] = result["issuer_text"] == result["subject_text"]
         try:
             not_before = _parse_datetime(data.get_notBefore())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,11 @@ dependencies = [
     "cryptography",
     "defusedxml",
     "pymongo>=4.10",
-    "pyOpenSSL>=16.1.0",
+    # ``X509.to_cryptography`` is used in ``ivre.utils.get_cert_info``
+    # for the SubjectAlternativeName lookup; it landed in
+    # pyOpenSSL 17.1.0 (the legacy ``X509.get_extension`` /
+    # ``get_extension_count`` index loop was removed in 26.x).
+    "pyOpenSSL>=17.1.0",
     "bottle",
     # Static ReDoS analyser (Doyensec). Used by
     # ``ivre.web.utils.validate_regex_complexity`` to reject

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1532,6 +1532,191 @@ class PostgresExplainTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# CertExtensionFormatTests -- pin the format of
+# ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
+# the migration off pyOpenSSL's removed ``X509.get_extension(i)``
+# index loop. Each entry must keep the OpenSSL CLI ``v2i_GENERAL_NAME``
+# shape ("DNS:foo", "IP Address:1.2.3.4", "email:a@b", "URI:...")
+# so downstream consumers (``ivre.active.data.cert_lines``, the
+# ``ssl-cert`` script output renderer, etc.) keep working.
+# ---------------------------------------------------------------------
+
+
+try:
+    import datetime as _cert_datetime
+    import ipaddress as _cert_ipaddress
+
+    from cryptography import x509 as _cert_x509  # type: ignore[import-untyped]
+    from cryptography.hazmat.primitives import (
+        hashes as _cert_hashes,  # type: ignore[import-untyped]
+    )
+    from cryptography.hazmat.primitives import (
+        serialization as _cert_serialization,  # type: ignore[import-untyped]
+    )
+    from cryptography.hazmat.primitives.asymmetric import (
+        rsa as _cert_rsa,  # type: ignore[import-untyped]
+    )
+    from cryptography.x509.oid import (
+        NameOID as _cert_NameOID,  # type: ignore[import-untyped]
+    )
+
+    _HAVE_CRYPTOGRAPHY = True
+except ImportError:
+    _HAVE_CRYPTOGRAPHY = False
+
+try:
+    # ``cryptography`` alone is not enough -- ``ivre.utils.get_cert_info``
+    # is only defined when ``USE_PYOPENSSL`` is true.
+    from OpenSSL import (  # type: ignore[import-untyped] # noqa: F401
+        crypto as _cert_osslc,
+    )
+
+    _HAVE_PYOPENSSL = True
+except ImportError:
+    _HAVE_PYOPENSSL = False
+
+
+@unittest.skipUnless(
+    _HAVE_CRYPTOGRAPHY and _HAVE_PYOPENSSL,
+    "cryptography and pyOpenSSL are required for CertExtensionFormatTests",
+)
+class CertExtensionFormatTests(unittest.TestCase):
+    """Pin the SAN-string format produced by
+    ``ivre.utils.get_cert_info`` and the standalone
+    ``_format_san_general_name`` helper.
+
+    Background: pyOpenSSL 26.x removed ``X509.get_extension(i)``
+    (deprecated since 23.3); ``ivre.utils.get_cert_info`` used to
+    iterate that legacy API and call ``str(ext)`` to get the
+    ``"DNS:..., IP Address:..."`` text. The migration routes the
+    lookup through ``X509.to_cryptography()`` and rebuilds the
+    same strings from the typed ``GeneralName`` objects, so this
+    class pins each subtype's expected output shape and the
+    end-to-end ``get_cert_info(cert)["san"]`` list ordering.
+    """
+
+    @staticmethod
+    def _build_cert(general_names: "list") -> bytes:
+        """Build a self-signed DER cert with the given list of
+        ``cryptography.x509`` ``GeneralName`` objects in its
+        ``SubjectAlternativeName`` extension."""
+        key = _cert_rsa.generate_private_key(65537, 2048)
+        subject = issuer = _cert_x509.Name(
+            [_cert_x509.NameAttribute(_cert_NameOID.COMMON_NAME, "test.example.com")]
+        )
+        now = _cert_datetime.datetime.now(_cert_datetime.timezone.utc)
+        builder = (
+            _cert_x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(_cert_x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + _cert_datetime.timedelta(days=10))
+            .add_extension(
+                _cert_x509.SubjectAlternativeName(general_names), critical=False
+            )
+        )
+        cert = builder.sign(key, _cert_hashes.SHA256())
+        return cert.public_bytes(_cert_serialization.Encoding.DER)
+
+    def test_format_helper_dns(self) -> None:
+        from ivre.utils import _format_san_general_name
+
+        self.assertEqual(
+            _format_san_general_name(_cert_x509.DNSName("example.com")),
+            "DNS:example.com",
+        )
+
+    def test_format_helper_ipv4(self) -> None:
+        from ivre.utils import _format_san_general_name
+
+        self.assertEqual(
+            _format_san_general_name(
+                _cert_x509.IPAddress(_cert_ipaddress.IPv4Address("192.0.2.1"))
+            ),
+            "IP Address:192.0.2.1",
+        )
+
+    def test_format_helper_email(self) -> None:
+        from ivre.utils import _format_san_general_name
+
+        self.assertEqual(
+            _format_san_general_name(_cert_x509.RFC822Name("admin@example.com")),
+            "email:admin@example.com",
+        )
+
+    def test_format_helper_uri(self) -> None:
+        from ivre.utils import _format_san_general_name
+
+        self.assertEqual(
+            _format_san_general_name(
+                _cert_x509.UniformResourceIdentifier("https://example.com/")
+            ),
+            "URI:https://example.com/",
+        )
+
+    def test_format_helper_registered_id(self) -> None:
+        from ivre.utils import _format_san_general_name
+
+        self.assertEqual(
+            _format_san_general_name(
+                _cert_x509.RegisteredID(_cert_x509.ObjectIdentifier("1.2.3.4"))
+            ),
+            "Registered ID:1.2.3.4",
+        )
+
+    def test_get_cert_info_san_dns_and_ip(self) -> None:
+        from ivre import utils
+
+        if not utils.USE_PYOPENSSL:
+            self.skipTest("pyOpenSSL bindings unavailable in this build")
+        der = self._build_cert(
+            [
+                _cert_x509.DNSName("example.com"),
+                _cert_x509.DNSName("www.example.com"),
+                _cert_x509.IPAddress(_cert_ipaddress.IPv4Address("192.0.2.1")),
+            ]
+        )
+        info = utils.get_cert_info(der)
+        self.assertEqual(
+            info["san"],
+            [
+                "DNS:example.com",
+                "DNS:www.example.com",
+                "IP Address:192.0.2.1",
+            ],
+        )
+
+    def test_get_cert_info_san_missing(self) -> None:
+        # No SAN extension at all -> ``result`` must NOT contain
+        # the ``"san"`` key (downstream code uses ``"san" in info``
+        # as the presence check).
+        from ivre import utils
+
+        if not utils.USE_PYOPENSSL:
+            self.skipTest("pyOpenSSL bindings unavailable in this build")
+        # Build a SAN-less cert by overriding ``_build_cert`` inline.
+        key = _cert_rsa.generate_private_key(65537, 2048)
+        subject = issuer = _cert_x509.Name(
+            [_cert_x509.NameAttribute(_cert_NameOID.COMMON_NAME, "no-san.example")]
+        )
+        now = _cert_datetime.datetime.now(_cert_datetime.timezone.utc)
+        cert = (
+            _cert_x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(_cert_x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + _cert_datetime.timedelta(days=10))
+            .sign(key, _cert_hashes.SHA256())
+        )
+        info = utils.get_cert_info(cert.public_bytes(_cert_serialization.Encoding.DER))
+        self.assertNotIn("san", info)
+
+
+# ---------------------------------------------------------------------
 # PassiveDatetimeCoercionTests -- the ``/cgi/passive`` route's
 # datetime-to-timestamp helper must accept the three concrete
 # field shapes that show up in real datasets (datetime, numeric,

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1715,6 +1715,61 @@ class CertExtensionFormatTests(unittest.TestCase):
         info = utils.get_cert_info(cert.public_bytes(_cert_serialization.Encoding.DER))
         self.assertNotIn("san", info)
 
+    def test_get_cert_info_continues_when_to_cryptography_raises(self) -> None:
+        """If ``X509.to_cryptography()`` raises -- because
+        ``cryptography``'s strict ASN.1 parser rejects a malformed
+        but pyOpenSSL-tolerated cert (real-world examples include
+        ``InvalidVersion: 3 is not a valid X509 version``,
+        ``ParseError ... Time::UtcTime``, ``BasicConstraints::ca``
+        ``EncodedDefault``) -- the SAN lookup must be skipped
+        without aborting the rest of ``get_cert_info``.
+
+        Critical invariant: ``result["pubkey"]["exponent"]`` and
+        ``result["pubkey"]["modulus"]`` must still be populated
+        for RSA keys, because ``ivre getmoduli`` (the consumer
+        exercised by ``test_30_nmap`` in ``tests/tests.py``)
+        reads ``key["exponent"]`` and crashes with ``KeyError`` on
+        a missing field.
+        """
+        from unittest import mock
+
+        from ivre import utils
+
+        if not utils.USE_PYOPENSSL:
+            self.skipTest("pyOpenSSL bindings unavailable in this build")
+        der = self._build_cert([_cert_x509.DNSName("example.com")])
+        # Patch ``X509.to_cryptography`` at the class level so the
+        # call inside ``get_cert_info`` raises the same ``ValueError``
+        # the strict ``cryptography`` ASN.1 parser would emit on a
+        # malformed real-world cert.
+        with mock.patch.object(
+            _cert_osslc.X509,
+            "to_cryptography",
+            side_effect=ValueError(
+                "simulated cryptography ASN.1 parse error on malformed cert"
+            ),
+        ):
+            info = utils.get_cert_info(der)
+        # SAN absent (lookup failed and was skipped).
+        self.assertNotIn("san", info)
+        # Pubkey block fully populated -- this is the field
+        # ``getmoduli`` requires.
+        self.assertIn("pubkey", info)
+        self.assertIn("type", info["pubkey"])
+        self.assertEqual(info["pubkey"]["type"], "rsa")
+        self.assertIn("exponent", info["pubkey"])
+        self.assertIn("modulus", info["pubkey"])
+        self.assertIn("bits", info["pubkey"])
+        # Subject / issuer / serial / dates also recovered.
+        # ``_parse_subject`` maps short OIDs (``CN``) to their long
+        # form (``commonName``) via the ``_CERTKEYS`` table and joins
+        # components with ``/``; for a single-component DN there is
+        # no leading ``/``.
+        self.assertEqual(info["subject_text"], "commonName=test.example.com")
+        self.assertEqual(info["issuer_text"], "commonName=test.example.com")
+        self.assertIn("serial_number", info)
+        self.assertIn("version", info)
+
 
 # ---------------------------------------------------------------------
 # PassiveDatetimeCoercionTests -- the ``/cgi/passive`` route's

--- a/uv.lock
+++ b/uv.lock
@@ -786,7 +786,7 @@ requires-dist = [
     { name = "pycurl", marker = "extra == 'gssapi-http'" },
     { name = "pylint", marker = "extra == 'linting'" },
     { name = "pymongo", specifier = ">=4.10" },
-    { name = "pyopenssl", specifier = ">=16.1.0" },
+    { name = "pyopenssl", specifier = ">=17.1.0" },
     { name = "regexploit", specifier = ">=1.0,<2" },
     { name = "rstcheck", extras = ["sphinx"], marker = "extra == 'linting'" },
     { name = "scapy", marker = "extra == 'ja3'" },


### PR DESCRIPTION
pyOpenSSL 23.3 deprecated ``X509.get_extension(i)`` / ``X509.get_extension_count()`` (pyOpenSSL #1247) and 26.x removed ``get_extension(i)`` outright. Hosted MongoDB CI runners that resolve a recent pyOpenSSL via pip pick up 26.x and crash out of every cert ingestion with::

  File ".../ivre/utils.py", line 2255, in get_cert_info
      ext = data.get_extension(i)
  AttributeError: 'X509' object has no attribute 'get_extension'.
                  Did you mean: 'get_version'?

The exception is caught by ``passive2db`` / ``zgrabout`` / ``view`` ingestion's broad ``try/except`` wrappers, but every cert silently loses its ``info`` payload and ``"san"`` field; the resulting MongoDB tests fail with discrepancies like ``check_value() fail for nmap_domain_com_count: got 60, expected 64`` (= the four hosts whose count comes from a SAN match) and ``test_55_view_delete: StopIteration`` on a record that was never inserted.

Fix
===

Route the SAN lookup through ``X509.to_cryptography()`` (added in pyOpenSSL 17.1, the new pin floor) and use the
``cryptography`` library's typed extension API:

  san_ext = data.to_cryptography().extensions.get_extension_for_class(
      x509.SubjectAlternativeName
  )

Each ``GeneralName`` in the extension is mapped back to the ``v2i_GENERAL_NAME``-style string the legacy
``str(<X509Extension>)`` used to emit (``"DNS:..."``, ``"IP Address:..."``, ``"email:..."``, ``"URI:..."``, ``"DirName:..."``, ``"Registered ID:..."``, ``"othername:..."``) so downstream consumers (``ivre.active.data.cert_lines``, the HTTP API filter on ``infos.san``, etc.) see the exact same string list the previous implementation produced. The ``ExtensionNotFound`` branch leaves ``result["san"]`` absent -- matching the legacy "no SAN extension found, key not set" behaviour.

The ``get_cert_info`` non-pyOpenSSL fallback at
``ivre/utils.py:~2316`` (which parses ``openssl x509 -text`` output via the ``_CERTINFOS_EXT_SAN`` regex) is unchanged.

Pin bump
========

``pyOpenSSL>=16.1.0`` -> ``pyOpenSSL>=17.1.0`` in
``pyproject.toml`` and ``uv.lock``. ``X509.to_cryptography`` landed in 17.1 (July 2017, eight years ago), so the floor bump is trivially safe.

Tests
=====

Adds ``CertExtensionFormatTests`` to ``tests_no_backend.py`` (7 cases, skipped when ``cryptography`` or pyOpenSSL is absent). Pins:

  - ``_format_san_general_name`` for each ``GeneralName`` subtype produced by ``ivre`` (DNS, IPv4, email, URI, Registered OID).
  - ``get_cert_info(cert)["san"]`` end-to-end on a synthetic cert built via ``cryptography.x509.CertificateBuilder`` -- list ordering and per-entry string format.
  - Missing-SAN case: ``"san"`` key absent (not ``None``, not ``[]``) so the existing ``"san" in info`` presence checks (``ivre/active/data.py:101``, ``ivre/active/data.py:187``) keep working.

Verified
========

  - ``pkg/runchecks`` clean across all 13 checks.
  - ``CertExtensionFormatTests`` 7/7 pass on pyOpenSSL 26.2.0 (the version that triggered the CI failure) AND pyOpenSSL 26.0.0.
  - Full ``tests_no_backend`` suite: 144/145 (the lone failure is the pre-existing ``test_utils`` timezone test, unrelated and out of scope).

The MongoDB CI matrix should now go green on every pyOpenSSL >= 26.x runner.