### PR TITLE
feat(db/sql): _searchstring_re_inarray supports neg=True for regex values

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -502,9 +502,6 @@ class SQLDB(DB):
     @staticmethod
     def _searchstring_re_inarray(idfield, field, value, neg=False):
         if isinstance(value, utils.REGEXP_T):
-            if neg:
-                # FIXME
-                raise ValueError("Not implemented")
             operator = "~*" if (value.flags & re.IGNORECASE) else "~"
             value = value.pattern
             base1 = select(idfield.label("id"), func.unnest(field).label("field")).cte(
@@ -515,6 +512,15 @@ class SQLDB(DB):
                 .select_from(base1)
                 .where(column("field").op(operator)(value))
             )
+            # ``base2`` is the set of row-ids whose array contains
+            # at least one element matching the regex. Positive
+            # selects those ids; negative selects everything else
+            # -- rows whose array has zero matching elements,
+            # plus rows with empty or NULL arrays. Matches the
+            # ``not_(field.any(value)) if neg`` shape on the
+            # scalar-value path below.
+            if neg:
+                return idfield.notin_(base2)
             return idfield.in_(base2)
         return not_(field.any(value)) if neg else field.any(value)
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1900,6 +1900,83 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         positive, _clause = flt.tag[0]
         self.assertFalse(positive)
 
+    def test_searchstring_re_inarray_regex_positive(self):
+        # ``SQLDB._searchstring_re_inarray`` over an array column
+        # with a regex value returns ``idfield IN (subquery)``
+        # where the subquery unnests the array and filters on the
+        # regex match. The PostgreSQL ``~`` operator (``~*`` for
+        # case-insensitive) is the regex matcher.
+        sa = _sqlalchemy
+        from ivre.db.sql import SQLDB
+
+        meta = sa.MetaData()
+        scan = sa.Table(
+            "scan",
+            meta,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column(
+                "source", _sqlalchemy_postgresql.ARRAY(sa.String), nullable=False
+            ),
+        )
+        clause = SQLDB._searchstring_re_inarray(
+            scan.c.id, scan.c.source, re.compile("^source-")
+        )
+        sql = self._compile(clause)
+        self.assertIn("scan.id IN", sql)
+        self.assertIn("WHERE field ~ '^source-'", sql)
+
+    def test_searchstring_re_inarray_regex_negative(self):
+        # M4.0.3: the negative regex path used to ``raise
+        # ValueError("Not implemented")``. The fix mirrors the
+        # positive form via ``idfield.notin_(base2)``: rows whose
+        # array contains zero elements matching the regex (plus
+        # rows with empty or NULL arrays) match. Pin the SQL
+        # primitive so any future rewrite preserves the
+        # contract.
+        sa = _sqlalchemy
+        from ivre.db.sql import SQLDB
+
+        meta = sa.MetaData()
+        scan = sa.Table(
+            "scan",
+            meta,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column(
+                "source", _sqlalchemy_postgresql.ARRAY(sa.String), nullable=False
+            ),
+        )
+        clause = SQLDB._searchstring_re_inarray(
+            scan.c.id, scan.c.source, re.compile("^source-"), neg=True
+        )
+        sql = self._compile(clause)
+        # ``NOT IN`` (with parentheses inserted by SA) over the
+        # subquery built from the unnest CTE.
+        self.assertIn("NOT IN", sql)
+        self.assertIn("WHERE field ~ '^source-'", sql)
+
+    def test_searchstring_re_inarray_regex_negative_case_insensitive(self):
+        # Case-insensitive regex (``re.I``) must use the
+        # PostgreSQL ``~*`` operator for the unnest filter, with
+        # the negative path still wrapping in ``NOT IN``.
+        sa = _sqlalchemy
+        from ivre.db.sql import SQLDB
+
+        meta = sa.MetaData()
+        scan = sa.Table(
+            "scan",
+            meta,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column(
+                "source", _sqlalchemy_postgresql.ARRAY(sa.String), nullable=False
+            ),
+        )
+        clause = SQLDB._searchstring_re_inarray(
+            scan.c.id, scan.c.source, re.compile("^source-", re.I), neg=True
+        )
+        sql = self._compile(clause)
+        self.assertIn("NOT IN", sql)
+        self.assertIn("WHERE field ~* '^source-'", sql)
+
 
 # ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of


### PR DESCRIPTION
Implement the negative-regex branch of
`SQLDB._searchstring_re_inarray` (`ivre/db/sql/__init__.py:503`). The previous code raised `ValueError("Not implemented")` with a FIXME marker; callers passing a compiled regex with `neg=True` hit the error.

The fix mirrors the positive form: build the same unnest CTE that collects row ids whose array column has at least one element matching the regex, then negate selection via `idfield.notin_(base2)` instead of `idfield.in_(base2)`. Rows whose array contains zero matching elements -- including rows with empty or NULL arrays -- match. This matches the contract on the scalar-value branch (`not_(field.any(value)) if neg`) below.

The PostgreSQL operator (`~` for case-sensitive, `~*` for case-insensitive) is unchanged; only the wrapper around the subquery flips polarity.

Tests
=====

Three new pinning tests in
`tests_no_backend.SQLDBSearchFieldTests`:

  - `test_searchstring_re_inarray_regex_positive`: pins the rendered SQL for the existing positive-regex path (`scan.id IN (...)` over the unnest CTE).
  - `test_searchstring_re_inarray_regex_negative`: the new negative-regex path renders `NOT IN` over the same unnest CTE.
  - `test_searchstring_re_inarray_regex_negative_case_insensitive`: case-insensitive regex (`re.I`) uses `~*` and still wraps in `NOT IN`.

Verified
========

  - `SQLDBSearchFieldTests` 17/17 (was 14/14) pass on SQLA 2.0.49.
  - Full `tests_no_backend`: 165/166 (sole failure is the pre-existing `test_utils` timezone test, unrelated).
  - `pkg/runchecks` clean across all 13 checks.

Removes the lone `raise ValueError` from this helper; clears one of the latent FIXMEs in the SQL backend abstract surface.