### PR TITLE
refactor(db/sql): migrate _searchstring_list callers to _search_field; drop dead helper

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -578,20 +578,6 @@ class SQLDB(DB):
             value = map_(value)
         return field != value if neg else field == value
 
-    @staticmethod
-    def _searchstring_list(field, value, neg=False, map_=None):
-        if not isinstance(value, str) and hasattr(value, "__iter__"):
-            if map_ is not None:
-                value = [map_(elt) for elt in value]
-            if neg:
-                return field.notin_(value)
-            return field.in_(value)
-        if map_ is not None:
-            value = map_(value)
-        if neg:
-            return field != value
-        return field == value
-
     @classmethod
     def _searchcert(
         cls,
@@ -2610,7 +2596,7 @@ class SQLDBView(SQLDBActive, DBView):
         """
         country = utils.country_unalias(country)
         return cls.base_filter(
-            main=cls._searchstring_list(
+            main=cls._search_field(
                 cls.tables.scan.info["country_code"].astext, country, neg=neg
             )
         )
@@ -2634,7 +2620,7 @@ class SQLDBView(SQLDBActive, DBView):
 
         """
         return cls.base_filter(
-            main=cls._searchstring_list(
+            main=cls._search_field(
                 cls.tables.scan.info["as_num"], asnum, neg=neg, map_=str
             )
         )

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1743,6 +1743,46 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         )
         self.assertEqual(self._compile(nmap_filter.main), self._compile(direct))
 
+    def test_searchcountry_view_delegates_to_helper(self):
+        # ``SQLDBView.searchcountry`` migrated from the legacy
+        # ``_searchstring_list`` helper to the unified
+        # ``_search_field`` helper. The migration is internal:
+        # same accept-shape (scalar / list -- regex is rejected
+        # earlier in the pipeline by ``utils.country_unalias``),
+        # same emitted SQL, just routed through one helper. Pin
+        # both list and scalar paths bit-for-bit against direct
+        # ``_search_field`` calls.
+        from ivre.db.sql import SQLDBView
+
+        col = SQLDBView.tables.scan.info["country_code"].astext
+        # ``country_unalias`` is the identity on uppercase
+        # 2-letter codes, so the comparison is bit-for-bit.
+        for value in ("FR", ["FR", "DE"], ["FR"]):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    self._compile(SQLDBView.searchcountry(value).main),
+                    self._compile(SQLDBView._search_field(col, value)),
+                )
+
+    def test_searchasnum_view_preserves_str_coercion(self):
+        # ``SQLDBView.searchasnum`` historically called
+        # ``_searchstring_list(map_=str)`` to stringify integer
+        # AS numbers stored in the JSONB-as-text
+        # ``info.as_num`` column. The migration to
+        # ``_search_field(map_=str)`` must preserve this:
+        # callers passing an int / list-of-int still produce
+        # quoted-string clauses.
+        from ivre.db.sql import SQLDBView
+
+        # Scalar int.
+        sql = self._compile(SQLDBView.searchasnum(1234).main)
+        # The JSONB getitem expression on the LHS quotes the
+        # key, so we only assert on the RHS literal.
+        self.assertIn("'1234'", sql)
+        # List of ints.
+        sql = self._compile(SQLDBView.searchasnum([1, 2, 3]).main)
+        self.assertIn("'1', '2', '3'", sql)
+
 
 # ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of


### PR DESCRIPTION
Follow-up to commit ``29e14d5b`` (``_search_field`` helper + ``SQLDBNmap.searchsource`` migration). The two remaining ``_searchstring_list`` callers
(``SQLDBView.searchcountry`` / ``SQLDBView.searchasnum``) now also delegate to the unified helper, removing the last caller of ``_searchstring_list``. The helper itself becomes dead code and is dropped.

Migration is purely internal: same accept-shape (scalar / list with optional ``map_``), same emitted SQL, just routed through one helper instead of two. ``_search_field`` is a strict superset of ``_searchstring_list``'s behaviour for the inputs these two callers actually pass:

  - regex paths are not exposed through these methods -- ``country_unalias`` rejects regex up front for ``searchcountry``, and ``map_=str`` + regex raises ``TypeError`` (helper-level mutual exclusion) for ``searchasnum``. So neither caller's API widens.
  - list / scalar / list-of-1 dispatch is identical, with one wire-shape consequence pinned by the prior commit: a single-element list now collapses to ``= 'A'`` instead of ``IN ('A')``. Identical PG plan.

Sites
=====

  - ``SQLDBView.searchcountry`` (1 line changed): ``cls._searchstring_list(...)`` -> ``cls._search_field(...)``.

  - ``SQLDBView.searchasnum`` (1 line changed): same, with ``map_=str`` preserved.

  - ``SQLDB._searchstring_list`` (13 lines deleted): no callers remain, helper removed.

Tests
=====

Two new pinning tests in
``tests_no_backend.SQLDBSearchFieldTests``:

  - ``test_searchcountry_view_delegates_to_helper``: asserts that ``SQLDBView.searchcountry(value)`` and ``SQLDBView._search_field(country_code_col, value)`` compile to the same SQL for scalar / multi-list / single-element-list inputs. ``country_unalias`` is the identity on uppercase 2-letter codes, so the comparison is bit-for-bit.

  - ``test_searchasnum_view_preserves_str_coercion``: asserts that scalar int (``1234``) and list of ints (``[1, 2, 3]``) still emit quoted-string clauses (``'1234'`` / ``'1', '2', '3'``) -- the JSONB-as-text ``info.as_num`` column requires the str coercion that ``map_=str`` provides.

Verified
========

  - ``SQLDBSearchFieldTests`` 14/14 (was 12/12) pass on SQLA 2.0.49.
  - Full ``tests_no_backend``: 162/163 (sole failure is the pre-existing ``test_utils`` timezone test, unrelated).
  - ``pkg/runchecks`` clean across all 13 checks.
  - ``rg _searchstring_list`` returns no hits anywhere in the tree.