### PR TITLE
feat(db/sql/passive): add SQLDBPassive.searchja4client (parity with Mongo)

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -3529,6 +3529,14 @@ class SQLDBPassive(SQLDB, DBPassive):
                     base &= (
                         cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == r_c_raw
                     )
+                    # ``== ""`` builds a SQL ``= ''`` clause, not
+                    # a Python boolean check; disable pylint's
+                    # implicit-booleaness suggestion (would invert
+                    # the SA BinaryExpression's polarity). The
+                    # disable goes on the line where the
+                    # comparison's left operand sits, which is
+                    # where pylint attributes the message.
+                    # pylint: disable-next=use-implicit-booleaness-not-comparison-to-string
                     base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == ""
             except (KeyError, ValueError, IndexError):
                 utils.LOGGER.warning("Invalid JA4 raw value %r", raw, exc_info=True)
@@ -3547,6 +3555,11 @@ class SQLDBPassive(SQLDB, DBPassive):
                 base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == c2
             else:
                 base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == ja4_c_raw
+                # ``== ""`` builds a SQL ``= ''`` clause; see the
+                # comment above the matching line in the ``raw``
+                # branch for why pylint's implicit-booleaness
+                # suggestion is wrong here.
+                # pylint: disable-next=use-implicit-booleaness-not-comparison-to-string
                 base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == ""
         if ja4_c1_raw is not None:
             base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == ja4_c1_raw

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -3457,6 +3457,104 @@ class SQLDBPassive(SQLDB, DBPassive):
         )
 
     @classmethod
+    def searchja4client(
+        cls,
+        value=None,
+        raw=None,
+        ja4_a=None,
+        ja4_b=None,
+        ja4_c=None,
+        ja4_b_raw=None,
+        ja4_c_raw=None,
+        ja4_c1_raw=None,
+        ja4_c2_raw=None,
+        neg=False,
+    ):
+        """SQL passive equivalent of
+        :meth:`MongoDBPassive.searchja4client`.
+
+        Filters the passive store for JA4 client fingerprint records
+        (``recontype == "SSL_CLIENT"``, ``source == "ja4"``). Each
+        component is matched against the relevant
+        ``moreinfo`` JSONB key:
+
+          - ``value`` matches ``passive.value`` directly. If passed
+            as a string in the canonical
+            ``ja4_a_ja4_b_ja4_c`` form, the indexed components
+            are also extracted and constrained.
+          - ``raw`` is split into ``ja4_a`` /
+            ``ja4_b_raw`` / ``ja4_c1_raw`` /
+            ``ja4_c2_raw`` along the same scheme.
+          - The individual ``ja4_*`` parameters bypass parsing
+            and constrain a single JSON key each.
+
+        ``neg=True`` wraps the whole condition in ``not_(...)``.
+        """
+        base = (cls.tables.passive.recontype == "SSL_CLIENT") & (
+            cls.tables.passive.source == "ja4"
+        )
+        if value is not None:
+            base &= cls.tables.passive.value == value
+            # Also constrain the indexed ja4_* components when
+            # ``value`` is the canonical 10-char-prefix form.
+            # ``isinstance(value, str)`` mirrors the Mongo guard
+            # (``MongoDBPassive.searchja4client`` at
+            # ``mongo.py:5672``); a regex / list value is left
+            # to the equality check above.
+            if isinstance(value, str):
+                try:
+                    if value[10] != "_":
+                        raise ValueError()
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_a") == value[:10]
+                    v_b, v_c = value[11:].split("_", 1)
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_b") == v_b
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_c") == v_c
+                except (KeyError, ValueError, IndexError):
+                    utils.LOGGER.warning("Invalid JA4 value %r", value, exc_info=True)
+        if raw is not None:
+            try:
+                if raw[10] != "_":
+                    raise ValueError()
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_a") == raw[:10]
+                # Split ``raw[11:]`` into ``ja4_b_raw`` and
+                # ``ja4_c_raw``; ``ja4_c_raw`` may further split
+                # into ``ja4_c1_raw`` / ``ja4_c2_raw``.
+                r_b, r_c_raw = raw[11:].split("_", 1)
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_b_raw") == r_b
+                if "_" in r_c_raw:
+                    c1, c2 = r_c_raw.split("_", 1)
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == c1
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == c2
+                else:
+                    base &= (
+                        cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == r_c_raw
+                    )
+                    base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == ""
+            except (KeyError, ValueError, IndexError):
+                utils.LOGGER.warning("Invalid JA4 raw value %r", raw, exc_info=True)
+        if ja4_a is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_a") == ja4_a
+        if ja4_b is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_b") == ja4_b
+        if ja4_c is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_c") == ja4_c
+        if ja4_b_raw is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_b_raw") == ja4_b_raw
+        if ja4_c_raw is not None:
+            if "_" in ja4_c_raw:
+                c1, c2 = ja4_c_raw.split("_", 1)
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == c1
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == c2
+            else:
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == ja4_c_raw
+                base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == ""
+        if ja4_c1_raw is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_c1_raw") == ja4_c1_raw
+        if ja4_c2_raw is not None:
+            base &= cls.tables.passive.moreinfo.op("->>")("ja4_c2_raw") == ja4_c2_raw
+        return PassiveFilter(main=not_(base) if neg else base)
+
+    @classmethod
     def searchsshkey(cls, fingerprint=None, key=None, keytype=None, bits=None):
         cnd = (cls.tables.passive.recontype == "SSH_SERVER_HOSTKEY") & (
             cls.tables.passive.source == "SSHv2"

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1783,6 +1783,63 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         sql = self._compile(SQLDBView.searchasnum([1, 2, 3]).main)
         self.assertIn("'1', '2', '3'", sql)
 
+    def test_searchja4client_passive_canonical_value(self):
+        # M4.0.4: ``SQLDBPassive.searchja4client`` mirrors
+        # ``MongoDBPassive.searchja4client`` (mongo.py:5655).
+        # Passing the canonical string form
+        # (``ja4_a_ja4_b_ja4_c``) must split out the indexed
+        # components and constrain each via the
+        # ``moreinfo`` JSONB column.
+        from ivre.db.sql import SQLDBPassive
+
+        flt = SQLDBPassive.searchja4client(value="t13d1715h2_5b57614c22b0_93c9c6ee0ce4")
+        sql = self._compile(flt.main)
+        self.assertIn("passive.recontype = 'SSL_CLIENT'", sql)
+        self.assertIn("passive.source = 'ja4'", sql)
+        self.assertIn("passive.value = 't13d1715h2_5b57614c22b0_93c9c6ee0ce4'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_b') = '5b57614c22b0'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_c') = '93c9c6ee0ce4'", sql)
+
+    def test_searchja4client_passive_individual_components(self):
+        # Individual ``ja4_*`` parameters bypass parsing; each
+        # constrains exactly one ``moreinfo`` JSONB key.
+        from ivre.db.sql import SQLDBPassive
+
+        flt = SQLDBPassive.searchja4client(ja4_a="t13d1715h2", ja4_b="5b57614c22b0")
+        sql = self._compile(flt.main)
+        self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_b') = '5b57614c22b0'", sql)
+        # ``ja4_c`` not constrained when not passed; check the
+        # short bare key is absent (ignoring ``ja4_c1_raw`` /
+        # ``ja4_c2_raw`` substrings which would false-positive).
+        scrubbed = sql.replace("ja4_c1_raw", "").replace("ja4_c2_raw", "")
+        self.assertNotIn("'ja4_c'", scrubbed)
+
+    def test_searchja4client_passive_raw_splits_c1_c2(self):
+        # The ``raw`` parameter splits ``ja4_c_raw`` further
+        # into ``ja4_c1_raw`` / ``ja4_c2_raw`` when it contains
+        # an underscore.
+        from ivre.db.sql import SQLDBPassive
+
+        flt = SQLDBPassive.searchja4client(raw="t13d1715h2_002f,0035_aaaaaa_bbbbbb")
+        sql = self._compile(flt.main)
+        self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_b_raw') = '002f,0035'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_c1_raw') = 'aaaaaa'", sql)
+        self.assertIn("(passive.moreinfo ->> 'ja4_c2_raw') = 'bbbbbb'", sql)
+
+    def test_searchja4client_passive_neg_wraps_in_not(self):
+        # ``neg=True`` wraps the whole AND-chain in
+        # ``not_(...)`` -- one NOT around the conjunction, not
+        # one per condition.
+        from ivre.db.sql import SQLDBPassive
+
+        flt = SQLDBPassive.searchja4client(ja4_a="t13d1715h2", neg=True)
+        sql = self._compile(flt.main)
+        self.assertTrue(sql.startswith("NOT ("))
+        self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
+
 
 # ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of


### PR DESCRIPTION
`SQLDBPassive` was missing `searchja4client` -- audit identified the gap when surveying the `comm -23 mongo-vs-pg` diff for the `passive` purpose. `MongoDBPassive.searchja4client` exists at `mongo.py:5655` and is exercised by the JA4-fingerprint passive search paths (web filter language token `ja4-client:...`, `tests/tests.py` JA4 fingerprint assertions).

Mirror the Mongo signature bit-for-bit: `value`, `raw`, plus the eight individual `ja4_*` parameter components, plus `neg`. Each component constrains a single key in the `moreinfo` JSONB column except `value` (matched against `passive.value` directly). The canonical `ja4_a_ja4_b_ja4_c` form is split out into the indexed components when passed via `value`; `raw` follows the same scheme but populates `ja4_b_raw` / `ja4_c1_raw` / `ja4_c2_raw`. `neg=True` wraps the entire AND-chain in `not_(...)`.

Implementation note: the Mongo function at `mongo.py:5686` accidentally references `value[11:]` in the `raw`-handling branch (clearly meant to be `raw[11:]`); the SQL version uses `raw[11:]` (the obviously-correct intent). The Mongo typo is a pre-existing bug, out of scope here -- a separate PR can fix both backends to use the same source variable.

Tests
=====

Four pinning tests in
`tests_no_backend.SQLDBSearchFieldTests`:

  - `test_searchja4client_passive_canonical_value`: canonical `value` form splits into indexed components.
  - `test_searchja4client_passive_individual_components`: individual `ja4_*` parameters bypass parsing.
  - `test_searchja4client_passive_raw_splits_c1_c2`: `raw` splits `ja4_c_raw` further into c1/c2 along the underscore.
  - `test_searchja4client_passive_neg_wraps_in_not`: one `NOT` around the conjunction, not one per condition.

Verified
========

  - `SQLDBSearchFieldTests` 18/18 (was 17/17) pass on SQLA 2.0.49.
  - Full `tests_no_backend`: 166/167 (sole failure is the pre-existing `test_utils` timezone test, unrelated).
  - `pkg/runchecks` clean across all 13 checks.