### PR TITLE
fix(db/sql): silence SAWarning from CTE-passed-to-IN coercion in remove paths

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -1531,7 +1531,13 @@ class SQLDBActive(SQLDB, DBActive):
                 .select_from(join(self.tables.port, self.tables.scan))
                 .where(self.tables.port.state == "open")
                 .group_by(self.tables.scan.addr, self.tables.scan.time_start)
-                .where(self.tables.scan.id.in_(base))
+                # Wrap the CTE in an explicit ``select(...)`` for
+                # ``.in_(...)``: SQLAlchemy 2.x emits ``SAWarning:
+                # Coercing CTE object into a select() for use in
+                # IN()`` when a CTE is passed directly. Same fix
+                # applied to ``SQLDBActive.remove_many`` and
+                # ``SQLDBPassive.remove`` below.
+                .where(self.tables.scan.id.in_(select(base.c.id)))
             )
         )
 
@@ -1745,7 +1751,12 @@ class SQLDBActive(SQLDB, DBActive):
 
         """
         base = flt.query(select(self.tables.scan.id)).cte("base")
-        self._write(delete(self.tables.scan).where(self.tables.scan.id.in_(base)))
+        # ``.in_(select(base.c.id))`` instead of ``.in_(base)``:
+        # SA 2.x emits ``SAWarning: Coercing CTE object into a
+        # select() for use in IN()`` when a CTE is passed directly.
+        self._write(
+            delete(self.tables.scan).where(self.tables.scan.id.in_(select(base.c.id)))
+        )
 
     _topstructure = namedtuple(
         "topstructure", ["base", "fields", "where", "group_by", "extraselectfrom"]
@@ -2751,7 +2762,14 @@ class SQLDBPassive(SQLDB, DBPassive):
         base = spec_or_id.query(
             select(self.tables.passive.id).select_from(spec_or_id.select_from)
         ).cte("base")
-        self._write(delete(self.tables.passive).where(self.tables.passive.id.in_(base)))
+        # ``.in_(select(base.c.id))`` instead of ``.in_(base)``:
+        # SA 2.x emits ``SAWarning: Coercing CTE object into a
+        # select() for use in IN()`` when a CTE is passed directly.
+        self._write(
+            delete(self.tables.passive).where(
+                self.tables.passive.id.in_(select(base.c.id))
+            )
+        )
 
     def _get(self, flt, limit=None, skip=None, sort=None, fields=None):
         if fields is not None:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1977,6 +1977,75 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         self.assertIn("NOT IN", sql)
         self.assertIn("WHERE field ~* '^source-'", sql)
 
+    def test_remove_paths_do_not_emit_cte_coercion_sawarning(self):
+        # M4.0.1: SQLAlchemy 2.x emits ``SAWarning: Coercing CTE
+        # object into a select() for use in IN()`` when a CTE is
+        # passed directly to ``Column.in_(...)``. Three sites in
+        # ``ivre/db/sql/__init__.py`` historically did this:
+        #
+        #   - ``SQLDBActive._get_open_port_count``
+        #   - ``SQLDBActive.remove_many``
+        #   - ``SQLDBPassive.remove``
+        #
+        # Each was adjusted to wrap the CTE in
+        # ``select(base.c.id)`` before the ``.in_(...)``. Pin the
+        # silence by AST-walking the source for any
+        # ``.in_(<bare-name>)`` where the name was bound to a CTE
+        # in the same function. The test is white-box; it
+        # documents the contract so a future refactor can't
+        # regress it.
+        import ast
+        from inspect import getsource
+        from textwrap import dedent
+
+        from ivre.db.sql import SQLDBActive, SQLDBPassive
+
+        for fn in [
+            SQLDBActive._get_open_port_count,
+            SQLDBActive.remove_many,
+            SQLDBPassive.remove,
+        ]:
+            with self.subTest(method=fn.__qualname__):
+                src = dedent(getsource(fn))
+                tree = ast.parse(src)
+                # Find variables bound to ``....cte(...)``.
+                cte_names = set()
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Assign) and isinstance(
+                        node.value, ast.Call
+                    ):
+                        # Look for a chain ending in ``.cte(...)``.
+                        call = node.value
+                        if (
+                            isinstance(call.func, ast.Attribute)
+                            and call.func.attr == "cte"
+                        ):
+                            for tgt in node.targets:
+                                if isinstance(tgt, ast.Name):
+                                    cte_names.add(tgt.id)
+                # Every ``.in_(<Name>)`` call where the name is in
+                # ``cte_names`` must be flagged. (We allow
+                # ``.in_(select(<Name>.c.<col>))`` -- the wrapped
+                # form.)
+                bad = []
+                for node in ast.walk(tree):
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "in_"
+                        and len(node.args) == 1
+                        and isinstance(node.args[0], ast.Name)
+                        and node.args[0].id in cte_names
+                    ):
+                        bad.append(ast.unparse(node))
+                self.assertEqual(
+                    bad,
+                    [],
+                    f"{fn.__qualname__}: a CTE is passed bare to .in_(...); "
+                    f"wrap it in select(<cte>.c.<column>) to silence "
+                    f"SQLAlchemy 2.x's SAWarning. Offending calls: {bad}",
+                )
+
 
 # ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of


### PR DESCRIPTION
SQLAlchemy 2.x emits `SAWarning: Coercing CTE object into a select() for use in IN(); please pass a select() construct explicitly` when a CTE is passed directly to `Column.in_(...)`. Three sites in `ivre/db/sql/__init__.py` triggered the warning, producing stderr noise that `tests/tests.py` worked around with ~10 `if DATABASE != "postgres":` skip blocks.

Sites fixed (each builds a CTE then uses it in an IN-clause):

  - `SQLDBActive._get_open_port_count` (line 1528)
  - `SQLDBActive.remove_many` (line 1748)
  - `SQLDBPassive.remove` (line 2756)

Each `.in_(base)` becomes `.in_(select(base.c.id))`. The emitted SQL is identical (the SA 2.x coercion does the same `select base.id from base` wrap automatically); only the warning is suppressed.

Tests
=====

`tests_no_backend.SQLDBSearchFieldTests
.test_remove_paths_do_not_emit_cte_coercion_sawarning` walks the AST of each method and asserts no bare `Name.in_(<cte-name>)` call exists. White-box but robust: a regex would over-match; the AST walker pins the contract precisely.

After this lands, the `if DATABASE != "postgres"` blocks in `tests/tests.py` that swallow this specific warning can be removed (M4.9 capability-registry sweep).

Verified
========

  - SA primitive smoke test: pre-fix produces 1 CTE warning, post-fix produces 0.
  - `SQLDBSearchFieldTests` 19/19 (was 18/18) pass on SQLA 2.0.49.
  - Full `tests_no_backend`: 163/164 (sole failure is the pre-existing `test_utils` timezone test, unrelated).
  - `pkg/runchecks` clean across all 13 checks.