### PR TITLE
refactor(db/sql): extract _search_field helper; migrate SQLDBNmap.searchsource

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -531,6 +531,53 @@ class SQLDB(DB):
             return field != value
         return field == value
 
+    @classmethod
+    def _search_field(cls, field, value, neg=False, map_=None):
+        """Build a positive (``neg=False``) or negative equality
+        clause for a single SQL column given a scalar, list, or
+        compiled regex value. Encapsulates the scalar / list /
+        regex dispatch shared by the various ``searchXXX``
+        helpers on the SQL backends.
+
+        Mirrors :meth:`MongoDB._search_field` so a caller that
+        moves between backends sees the same accept-shape for
+        ``value``. For list values, a single-element list
+        collapses to scalar form (``field == v``) instead of
+        emitting a redundant ``IN ('v')`` -- matching the wire
+        shape Mongo's helper produces.
+
+        ``map_`` is an optional per-element coercion (default
+        ``None`` / identity). Used by ``searchasnum`` to
+        stringify integer AS numbers stored as text in the
+        JSONB-as-text column. ``map_`` and a regex value are
+        mutually exclusive (a compiled pattern has nothing for
+        a per-element coercion to operate on); passing both
+        raises ``TypeError``.
+
+        Declared as ``@classmethod`` so a backend-specific
+        subclass (e.g. a future SQLite backend) can replace the
+        regex-operator dispatch by overriding
+        ``_searchstring_re`` without touching every caller.
+        """
+        if isinstance(value, utils.REGEXP_T):
+            if map_ is not None:
+                raise TypeError(
+                    "_search_field: map_ is incompatible with a regex value"
+                )
+            return cls._searchstring_re(field, value, neg=neg)
+        if not isinstance(value, str) and hasattr(value, "__iter__"):
+            if map_ is not None:
+                value = [map_(elt) for elt in value]
+            else:
+                value = list(value)
+            if len(value) == 1:
+                value = value[0]
+            else:
+                return field.notin_(value) if neg else field.in_(value)
+        elif map_ is not None:
+            value = map_(value)
+        return field != value if neg else field == value
+
     @staticmethod
     def _searchstring_list(field, value, neg=False, map_=None):
         if not isinstance(value, str) and hasattr(value, "__iter__"):
@@ -2471,12 +2518,8 @@ class SQLDBNmap(SQLDBActive, DBNmap):
 
     @classmethod
     def searchsource(cls, src, neg=False):
-        if isinstance(src, list):
-            if neg:
-                return cls.base_filter(main=cls.tables.scan.source.notin_(src))
-            return cls.base_filter(main=cls.tables.scan.source.in_(src))
         return cls.base_filter(
-            main=cls._searchstring_re(cls.tables.scan.source, src, neg=neg)
+            main=cls._search_field(cls.tables.scan.source, src, neg=neg)
         )
 
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1595,6 +1595,156 @@ class PostgresExplainTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBSearchFieldTests -- pin the shared ``_search_field``
+# dispatch on the SQL backends and the wire shape of the
+# search methods that delegate to it. Mirrors
+# ``MongoDBSearchFieldTests`` /
+# ``ElasticDBSearchFieldTests`` so a reader sees a
+# consistent helper-shape across all three backends.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` extras)",
+)
+class SQLDBSearchFieldTests(unittest.TestCase):
+    """Behaviour-pin for ``ivre.db.sql.SQLDB._search_field``
+    and the ``SQLDBNmap.searchsource`` migration that delegates
+    to it.
+
+    The previous implementation hand-rolled a scalar / list /
+    regex ladder per call site (round-2 SQL audit follow-up
+    flagged ``SQLDBNmap.searchsource``). The shared helper
+    matches the wire-shape contract of
+    :meth:`MongoDB._search_field` so a regex / list / scalar
+    accept-shape is identical across backends, with one
+    deliberate change vs. the legacy SQL ladder: a
+    single-element list now collapses to ``field = 'A'``
+    instead of emitting ``field IN ('A')``. The two forms have
+    identical query plans on PostgreSQL.
+    """
+
+    @staticmethod
+    def _compile(clause):
+        # Inline binds via the PostgreSQL dialect so the
+        # rendered string is human-readable and stable across
+        # SA versions (1.4 / 2.0).
+        return str(
+            clause.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _scan_source_column():
+        sa = _sqlalchemy
+        meta = sa.MetaData()
+        scan = sa.Table("scan", meta, sa.Column("source", sa.String))
+        return scan.c.source
+
+    def _SQLDB(self):  # noqa: N802 -- factory accessor
+        from ivre.db.sql import SQLDB
+
+        return SQLDB
+
+    def test_scalar_positive(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, "X"))
+        self.assertEqual(sql, "scan.source = 'X'")
+
+    def test_scalar_negative(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, "X", neg=True))
+        self.assertEqual(sql, "scan.source != 'X'")
+
+    def test_list_positive(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, ["A", "B"]))
+        self.assertEqual(sql, "scan.source IN ('A', 'B')")
+
+    def test_list_negative(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, ["A", "B"], neg=True))
+        # SQLAlchemy parenthesises NOT IN; assert on the
+        # SQL primitive instead of strict equality so the
+        # exact parenthesisation is not over-pinned.
+        self.assertIn("NOT IN", sql)
+        self.assertIn("('A', 'B')", sql)
+
+    def test_list_of_one_collapses_to_scalar(self):
+        # Behaviour change vs. legacy ``searchsource``: a
+        # single-element list now emits ``= 'A'`` not
+        # ``IN ('A')``. PG plans them identically; the
+        # rewrite matches Mongo / Elastic semantics.
+        col = self._scan_source_column()
+        self.assertEqual(
+            self._compile(self._SQLDB()._search_field(col, ["A"])),
+            "scan.source = 'A'",
+        )
+        self.assertEqual(
+            self._compile(self._SQLDB()._search_field(col, ["A"], neg=True)),
+            "scan.source != 'A'",
+        )
+
+    def test_regex_positive(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, re.compile("^foo")))
+        self.assertEqual(sql, "scan.source ~ '^foo'")
+
+    def test_regex_case_insensitive(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, re.compile("^foo", re.I)))
+        # PostgreSQL ``~*`` is the case-insensitive POSIX-regex
+        # operator (vs. ``~`` for case-sensitive).
+        self.assertEqual(sql, "scan.source ~* '^foo'")
+
+    def test_regex_negative(self):
+        col = self._scan_source_column()
+        sql = self._compile(
+            self._SQLDB()._search_field(col, re.compile("^foo"), neg=True)
+        )
+        self.assertIn("NOT", sql)
+        self.assertIn("scan.source ~ '^foo'", sql)
+
+    def test_map_scalar(self):
+        # ``map_=str`` mirrors ``SQLDBActive.searchasnum`` --
+        # AS numbers are stored as text, callers pass ints.
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, 1234, map_=str))
+        self.assertEqual(sql, "scan.source = '1234'")
+
+    def test_map_list(self):
+        col = self._scan_source_column()
+        sql = self._compile(self._SQLDB()._search_field(col, [1, 2, 3], map_=str))
+        self.assertEqual(sql, "scan.source IN ('1', '2', '3')")
+
+    def test_map_with_regex_raises(self):
+        # ``map_`` is an element-wise coercion; pairing it with
+        # a compiled regex pattern is undefined and rejected
+        # explicitly so callers don't get silently-broken
+        # filters at query time.
+        col = self._scan_source_column()
+        with self.assertRaises(TypeError):
+            self._SQLDB()._search_field(col, re.compile("foo"), map_=str)
+
+    def test_searchsource_nmap_delegates_to_helper(self):
+        # End-to-end: the ``SQLDBNmap.searchsource`` migration
+        # produces the same SQL as a direct
+        # ``_search_field`` call on the ``scan.source`` column.
+        # We compare the two ``.main`` clauses bit-for-bit so
+        # the round-2 follow-up is pinned end-to-end.
+        from ivre.db.sql import SQLDBNmap
+
+        nmap_filter = SQLDBNmap.searchsource(["A", "B"], neg=True)
+        direct = SQLDBNmap._search_field(
+            SQLDBNmap.tables.scan.source, ["A", "B"], neg=True
+        )
+        self.assertEqual(self._compile(nmap_filter.main), self._compile(direct))
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Mirror the round-2 ``MongoDB._search_field`` extraction (#1808) and the matching ``ElasticDB._search_field`` migration (#1812) on the SQL backends. Factor the canonical scalar / list / regex ladder into a single classmethod on ``SQLDB`` and reduce the hand-rolled ladder in ``SQLDBNmap.searchsource`` (round-2 audit follow-up) to a one-line delegation.

Helper
======

``ivre.db.sql.SQLDB._search_field(field, value, neg=False, map_=None)`` handles the four input shapes the IVRE web filter language can produce:

  - regex (``utils.REGEXP_T``)         -> delegates to
                                          ``_searchstring_re``
                                          (PG ``~`` / ``~*``,
                                          ``not_(...)`` for neg).
  - list of length one                 -> collapses to scalar
                                          (``field == v``).
  - list of more elements              -> ``field.in_`` /
                                          ``field.notin_``.
  - scalar                             -> ``field == v`` /
                                          ``field != v``.

``map_`` is an optional per-element coercion (default ``None`` / identity); it is what ``SQLDBActive.searchasnum`` already uses to stringify integer AS numbers stored as text in the JSONB-as-text column. ``map_`` paired with a regex value is rejected explicitly with ``TypeError`` (a compiled pattern has no per-element handle to coerce).

The helper mirrors :meth:`MongoDB._search_field` so a caller that moves between backends sees the same accept-shape for ``value``.

Behaviour change
================

The legacy ``SQLDBNmap.searchsource`` ladder emitted ``field IN ('A')`` for a single-element list. The new helper collapses to ``field = 'A'`` -- matching Mongo / Elastic semantics. The two SQL forms have identical query plans on PostgreSQL (verified via ``EXPLAIN``); the wire shape change is therefore lossless. Pinned by
``test_list_of_one_collapses_to_scalar``.

Migration
=========

  - ``SQLDBNmap.searchsource`` (8 lines -> 4): one-line delegation. The view (``SQLDBView.searchsource``, array column) already uses ``_searchstring_re_inarray`` -- the only regex-aware helper that handles array columns; left untouched. The passive (``SQLDBPassive.searchsource``) delegates to ``searchrecontype`` -- left untouched.

Out of scope (deferred)
=======================

``_searchstring_list`` callers (``SQLDBActive.searchcountry``, ``SQLDBActive.searchasnum``) could also migrate, transparently widening their API to accept regex patterns. Two callers, two small migrations -- a follow-up PR if useful, not required by the audit.

Tests
=====

``tests_no_backend.SQLDBSearchFieldTests`` (12 cases, skipped when ``sqlalchemy`` is unavailable). Mirrors
``MongoDBSearchFieldTests`` /
``ElasticDBSearchFieldTests``:

  - 6 dispatch shapes: scalar / list / list-of-one with both polarities.
  - 3 regex shapes: positive / case-insensitive / negative.
  - 2 ``map_`` shapes: scalar coercion / list coercion.
  - 1 mutual-exclusion check: ``map_`` + regex -> TypeError.
  - 1 end-to-end: ``SQLDBNmap.searchsource(["A", "B"], neg=True)`` compiles to the same SQL as a direct ``SQLDB._search_field(scan.source, ["A", "B"], neg=True)``.

The compile path uses ``literal_binds=True`` against the PostgreSQL dialect so the rendered SQL is human-readable and stable across SA 1.4 / 2.0; the helper itself is dialect- agnostic at the construction layer.

Verified
========

  - ``SQLDBSearchFieldTests`` 12/12 pass on SQLA 2.0.49.
  - Full ``tests_no_backend``: 160/161 (sole failure is the pre-existing ``test_utils`` timezone test, unrelated).
  - ``pkg/runchecks`` clean across all 13 checks.