### PR TITLE
refactor(db/sql): lift searchtag from SQLDBView to SQLDBActive

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -1842,6 +1842,30 @@ class SQLDBActive(SQLDB, DBActive):
         )
 
     @classmethod
+    def searchtag(cls, tag=None, neg=False):
+        """Filters (if `neg` == True, filters out) one particular tag (records
+        may have zero, one or more tags).
+
+        `tag` may be the value (as a str) or the tag (as a Tag, e.g.:
+        `{"value": value, "info": info}`).
+
+        Lifted to ``SQLDBActive`` so both ``SQLDBNmap`` and
+        ``SQLDBView`` inherit it -- both backends have a ``tag``
+        table in their ``tables`` namespace and accept the ``tag=``
+        keyword on their ``base_filter`` (``ActiveFilter`` and its
+        subclasses, ``ivre/db/sql/__init__.py:725``).
+        """
+        if not tag:
+            return cls.base_filter(tag=[(not neg, True)])
+        if not isinstance(tag, dict):
+            tag = {"value": tag}
+        req = [
+            cls._searchstring_re(getattr(cls.tables.tag, key), value)
+            for key, value in tag.items()
+        ]
+        return cls.base_filter(tag=[(not neg, and_(*req))])
+
+    @classmethod
     def searchport(cls, port, protocol="tcp", state="open", neg=False):
         """Filters (if `neg` == True, filters out) records with
         specified protocol/port at required state. Be aware that when
@@ -2568,25 +2592,6 @@ class SQLDBView(SQLDBActive, DBView):
                 cls.tables.scan.id, cls.tables.scan.source, src, neg=neg
             )
         )
-
-    @classmethod
-    def searchtag(cls, tag=None, neg=False):
-        """Filters (if `neg` == True, filters out) one particular tag (records
-        may have zero, one or more tags).
-
-        `tag` may be the value (as a str) or the tag (as a Tag, e.g.:
-        `{"value": value, "info": info}`).
-
-        """
-        if not tag:
-            return cls.base_filter(tag=[(not neg, True)])
-        if not isinstance(tag, dict):
-            tag = {"value": tag}
-        req = [
-            cls._searchstring_re(getattr(cls.tables.tag, key), value)
-            for key, value in tag.items()
-        ]
-        return cls.base_filter(tag=[(not neg, and_(*req))])
 
     @classmethod
     def searchcountry(cls, country, neg=False):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1840,6 +1840,66 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         self.assertTrue(sql.startswith("NOT ("))
         self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
 
+    def test_searchtag_lifted_to_sqldbactive(self):
+        # M4.0.5: ``searchtag`` was previously defined only on
+        # ``SQLDBView``. Both ``SQLDBView`` and ``SQLDBNmap`` have
+        # a ``tag`` table in ``tables`` and a ``base_filter``
+        # (``ActiveFilter`` subclass) that accepts the ``tag=``
+        # keyword, so the implementation lifts cleanly to
+        # ``SQLDBActive`` and both backends inherit it.
+        from ivre.db.sql import SQLDBActive, SQLDBNmap, SQLDBView
+
+        # Method is owned by ``SQLDBActive`` (not duplicated on
+        # the subclasses).
+        self.assertIs(SQLDBNmap.searchtag.__func__, SQLDBActive.searchtag.__func__)
+        self.assertIs(SQLDBView.searchtag.__func__, SQLDBActive.searchtag.__func__)
+
+    def test_searchtag_nmap_produces_nmap_filter(self):
+        # ``SQLDBNmap.searchtag(value)`` builds a ``NmapFilter``
+        # with a ``(positive, value-equality)`` entry on the
+        # ``tag`` axis. Pin both the filter type and the entry
+        # shape so the lift cannot accidentally degrade the
+        # NmapFilter into a base ActiveFilter.
+        from ivre.db.sql import SQLDBNmap
+        from ivre.db.sql.tables import N_Tag
+
+        flt = SQLDBNmap.searchtag("CDN")
+        self.assertEqual(type(flt).__name__, "NmapFilter")
+        # One entry: (True, <equality clause>).
+        self.assertEqual(len(flt.tag), 1)
+        positive, clause = flt.tag[0]
+        self.assertTrue(positive)
+        # The clause references the Nmap tag table's ``value``
+        # column (not the View tag table).
+        sql = self._compile(clause)
+        self.assertIn("n_tag.value = 'CDN'", sql)
+        self.assertEqual(N_Tag.__tablename__, "n_tag")
+
+    def test_searchtag_nmap_with_dict_constrains_multiple_keys(self):
+        # Passing a dict (e.g.
+        # ``{"value": "CDN", "info": "Cloudflare"}``) constrains
+        # multiple ``tag`` columns AND-ed together.
+        from ivre.db.sql import SQLDBNmap
+
+        flt = SQLDBNmap.searchtag({"value": "CDN", "info": "Cloudflare"})
+        self.assertEqual(len(flt.tag), 1)
+        positive, clause = flt.tag[0]
+        self.assertTrue(positive)
+        sql = self._compile(clause)
+        self.assertIn("n_tag.value = 'CDN'", sql)
+        self.assertIn("n_tag.info = 'Cloudflare'", sql)
+
+    def test_searchtag_nmap_neg(self):
+        # ``neg=True`` flips the polarity flag on the tag entry
+        # (the per-axis evaluator handles the inversion); the
+        # value clause itself stays positive.
+        from ivre.db.sql import SQLDBNmap
+
+        flt = SQLDBNmap.searchtag("CDN", neg=True)
+        self.assertEqual(len(flt.tag), 1)
+        positive, _clause = flt.tag[0]
+        self.assertFalse(positive)
+
 
 # ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of


### PR DESCRIPTION
`searchtag` was previously defined only on `SQLDBView` (`ivre/db/sql/__init__.py:2573`), even though both `SQLDBView` and `SQLDBNmap` have a `tag` table in their `tables` namespace and accept `tag=` on their `base_filter` (both NmapFilter and ViewFilter inherit from `ActiveFilter`, `ivre/db/sql/__init__.py:725`). Mongo's equivalent (`MongoDBActive.searchtag`, `mongo.py:4561`) lives on the shared Active class; SQL diverged unnecessarily.

Move the implementation up to `SQLDBActive` so both `SQLDBNmap` and `SQLDBView` inherit it. The body of the method is unchanged -- it operates on `cls.tables.tag` (which points at `N_Tag` for Nmap, `V_Tag` for View, both having the same column shape) and returns `cls.base_filter(tag=...)` (NmapFilter for Nmap, ViewFilter for View).

Closes one entry in the `comm -23 mongo-vs-pg` audit diff: `SQLDBNmap.searchtag` previously raised `AttributeError` if called.

Tests
=====

Four pinning tests in
`tests_no_backend.SQLDBSearchFieldTests`:

  - `test_searchtag_lifted_to_sqldbactive`: confirms both subclass references point at the same underlying function on `SQLDBActive`.
  - `test_searchtag_nmap_produces_nmap_filter`: pins the filter type (`NmapFilter`) and the rendered SQL clause (`n_tag.value = 'CDN'`) -- the lifted method dispatches on `cls.tables.tag` correctly.
  - `test_searchtag_nmap_with_dict_constrains_multiple_keys`: dict input AND-conjoins multiple column equalities.
  - `test_searchtag_nmap_neg`: `neg=True` flips the polarity flag on the tag-axis tuple (per the `ActiveFilter` contract).

Verified
========

  - `SQLDBSearchFieldTests` 18/18 pass on SQLA 2.0.49.
  - Full `tests_no_backend`: 166/167 (sole failure is the pre-existing `test_utils` timezone test, unrelated).
  - `pkg/runchecks` clean across all 13 checks.