### PR TITLE
docs(db/sql): retarget the _search_field docstring at the future DuckDB backend

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -555,7 +555,7 @@ class SQLDB(DB):
         raises ``TypeError``.
 
         Declared as ``@classmethod`` so a backend-specific
-        subclass (e.g. a future SQLite backend) can replace the
+        subclass (e.g. a future DuckDB backend) can replace the
         regex-operator dispatch by overriding
         ``_searchstring_re`` without touching every caller.
         """


### PR DESCRIPTION
The docstring example at `ivre/db/sql/__init__.py:558` referenced a "future SQLite backend" -- a forward-looking note added when the helper was introduced (commit 29e14d5b / PR #1815). The SQLite backend was dropped in PR #1790 (commit 8f001007); the file-based tier slot is now scheduled to be filled by DuckDB.

Update the comment to reflect the actual future shape so a reader walking the SQL helper hierarchy is pointed at the right direction. No code change.

Verified: `pkg/runchecks` clean across all 13 checks.