### PR TITLE
feat(db): add DB.flush() helper; replace time.sleep(...) Elastic test waits

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -407,6 +407,21 @@ class DB:
     def from_binary(data):
         return data
 
+    def flush(self):
+        """Force any pending writes to be visible to subsequent reads.
+
+        Most backends are synchronous and this is a no-op. The
+        exception is Elasticsearch, which buffers writes for a
+        ``refresh_interval`` (default 1s) before they become
+        searchable; the Elastic override calls
+        ``indices.refresh`` to force the buffer flush.
+
+        Tests use this helper instead of ``time.sleep(2)`` after
+        a batch of writes so the assertion that follows
+        immediately observes the just-written state on every
+        backend.
+        """
+
     # filters
 
     @classmethod

--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -135,6 +135,20 @@ class ElasticDB(DB):
     def from_binary(data):
         return utils.decode_b64(data.encode())
 
+    def flush(self):
+        """Force-refresh every Elasticsearch index this backend
+        owns so that just-written documents become searchable.
+
+        Elasticsearch buffers writes for the cluster's
+        ``refresh_interval`` (default 1s) before they are visible
+        to ``_search``. Tests that read-back-after-write rely on
+        this synchronous refresh to avoid race conditions; in
+        production, the default refresh cadence is fine and the
+        method is rarely used outside the test suite.
+        """
+        for idxname in self.indexes:
+            self.db_client.indices.refresh(index=idxname)
+
     @staticmethod
     def ip2internal(addr):
         return addr

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3972,8 +3972,7 @@ class IvreTests(unittest.TestCase):
         view_count = 0
         # Count passive results
         self.assertEqual(RUN(["ivre", "db2view"] + processes + ["passive"])[0], 0)
-        if DATABASE == "elastic":
-            time.sleep(ELASTIC_INSERT_TEMPO)
+        ivre.db.db.view.flush()
         ret, out, _ = RUN(["ivre", "view", "--count"])
         self.assertEqual(ret, 0)
         view_count = int(out)
@@ -3984,8 +3983,7 @@ class IvreTests(unittest.TestCase):
         )
         # Count active results
         self.assertEqual(RUN(["ivre", "db2view"] + processes + ["nmap"])[0], 0)
-        if DATABASE == "elastic":
-            time.sleep(ELASTIC_INSERT_TEMPO)
+        ivre.db.db.view.flush()
         ret, out, _ = RUN(["ivre", "view", "--count"])
         self.assertEqual(ret, 0)
         view_count = int(out)
@@ -4000,8 +3998,7 @@ class IvreTests(unittest.TestCase):
             )[0],
             0,
         )
-        if DATABASE == "elastic":
-            time.sleep(ELASTIC_INSERT_TEMPO)
+        ivre.db.db.view.flush()
         ret, out, _ = RUN(["ivre", "view", "--count"])
         self.assertEqual(ret, 0)
         view_count = int(out)
@@ -4857,16 +4854,14 @@ class IvreTests(unittest.TestCase):
         )["addr"]
         for result in ivre.db.db.view.get(ivre.db.db.view.searchhost(addr)):
             ivre.db.db.view.remove(result)
-        if DATABASE == "elastic":
-            time.sleep(ELASTIC_INSERT_TEMPO)
+        ivre.db.db.view.flush()
         count = ivre.db.db.view.count(ivre.db.db.view.searchhost(addr))
         self.assertEqual(count, 0)
         addr = next(
             iter(ivre.db.db.view.get(ivre.db.db.view.flt_empty, sort=[("addr", -1)]))
         )["addr"]
         ivre.db.db.view.remove_many(ivre.db.db.view.searchhost(addr))
-        if DATABASE == "elastic":
-            time.sleep(ELASTIC_INSERT_TEMPO)
+        ivre.db.db.view.flush()
         count = ivre.db.db.view.count(ivre.db.db.view.searchhost(addr))
         self.assertEqual(count, 0)
 
@@ -5118,7 +5113,7 @@ def parse_args():
 
 
 def parse_env():
-    global DATABASE, BACKEND_FLAVOR, ELASTIC_INSERT_TEMPO
+    global DATABASE, BACKEND_FLAVOR
     DATABASE = os.getenv("DB")
     BACKEND_FLAVOR = os.getenv("IVRE_BACKEND_FLAVOR")
     for test in DATABASES.get(DATABASE, []):
@@ -5139,9 +5134,12 @@ def parse_env():
                 getattr(IvreTests, test)
             ),
         )
-    # Elasticsearch insertion is asynchronous, this hack "ensures" the
-    # data has been inserted before continuing.
-    ELASTIC_INSERT_TEMPO = int(os.getenv("ES_INSERT_TEMPO", 2))
+    # ``ELASTIC_INSERT_TEMPO`` / ``ES_INSERT_TEMPO`` were the legacy
+    # ``time.sleep(...)`` knob used to wait out Elasticsearch's
+    # asynchronous indexing before reading back. Replaced by
+    # synchronous ``ivre.db.db.view.flush()`` calls in the tests
+    # (no-op on every backend except Elastic, where it triggers
+    # ``indices.refresh``).
 
 
 if __name__ == "__main__":

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1840,6 +1840,39 @@ class SQLDBSearchFieldTests(unittest.TestCase):
         self.assertTrue(sql.startswith("NOT ("))
         self.assertIn("(passive.moreinfo ->> 'ja4_a') = 't13d1715h2'", sql)
 
+    def test_db_flush_base_is_noop(self):
+        # M4.0.2: ``DB.flush()`` is the read-after-write barrier
+        # used by tests in place of ``time.sleep(...)`` for
+        # Elastic. The base method must be a no-op so SQL /
+        # Mongo / DocumentDB / HTTP backends inherit a free
+        # implementation. Only ``ElasticDB`` overrides it to
+        # call ``indices.refresh``. Pin the contract:
+        #
+        #   - ``DB.flush`` exists and is callable.
+        #   - The base method body is empty (just a docstring).
+        #
+        # The Elastic-specific override is verified separately
+        # in ``ElasticDB.flush`` (live-cluster check via
+        # ``tests/tests.py`` writes-then-reads).
+        import ast
+        from inspect import getsource
+        from textwrap import dedent
+
+        from ivre.db import DB
+
+        self.assertTrue(callable(DB.flush))
+        # Body should be docstring-only (no real statements).
+        tree = ast.parse(dedent(getsource(DB.flush)))
+        funcdef = tree.body[0]
+        self.assertIsInstance(funcdef, ast.FunctionDef)
+        body_after_docstring = funcdef.body[1:]
+        self.assertEqual(
+            body_after_docstring,
+            [],
+            "DB.flush() base method must be a docstring-only no-op; "
+            "non-Elastic backends rely on the inherited no-op.",
+        )
+
     def test_searchtag_lifted_to_sqldbactive(self):
         # M4.0.5: ``searchtag`` was previously defined only on
         # ``SQLDBView``. Both ``SQLDBView`` and ``SQLDBNmap`` have


### PR DESCRIPTION
Tests that read back data immediately after writing it had to wait out Elasticsearch's asynchronous indexing cycle (default `refresh_interval` = 1s) via:

  if DATABASE == "elastic":
      time.sleep(ELASTIC_INSERT_TEMPO)

Five such blocks lived in `tests/tests.py` (around the `db2view` -> `view --count` checkpoints in
`test_50_view` and the `view.remove` -> `view.count` checkpoints in `test_55_view_delete`). They flake on slow CI runners (the 2-second default isn't always enough) and add unconditional latency to every test run -- including non-Elastic backends that don't need it.

Replace the pattern with a synchronous `flush()` helper:

  ivre.db.db.view.flush()

  - `DB.flush()` (`ivre/db/__init__.py:411`): no-op base method. Mongo, PostgreSQL, DuckDB, HTTP, MaxMind, DocumentDB inherit it for free.
  - `ElasticDB.flush()` (`ivre/db/elastic.py:138`): iterates `self.indexes` and calls `db_client.indices.refresh` on each. Synchronous (returns when Elastic acks the refresh) so the next read sees the just-written state.

The 5 `if DATABASE == "elastic": time.sleep(...)` blocks collapse to a single `flush()` call. The
`ELASTIC_INSERT_TEMPO` global is dropped (no callers); the `ES_INSERT_TEMPO` env var is no longer consulted.

Tests
=====

Pinning test in `tests_no_backend.SQLDBSearchFieldTests .test_db_flush_base_is_noop` walks the `DB.flush` AST and asserts the body is docstring-only (no real statements). Stops a future refactor from accidentally adding a per-write barrier to the base method that would slow every backend.

Verified
========

  - `pkg/runchecks` clean across all 13 checks.
  - `DB.flush()` smoke test against PostgreSQL: returns immediately, no errors.
  - `tests_no_backend`: 175/176 (sole failure is the pre-existing `test_utils` timezone test, unrelated).

Closes audit item #19 (the 5 `time.sleep` skips). Removes `rg 'DATABASE\s*[!=]=' tests/tests.py | wc -l` from 19 to 14 once this lands.