### PR TITLE
feat(db/sql): bootstrap DuckDB backend (Nmap, View, Passive)

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -2325,6 +2325,7 @@ class DBActive(DB):
 
 class DBNmap(DBActive):
     backends = {
+        "duckdb": ("sql.duckdb", "DuckDBNmap"),
         "http": ("http", "HttpDBNmap"),
         "mongodb": ("mongo", "MongoDBNmap"),
         "documentdb": ("document", "DocumentDBNmap"),
@@ -4265,6 +4266,7 @@ class DBNmap(DBActive):
 
 class DBView(DBActive):
     backends = {
+        "duckdb": ("sql.duckdb", "DuckDBView"),
         "elastic": ("elastic", "ElasticDBView"),
         "http": ("http", "HttpDBView"),
         "mongodb": ("mongo", "MongoDBView"),
@@ -4566,6 +4568,7 @@ class DBPassive(DB):
     datetime_fields = ["firstseen", "lastseen", "infos.not_after", "infos.not_before"]
     list_fields = ["infos.domain", "infos.domaintarget", "infos.san"]
     backends = {
+        "duckdb": ("sql.duckdb", "DuckDBPassive"),
         "http": ("http", "HttpDBPassive"),
         "mongodb": ("mongo", "MongoDBPassive"),
         "documentdb": ("document", "DocumentDBPassive"),

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -270,7 +270,26 @@ class SQLDB(DB):
 
     def __init__(self, url):
         super().__init__()
-        self.dburl = url.geturl()
+        # ``urlparse(...).geturl()`` (and ``urlunparse``) collapse
+        # the empty-authority ``///`` separator down to a single
+        # ``/`` for any scheme that does not opt into
+        # ``urllib.parse.uses_netloc``: e.g.
+        # ``duckdb:///:memory:`` would round-trip as
+        # ``duckdb:/:memory:``, which SQLAlchemy then refuses with
+        # ``Could not parse SQLAlchemy URL from given URL string``.
+        # Reconstruct the wire form explicitly so empty-host URLs
+        # (DuckDB embedded files, ``:memory:``) survive untouched
+        # while PostgreSQL / MongoDB / Elasticsearch URLs --- which
+        # always carry a non-empty netloc --- come out byte-for-byte
+        # identical to what ``geturl()`` returned previously.
+        rebuilt = f"{url.scheme}://{url.netloc}{url.path}"
+        if url.params:
+            rebuilt += f";{url.params}"
+        if url.query:
+            rebuilt += f"?{url.query}"
+        if url.fragment:
+            rebuilt += f"#{url.fragment}"
+        self.dburl = rebuilt
 
     @property
     def db(self):

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -1,0 +1,328 @@
+#! /usr/bin/env python
+
+# This file is part of IVRE.
+# Copyright 2011 - 2026 Pierre LALET <pierre@droids-corp.org>
+#
+# IVRE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IVRE is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+
+"""DuckDB backend for IVRE's SQL data layer.
+
+DuckDB's SQLAlchemy dialect (``duckdb-engine``) inherits from
+:class:`sqlalchemy.dialects.postgresql.psycopg2.PGDialect_psycopg2`,
+so most PostgreSQL DDL and DML compiles unchanged.  This module
+adapts the small set of behaviours that genuinely differ between
+the two engines:
+
+* ``INET`` round-trips as a Python ``dict``
+  (``{'ip_type', 'address', 'mask'}``) rather than a string.
+* ``CREATE INDEX ... USING gin`` is rejected (DuckDB only ships
+  B-tree indexes).
+* ``COPY ... FROM STDIN`` and ``CREATE TEMP TABLE`` based bulk
+  paths are PG-specific implementation details; bulk-insert
+  parity with PostgreSQL is deferred to a follow-up milestone.
+
+The class hierarchy mirrors :mod:`ivre.db.sql.postgres`: a
+:class:`DuckDBMixin` carries the dialect-specific overrides and is
+placed *first* in the bases tuple of every concrete class so its
+methods win the MRO lookup against ``PostgresDB*``'s defaults.
+"""
+
+from typing import Any, override
+
+from sqlalchemy.dialects import postgresql
+
+from ivre import utils
+from ivre.db.sql.postgres import (
+    PostgresDBNmap,
+    PostgresDBPassive,
+    PostgresDBView,
+)
+from ivre.db.sql.tables import Base
+
+
+def _is_unsupported_on_duckdb(index: Any) -> bool:
+    """Return ``True`` for indexes DuckDB rejects at create-time.
+
+    DuckDB only ships B-tree (ART) indexes and only over a
+    subset of column types; the following declarations are
+    filtered out at ``init()`` time:
+
+    * **GIN indexes** (``postgresql_using='gin'``) -- emitted
+      against JSONB columns to accelerate containment queries
+      on PostgreSQL. DuckDB raises ``Binder Error: Unknown
+      index type: GIN``; JSONB lookups degrade to sequential
+      scans.
+
+    * **Partial indexes** (``postgresql_where=<expr>``) --
+      DuckDB raises ``NotImplementedException: Creating partial
+      indexes is not supported currently``. The relevant
+      declarations on
+      :class:`~ivre.db.sql.tables.Passive` collapse to a single
+      multi-column unique constraint on DuckDB at the cost of
+      treating ``NULL`` ``addr`` rows the same as any other.
+
+    * **Indexes that key on an ``INET`` or ``ARRAY`` column** --
+      DuckDB's catalog rejects them with
+      ``Invalid type for index key``. The underlying ART index
+      cannot order INET / list values, so IP-prefix and
+      domain-array lookups fall back to sequential scans
+      (matching the JSONB / partial-index degradation above).
+    """
+    if index.kwargs.get("postgresql_using") == "gin":
+        return True
+    if index.kwargs.get("postgresql_where") is not None:
+        return True
+    return any(
+        isinstance(col.type, (postgresql.INET, postgresql.ARRAY))
+        for col in index.columns
+    )
+
+
+# DuckDB's parser accepts only ``RESTRICT`` / ``NO ACTION``
+# referential actions (the implicit defaults); ``CASCADE``,
+# ``SET NULL`` and ``SET DEFAULT`` raise
+# ``Parser Error: FOREIGN KEY constraints cannot use CASCADE,
+# SET NULL or SET DEFAULT``. Every cross-table FK in
+# :mod:`ivre.db.sql.tables` declares ``ondelete='CASCADE'`` to
+# auto-clean child rows on host deletion, which DuckDB rejects
+# wholesale.
+_DUCKDB_REJECTED_FK_ACTIONS = frozenset({"CASCADE", "SET NULL", "SET DEFAULT"})
+
+
+def _normalise_fk_action(action: str | None) -> str | None:
+    """Return ``None`` (i.e. emit no ``ON DELETE`` / ``ON UPDATE``
+    clause -- DuckDB defaults to ``RESTRICT``) when ``action`` is
+    one of the cascade-flavoured forms DuckDB cannot parse, or
+    pass it through untouched when DuckDB accepts it
+    (``RESTRICT`` / ``NO ACTION`` / ``None``).
+
+    Stripping CASCADE down to the implicit RESTRICT preserves
+    the FK constraint's referential-integrity check (an attempt
+    to delete a parent row with extant children still raises an
+    ``IntegrityError``); only the auto-cleanup behaviour is
+    lost.  IVRE's PostgreSQL backend already issues child-first
+    deletions in its remove paths, so the lost cascade does not
+    affect the supported call sites in :class:`PostgresDB*`.
+    """
+    if action is None:
+        return None
+    if action.upper() in _DUCKDB_REJECTED_FK_ACTIONS:
+        return None
+    return action
+
+
+class DuckDBMixin:
+    """Dialect-specific overrides on top of :class:`PostgresDB`.
+
+    Place *first* in the bases tuple of every concrete DuckDB
+    backend class so the MRO resolves these overrides ahead of
+    PostgreSQL's defaults (see :pep:`3119` C3 linearisation).
+    """
+
+    @staticmethod
+    def ip2internal(addr: str | int | None) -> str | None:
+        """Convert an IP value into the form accepted by an INET
+        bind on DuckDB.
+
+        DuckDB's INET column accepts the same string literals as
+        PostgreSQL (``'192.0.2.1'``, ``'2001:db8::1'``,
+        ``'10.0.0.0/8'``, plus the ``'<ip>'::inet`` cast emitted
+        by :class:`~ivre.db.sql.tables.INETLiteral` for inlined
+        literals), so the bind side reduces to "give me the
+        canonical string form" and matches PG byte-for-byte.
+
+        ``utils.force_int2ip`` accepts either an existing string
+        (returned unchanged) or an integer (rendered through
+        :func:`socket.inet_ntoa` / :func:`socket.inet_ntop`).
+        """
+        if addr is None:
+            return None
+        return utils.force_int2ip(addr)
+
+    @staticmethod
+    def internal2ip(addr: dict[str, int] | str | None) -> str | None:
+        """Convert a DuckDB ``INET`` round-trip value to an IP
+        string.
+
+        ``duckdb-engine`` returns ``INET`` columns as a struct
+        ``{'ip_type': 1|2, 'address': int, 'mask': int}`` rather
+        than the bare string PostgreSQL's ``psycopg2`` returns
+        (which the parent :meth:`PostgresDB.internal2ip` simply
+        passes through).  The unsigned address that
+        :func:`ivre.utils.int2ip` / :func:`ivre.utils.int2ip6`
+        expect is recovered as follows:
+
+        * ``ip_type == 1`` (IPv4): ``address`` is already an
+          unsigned 32-bit value; pass it straight to
+          :func:`utils.int2ip`.
+        * ``ip_type == 2`` (IPv6): ``address`` is a *biased*
+          signed 128-bit integer and the true unsigned value is
+          ``address + (1 << 127)``.  DuckDB's ``INET`` stores
+          addresses as a signed ``HUGEINT`` with that bias so the
+          natural ordering of the underlying integer matches the
+          natural ordering of IP addresses across the IPv4/IPv6
+          boundary.  :func:`utils.int2ip6` is used (instead of
+          the v4/v6-autodetecting :func:`utils.int2ip`) to avoid
+          mis-formatting low-valued v6 addresses such as ``::``
+          or ``::1`` as IPv4.
+
+        A bare string is returned unchanged so callers that have
+        already normalised their input (or that hit code paths
+        which do not go through DuckDB) keep working.
+        """
+        if addr is None:
+            return None
+        if isinstance(addr, dict):
+            address = addr["address"]
+            if addr["ip_type"] == 2:
+                return utils.int2ip6(address + (1 << 127))
+            return utils.int2ip(address)
+        # Defensive: a future duckdb-engine release might switch
+        # to returning strings (matching psycopg2). Pass them
+        # through utils.force_int2ip so a stray int still
+        # round-trips correctly.
+        return utils.force_int2ip(addr)
+
+    def copy_from(self, *args: Any, conn: Any = None, **kwargs: Any) -> None:
+        """Not implemented on DuckDB.
+
+        :meth:`PostgresDB.copy_from` wraps psycopg2's
+        ``cursor.copy_from`` (``COPY ... FROM STDIN``); DuckDB
+        exposes a different bulk-load API
+        (``duckdb.DuckDBPyConnection.from_csv_auto`` /
+        ``read_csv``) and the calling code in
+        :meth:`PostgresDBPassive.insert_or_update_bulk` is built
+        around the psycopg2 cursor protocol.  Wiring an
+        equivalent fast path is tracked as a follow-up
+        milestone; in the meantime, callers should use the
+        per-row :meth:`insert_or_update` path on DuckDB.
+        """
+        raise NotImplementedError(
+            "DuckDB has no psycopg2-style COPY FROM bulk path; "
+            "use insert_or_update (per-row) on this backend."
+        )
+
+    def create_tmp_table(
+        self, table: Any, extracols: Any = None, conn: Any = None
+    ) -> Any:
+        """Not implemented on DuckDB.
+
+        Currently only used by
+        :meth:`PostgresDBPassive.insert_or_update_bulk`, which
+        depends on the psycopg2 ``COPY`` path
+        (:meth:`copy_from`).  See :meth:`copy_from` for the
+        rationale and the deferral plan.
+        """
+        raise NotImplementedError(
+            "create_tmp_table is currently only consumed by the "
+            "psycopg2 COPY-based bulk path, which is not wired "
+            "for DuckDB."
+        )
+
+    def explain(self, req: Any, **_: Any) -> str:
+        """Not implemented on DuckDB.
+
+        DuckDB ships an ``EXPLAIN`` statement with a different
+        output shape than PostgreSQL's; pretty-printing it
+        through the same code path as
+        :meth:`PostgresDB.explain` would mis-render results.
+        Wired separately if and when ``ivre`` grows a
+        DuckDB-specific debug helper.
+        """
+        raise NotImplementedError(
+            "DuckDB EXPLAIN output formatting is not wired through this backend yet."
+        )
+
+    @override
+    def init(self) -> None:  # type: ignore[misc]
+        """Drop and recreate the schema, transparently rewriting
+        the small set of declarations DuckDB does not accept:
+
+        * Indexes flagged as unsupported by
+          :func:`_is_unsupported_on_duckdb` (GIN; INET-keyed
+          B-tree) are evicted from each table's ``indexes`` set.
+        * Foreign-key referential actions that DuckDB's parser
+          rejects (``CASCADE`` / ``SET NULL`` / ``SET DEFAULT``)
+          are flattened to the implicit ``RESTRICT`` -- see
+          :func:`_normalise_fk_action`.
+
+        Both edits are applied to the in-process
+        :data:`~ivre.db.sql.tables.Base.metadata` for the
+        duration of ``super().init()`` and reverted in a
+        ``finally`` block so other engines sharing the same
+        metadata in the same Python process (e.g. a parallel
+        test run against PostgreSQL) see their original
+        schema declarations.
+        """
+        saved_indexes: dict[Any, list[Any]] = {}
+        saved_fk_actions: list[tuple[Any, str | None, str | None]] = []
+        try:
+            for table in Base.metadata.tables.values():
+                skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
+                if skipped:
+                    saved_indexes[table] = skipped
+                    for ix in skipped:
+                        table.indexes.discard(ix)
+                # Table-level constraints: ForeignKeyConstraint(...)
+                for fkc in table.foreign_key_constraints:
+                    new_ondelete = _normalise_fk_action(fkc.ondelete)
+                    new_onupdate = _normalise_fk_action(fkc.onupdate)
+                    if (new_ondelete, new_onupdate) != (fkc.ondelete, fkc.onupdate):
+                        saved_fk_actions.append((fkc, fkc.ondelete, fkc.onupdate))
+                        fkc.ondelete = new_ondelete
+                        fkc.onupdate = new_onupdate
+                # Column-level ForeignKey(...) (e.g. Flow.src/dst).
+                for fk in table.foreign_keys:
+                    new_ondelete = _normalise_fk_action(fk.ondelete)
+                    new_onupdate = _normalise_fk_action(fk.onupdate)
+                    if (new_ondelete, new_onupdate) != (fk.ondelete, fk.onupdate):
+                        saved_fk_actions.append((fk, fk.ondelete, fk.onupdate))
+                        fk.ondelete = new_ondelete
+                        fk.onupdate = new_onupdate
+            super().init()  # type: ignore[misc]
+        finally:
+            for table, indexes in saved_indexes.items():
+                for ix in indexes:
+                    table.indexes.add(ix)
+            for fk_or_fkc, ondelete, onupdate in saved_fk_actions:
+                fk_or_fkc.ondelete = ondelete
+                fk_or_fkc.onupdate = onupdate
+
+
+class DuckDBNmap(DuckDBMixin, PostgresDBNmap):
+    """DuckDB backend for the ``nmap`` (active-scan) data category."""
+
+
+class DuckDBView(DuckDBMixin, PostgresDBView):
+    """DuckDB backend for the ``view`` (merged-host) data category."""
+
+
+class DuckDBPassive(DuckDBMixin, PostgresDBPassive):
+    """DuckDB backend for the ``passive`` data category.
+
+    Bulk-insert (:meth:`insert_or_update_bulk`) inherits the
+    PostgreSQL implementation, which is gated behind
+    :meth:`copy_from` and :meth:`create_tmp_table` -- both raise
+    :exc:`NotImplementedError` on DuckDB until parity work
+    lands.  Per-row :meth:`insert_or_update` works today.
+    """
+
+
+# Flow ingestion on SQL backends is currently a stub:
+# ``ivre.db.sql.tables.Flow`` references a ``host`` table that
+# is not declared anywhere in :data:`Base.metadata`, so
+# ``PostgresDBFlow().init()`` raises
+# ``NoReferencedTableError`` on PostgreSQL too. A working flow
+# backend is tracked separately and will land alongside the
+# corresponding registration in :class:`~ivre.db.DBFlow`.

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -148,6 +148,29 @@ class PostgresDB(SQLDB):
                 if c.primary_key:
                     c.primary_key = False
                     c.index = True
+                    # Strip the ``Sequence``-driven default that
+                    # the source table's ``id`` column carries
+                    # (see ``ivre.db.sql.tables._id_column``).
+                    # ``Column.copy()`` propagates the
+                    # ``server_default = nextval('seq_<table>_id')``
+                    # clause to the temp-table mirror, which then
+                    # holds a hard catalog dependency on the
+                    # source sequence.  PostgreSQL refuses to
+                    # ``DROP SEQUENCE seq_<table>_id`` while a
+                    # pooled connection still owns the
+                    # session-scoped ``tmp_<table>`` (error
+                    # ``cannot drop sequence ... because other
+                    # objects depend on it``), which propagates
+                    # into the next test's ``init()`` and rolls
+                    # back the schema reset, leaking data across
+                    # tests.  The temp table never reads the
+                    # ``id`` column -- callers project only the
+                    # named columns through their
+                    # ``INSERT ... FROM SELECT`` -- so the
+                    # default is unnecessary; dropping it removes
+                    # the cross-session dependency.
+                    c.default = None
+                    c.server_default = None
             if extracols is not None:
                 cols.extend(extracols)
             t = Table(

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -27,12 +27,13 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     Integer,
+    Sequence,
     String,
     Text,
     func,
 )
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, declared_attr
 from sqlalchemy.types import UserDefinedType
 
 from ivre import passive, xmlnmap
@@ -56,8 +57,43 @@ from ivre import passive, xmlnmap
 #     emits).
 #   - PG ``ARRAY(t)`` works as-is on DuckDB (duckdb-engine
 #     compiles to the ``LIST``/``t[]`` form natively).
+#
+# Auto-incrementing primary keys: PostgreSQL accepts the bare
+# ``Column(Integer, primary_key=True)`` form and SQLAlchemy emits
+# ``SERIAL``. DuckDB's catalog rejects ``SERIAL`` as well as
+# ``GENERATED ... AS IDENTITY``, so every surrogate ``id`` column
+# in IVRE's schema is bound to an explicit ``Sequence``: SA emits
+# ``CREATE SEQUENCE`` once at ``create_all`` time and the column's
+# ``server_default = seq.next_value()`` resolves to ``nextval(...)``
+# under both dialects. Mixin classes use ``declared_attr`` so each
+# concrete subclass (``n_*`` and ``v_*``) gets its own
+# per-tablename sequence rather than sharing one and interleaving
+# IDs between active scans and the merged view.
 
 SQLJSONB = postgresql.JSONB().with_variant(JSON(), "duckdb")
+
+
+def _id_column():
+    """Return a fresh ``id`` ``Column`` bound to a per-table
+    ``Sequence``.
+
+    Used as a ``declared_attr`` on the abstract mixins below so
+    each concrete subclass gets its own ``seq_<tablename>_id``.
+    Top-level (non-mixin) tables inline the same pattern with a
+    module-level ``Sequence`` for clarity at the call site.
+    """
+
+    @declared_attr
+    def id(cls):  # pylint: disable=redefined-builtin
+        seq = Sequence(f"seq_{cls.__tablename__}_id")
+        return Column(
+            Integer,
+            seq,
+            server_default=seq.next_value(),
+            primary_key=True,
+        )
+
+    return id
 
 
 def SQLARRAY(item_type):
@@ -135,9 +171,17 @@ Base = declarative_base()
 
 
 # Flow
+_seq_flow_id = Sequence("seq_flow_id")
+
+
 class Flow(Base):
     __tablename__ = "flow"
-    id = Column(Integer, primary_key=True)
+    id = Column(
+        Integer,
+        _seq_flow_id,
+        server_default=_seq_flow_id.next_value(),
+        primary_key=True,
+    )
     proto = Column(String(32), index=True)
     dport = Column(Integer, index=True)
     src = Column(Integer, ForeignKey("host.id", ondelete="RESTRICT"))
@@ -161,7 +205,7 @@ class _Association_Scan_Category:
 
 
 class _Category:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     name = Column(String(32))
 
 
@@ -173,7 +217,7 @@ class _Script:
 
 
 class _Port:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     scan = Column(Integer)
     port = Column(Integer)
     protocol = Column(String(16))
@@ -194,7 +238,7 @@ class _Port:
 
 
 class _Tag:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     scan = Column(Integer)
     value = Column(String(256))
     type = Column(String(16))
@@ -202,7 +246,7 @@ class _Tag:
 
 
 class _Hostname:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     scan = Column(Integer)
     domains = Column(SQLARRAY(String(255)), index=True)
     name = Column(String(255), index=True)
@@ -216,14 +260,14 @@ class _Association_Scan_Hostname:
 
 
 class _Trace:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     scan = Column(Integer, nullable=False)
     port = Column(Integer)
     protocol = Column(String(16))
 
 
 class _Hop:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     trace = Column(Integer, nullable=False)
     ipaddr = Column(SQLINET)
     ttl = Column(Integer)
@@ -233,7 +277,7 @@ class _Hop:
 
 
 class _Scan:
-    id = Column(Integer, primary_key=True)
+    id = _id_column()
     addr = Column(SQLINET, nullable=False)
     # source = Column()
     info = Column(SQLJSONB)
@@ -411,9 +455,17 @@ class V_Scan(Base, _Scan):
 
 
 # Passive
+_seq_passive_id = Sequence("seq_passive_id")
+
+
 class Passive(Base):
     __tablename__ = "passive"
-    id = Column(Integer, primary_key=True)
+    id = Column(
+        Integer,
+        _seq_passive_id,
+        server_default=_seq_passive_id.next_value(),
+        primary_key=True,
+    )
     addr = Column(SQLINET)
     sensor = Column(String(64))
     count = Column(Integer)

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -33,7 +33,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import declarative_base, declared_attr
+from sqlalchemy.orm import declarative_base, declared_attr, mapped_column
 from sqlalchemy.types import UserDefinedType
 
 from ivre import passive, xmlnmap
@@ -81,16 +81,32 @@ def _id_column():
     each concrete subclass gets its own ``seq_<tablename>_id``.
     Top-level (non-mixin) tables inline the same pattern with a
     module-level ``Sequence`` for clarity at the call site.
+
+    The mapping is built via :func:`sqlalchemy.orm.mapped_column`
+    with ``sort_order=-100`` so the column is positioned *first*
+    in the resulting :class:`~sqlalchemy.schema.Table`'s
+    ``columns`` collection: ``declared_attr`` is processed after
+    the regular class attributes, so without an explicit sort
+    override the ``id`` column would land at the end of the
+    column list.  Several call sites in
+    :mod:`ivre.db.sql` (e.g.
+    :meth:`SQLDBView.get` / :meth:`SQLDBNmap.get`) unpack
+    ``select(self.tables.port)`` rows positionally and depend on
+    the historical ``id`` -> ``scan`` -> ``port`` -> ... order;
+    pinning it via ``sort_order`` avoids touching every such
+    site while still keeping the per-table Sequence default that
+    DuckDB requires.
     """
 
     @declared_attr
     def id(cls):  # pylint: disable=redefined-builtin
         seq = Sequence(f"seq_{cls.__tablename__}_id")
-        return Column(
+        return mapped_column(
             Integer,
             seq,
             server_default=seq.next_value(),
             primary_key=True,
+            sort_order=-100,
         )
 
     return id

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -1451,7 +1451,7 @@ def match_nmap_svc_fp(
     return softmatch
 
 
-_NMAP_PAYLOADS = {}
+_NMAP_PAYLOADS: dict[bytes, str] = {}
 _NMAP_PAYLOADS_POPULATED = False
 
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -2225,6 +2225,57 @@ class DuckDBBackendBootstrapTests(unittest.TestCase):
         _HAVE_DUCKDB_ENGINE,
         "duckdb-engine is required (install with the ``duckdb`` extras)",
     )
+    def test_create_tmp_table_strips_pk_sequence_default(self):
+        # Regression: after the M4.1.2 ``Sequence``-driven PK
+        # refactor, ``Column.copy()`` on a source PK column
+        # propagates the ``server_default = nextval('seq_<table>_id')``
+        # clause to the temp-table mirror that
+        # :meth:`PostgresDB.create_tmp_table` builds for the
+        # passive bulk-insert path.  PostgreSQL then refuses
+        # ``DROP SEQUENCE seq_<table>_id`` while a pooled
+        # connection still owns the session-scoped
+        # ``tmp_<table>`` (``cannot drop sequence ... because
+        # other objects depend on it``), which propagates into
+        # the next test's ``init()`` and rolls back the schema
+        # reset, leaking data across tests.
+        # ``create_tmp_table`` must therefore strip the
+        # ``server_default`` / ``default`` from copied PK
+        # columns; the temp table never reads ``id`` (callers
+        # project named columns via ``INSERT ... FROM SELECT``)
+        # so the default is unnecessary.
+        from ivre.db import DBPassive
+        from ivre.db.sql.postgres import PostgresDB
+        from ivre.db.sql.tables import Passive
+
+        # Bind ``create_tmp_table`` to a DuckDB-backed instance
+        # so the actual ``CREATE TEMPORARY TABLE`` DDL runs
+        # against an in-memory engine (DuckDB inherits the PG
+        # dialect via duckdb-engine, so the column-copy logic
+        # under test is identical).  The DuckDB override of
+        # ``create_tmp_table`` raises ``NotImplementedError``
+        # by design; reach past it via the unbound
+        # ``PostgresDB`` method to exercise the live code path.
+        db = DBPassive.from_url("duckdb:///:memory:")
+        db.init()
+        tmp = PostgresDB.create_tmp_table(db, Passive)
+
+        self.assertEqual(tmp.name, "tmp_passive")
+        # The source column keeps its sequence (PG must still
+        # auto-assign ``passive.id`` from ``seq_passive_id``).
+        self.assertIsNotNone(Passive.__table__.c.id.server_default)
+        self.assertIsNotNone(Passive.__table__.c.id.default)
+        # The mirror loses the cross-sequence dependency.
+        self.assertIsNone(tmp.c.id.server_default)
+        self.assertIsNone(tmp.c.id.default)
+        # And the rest of the PK-loosening transform still
+        # holds (no PK constraint, indexed, nullable).
+        self.assertFalse(tmp.c.id.primary_key)
+        self.assertTrue(tmp.c.id.nullable)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
     def test_crud_roundtrip_on_duckdb(self):
         # End-to-end CRUD: insert a scan + a hostname into
         # DuckDB; read them back; ``internal2ip`` collapses

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1810,6 +1810,458 @@ class DuckDBTypeAdapterTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# DuckDBBackendBootstrapTests -- pin the wiring of the new
+# ``ivre.db.sql.duckdb`` backend module: dialect-specific
+# overrides on :class:`~ivre.db.sql.duckdb.DuckDBMixin`,
+# concrete-class registration in :mod:`ivre.db`'s ``backends``
+# dicts, the empty-netloc URL round-trip workaround in
+# :meth:`SQLDB.__init__`, and the
+# ``Sequence`` + ``server_default`` primary-key refactor in
+# :mod:`ivre.db.sql.tables`. M4.1.2 lays the foundation for
+# DuckDB CRUD support; later milestones build query / topvalues
+# / bulk-insert parity on top.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or " "``duckdb`` extras)",
+)
+class DuckDBBackendBootstrapTests(unittest.TestCase):
+    """Pin the M4.1.2 DuckDB backend bootstrap surface.
+
+    Covers the dialect-specific overrides on
+    :class:`~ivre.db.sql.duckdb.DuckDBMixin`, the concrete
+    classes registered against ``duckdb://`` URLs in
+    :class:`~ivre.db.DBNmap` / :class:`~ivre.db.DBView` /
+    :class:`~ivre.db.DBPassive`, the
+    ``Sequence``-driven primary-key refactor in
+    :mod:`ivre.db.sql.tables` (so PostgreSQL keeps emitting
+    ``nextval`` defaults and DuckDB stops choking on ``SERIAL``
+    / ``IDENTITY``), and the empty-netloc URL round-trip
+    workaround in :meth:`~ivre.db.sql.SQLDB.__init__`.
+    """
+
+    # --- ip2internal / internal2ip --------------------------------
+    def test_ip2internal_passes_string_through(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        # On DuckDB the INET column accepts string literals
+        # straight (matching PostgreSQL); the bind-side helper
+        # therefore reduces to ``utils.force_int2ip``.
+        self.assertEqual(DuckDBMixin.ip2internal("192.0.2.1"), "192.0.2.1")
+        self.assertEqual(DuckDBMixin.ip2internal("2001:db8::1"), "2001:db8::1")
+        self.assertIsNone(DuckDBMixin.ip2internal(None))
+
+    def test_ip2internal_converts_int_to_string(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        # ``utils.force_int2ip`` rebuilds the dotted-quad form
+        # for IPv4 ints (mirrors what PostgresDB.ip2internal
+        # does today).
+        self.assertEqual(DuckDBMixin.ip2internal(0xC0000201), "192.0.2.1")
+
+    def test_internal2ip_handles_ipv4_struct(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        # DuckDB's ``INET`` round-trip shape: IPv4 keeps the
+        # natural unsigned address representation.
+        self.assertEqual(
+            DuckDBMixin.internal2ip({"ip_type": 1, "address": 0xC0000201, "mask": 32}),
+            "192.0.2.1",
+        )
+
+    def test_internal2ip_handles_ipv6_struct_with_bias(self):
+        # DuckDB stores ``INET`` v6 addresses as a biased signed
+        # 128-bit integer: the unsigned value is ``address +
+        # 2**127``. Pin three corner cases covering the bias
+        # boundary at zero (``::`` / ``::1``), a representative
+        # global address, and a high-bit-set link-local
+        # address.
+        cases = [
+            ({"ip_type": 2, "address": -((1 << 127)), "mask": 128}, "::"),
+            ({"ip_type": 2, "address": -((1 << 127)) + 1, "mask": 128}, "::1"),
+            (
+                {
+                    "ip_type": 2,
+                    "address": int("20010db8000000000000000000000001", 16) - (1 << 127),
+                    "mask": 128,
+                },
+                "2001:db8::1",
+            ),
+            (
+                {
+                    "ip_type": 2,
+                    "address": int("fe800000000000000000000000000000", 16) - (1 << 127),
+                    "mask": 128,
+                },
+                "fe80::",
+            ),
+        ]
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        for raw, expected in cases:
+            with self.subTest(raw=raw, expected=expected):
+                self.assertEqual(DuckDBMixin.internal2ip(raw), expected)
+
+    def test_internal2ip_passes_none_through(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        self.assertIsNone(DuckDBMixin.internal2ip(None))
+
+    def test_internal2ip_passes_string_through(self):
+        # Defensive path: a future ``duckdb-engine`` release
+        # might switch to returning bare strings (matching
+        # ``psycopg2``); the override should remain a no-op for
+        # those.
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        self.assertEqual(DuckDBMixin.internal2ip("192.0.2.1"), "192.0.2.1")
+
+    # --- NotImplementedError surface ------------------------------
+    def test_copy_from_raises_not_implemented(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        with self.assertRaises(NotImplementedError):
+            DuckDBMixin().copy_from(b"")
+
+    def test_create_tmp_table_raises_not_implemented(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        with self.assertRaises(NotImplementedError):
+            DuckDBMixin().create_tmp_table(object())
+
+    def test_explain_raises_not_implemented(self):
+        from ivre.db.sql.duckdb import DuckDBMixin
+
+        with self.assertRaises(NotImplementedError):
+            DuckDBMixin().explain(object())
+
+    # --- Index / FK classification helpers ------------------------
+    def test_is_unsupported_on_duckdb_classification(self):
+        sa = _sqlalchemy
+        from ivre.db.sql.duckdb import _is_unsupported_on_duckdb
+        from ivre.db.sql.tables import SQLARRAY, SQLINET
+
+        meta = sa.MetaData()
+        tbl = sa.Table(
+            "t",
+            meta,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("info", _sqlalchemy_postgresql.JSONB),
+            sa.Column("addr", SQLINET),
+            sa.Column("tags", SQLARRAY(sa.String(64))),
+            sa.Column("name", sa.String(32)),
+        )
+        gin = sa.Index("ix_gin", tbl.c.info, postgresql_using="gin")
+        partial = sa.Index(
+            "ix_partial", tbl.c.name, postgresql_where=tbl.c.id == 1, unique=True
+        )
+        inet_idx = sa.Index("ix_inet", tbl.c.addr)
+        array_idx = sa.Index("ix_array", tbl.c.tags)
+        plain = sa.Index("ix_plain", tbl.c.name)
+
+        self.assertTrue(_is_unsupported_on_duckdb(gin))
+        self.assertTrue(_is_unsupported_on_duckdb(partial))
+        self.assertTrue(_is_unsupported_on_duckdb(inet_idx))
+        self.assertTrue(_is_unsupported_on_duckdb(array_idx))
+        self.assertFalse(_is_unsupported_on_duckdb(plain))
+
+    def test_normalise_fk_action(self):
+        from ivre.db.sql.duckdb import _normalise_fk_action
+
+        # CASCADE / SET NULL / SET DEFAULT collapse to None
+        # (i.e. the DuckDB-implicit RESTRICT).
+        self.assertIsNone(_normalise_fk_action("CASCADE"))
+        self.assertIsNone(_normalise_fk_action("cascade"))
+        self.assertIsNone(_normalise_fk_action("SET NULL"))
+        self.assertIsNone(_normalise_fk_action("SET DEFAULT"))
+        # RESTRICT / NO ACTION / None pass through unchanged.
+        self.assertEqual(_normalise_fk_action("RESTRICT"), "RESTRICT")
+        self.assertEqual(_normalise_fk_action("NO ACTION"), "NO ACTION")
+        self.assertIsNone(_normalise_fk_action(None))
+
+    # --- tables.py Sequence-based PK refactor ---------------------
+    def test_pk_columns_use_sequence_default(self):
+        # Pin that every surrogate-id column we refactored at
+        # M4.1.2 is bound to a per-tablename
+        # :class:`~sqlalchemy.schema.Sequence` and a
+        # ``server_default`` calling its ``next_value()``.
+        # Without the explicit Sequence, DuckDB's ``CREATE
+        # TABLE`` would fall back to PG's default ``SERIAL``
+        # which DuckDB rejects ("Type with name SERIAL does not
+        # exist").
+        from ivre.db.sql.tables import (
+            Flow,
+            N_Category,
+            N_Hop,
+            N_Hostname,
+            N_Port,
+            N_Scan,
+            N_Tag,
+            N_Trace,
+            Passive,
+            V_Category,
+            V_Hop,
+            V_Hostname,
+            V_Port,
+            V_Scan,
+            V_Tag,
+            V_Trace,
+        )
+
+        for cls in (
+            Flow,
+            Passive,
+            N_Category,
+            V_Category,
+            N_Port,
+            V_Port,
+            N_Tag,
+            V_Tag,
+            N_Hostname,
+            V_Hostname,
+            N_Trace,
+            V_Trace,
+            N_Hop,
+            V_Hop,
+            N_Scan,
+            V_Scan,
+        ):
+            with self.subTest(cls=cls.__name__):
+                col = cls.__table__.c.id
+                self.assertIsNotNone(
+                    col.default, f"{cls.__tablename__}.id has no Sequence default"
+                )
+                self.assertEqual(col.default.name, f"seq_{cls.__tablename__}_id")
+                self.assertIsNotNone(col.server_default)
+                # The compiled default for both dialects calls
+                # ``nextval`` (PG) / the duckdb-engine
+                # equivalent.
+                self.assertIn("next_value", repr(col.server_default.arg))
+
+    def test_create_table_emits_nextval_under_postgresql(self):
+        # Sanity-pin that the Sequence-based PK refactor still
+        # emits the canonical PG ``DEFAULT nextval('...')``
+        # form (i.e. no regression from the previous
+        # ``SERIAL``-equivalent).
+        from sqlalchemy.schema import CreateTable
+
+        from ivre.db.sql.tables import N_Scan
+
+        sql = str(
+            CreateTable(N_Scan.__table__).compile(
+                dialect=_sqlalchemy_postgresql.dialect()
+            )
+        )
+        self.assertIn("DEFAULT nextval('seq_n_scan_id'", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_create_table_emits_nextval_under_duckdb(self):
+        # Same sanity check on DuckDB: the compiled DDL must
+        # call ``nextval`` against the per-table sequence
+        # (DuckDB supports the same ``CREATE SEQUENCE`` /
+        # ``nextval`` primitives as PostgreSQL) rather than
+        # falling back to ``SERIAL`` (which DuckDB rejects).
+        sa = _sqlalchemy
+        from sqlalchemy.schema import CreateTable
+
+        from ivre.db.sql.tables import N_Scan
+
+        engine = sa.create_engine("duckdb:///:memory:")
+        sql = str(CreateTable(N_Scan.__table__).compile(dialect=engine.dialect))
+        self.assertIn("nextval('seq_n_scan_id'", sql)
+        self.assertNotIn("SERIAL", sql)
+        self.assertNotIn("IDENTITY", sql)
+
+    # --- DBNmap / DBView / DBPassive registration -----------------
+    def test_backends_dict_registers_duckdb(self):
+        from ivre.db import DBNmap, DBPassive, DBView
+
+        self.assertEqual(DBNmap.backends.get("duckdb"), ("sql.duckdb", "DuckDBNmap"))
+        self.assertEqual(DBView.backends.get("duckdb"), ("sql.duckdb", "DuckDBView"))
+        self.assertEqual(
+            DBPassive.backends.get("duckdb"), ("sql.duckdb", "DuckDBPassive")
+        )
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_from_url_dispatches_to_duckdb_classes(self):
+        from ivre.db import DBNmap, DBPassive, DBView
+        from ivre.db.sql.duckdb import DuckDBNmap, DuckDBPassive, DuckDBView
+
+        for parent_cls, expected in (
+            (DBNmap, DuckDBNmap),
+            (DBView, DuckDBView),
+            (DBPassive, DuckDBPassive),
+        ):
+            with self.subTest(parent_cls=parent_cls.__name__):
+                inst = parent_cls.from_url("duckdb:///:memory:")
+                self.assertIsInstance(inst, expected)
+
+    # --- URL round-trip fix ---------------------------------------
+    def test_empty_netloc_url_survives_init_round_trip(self):
+        # ``urlparse('duckdb:///:memory:').geturl()`` collapses
+        # the empty-authority ``///`` to a single ``/``,
+        # yielding ``duckdb:/:memory:`` -- which SQLAlchemy
+        # rejects (``Could not parse SQLAlchemy URL from given
+        # URL string``). ``SQLDB.__init__`` reconstructs the
+        # wire form explicitly to side-step the stdlib bug; pin
+        # that.
+        from urllib.parse import urlparse
+
+        from ivre.db.sql import SQLDB
+
+        # First, evidence that the stdlib round-trip itself is
+        # lossy (so a stdlib fix in the future would let us
+        # drop the workaround knowingly).
+        self.assertNotEqual(
+            urlparse("duckdb:///:memory:").geturl(), "duckdb:///:memory:"
+        )
+
+        # Second, the workaround in SQLDB.__init__ produces the
+        # form SQLAlchemy can parse.
+        class _Probe(SQLDB):
+            def __init__(self, url):
+                super().__init__(url)
+
+        for raw in (
+            "duckdb:///:memory:",
+            "duckdb:////tmp/foo.db",
+            "duckdb:///tmp/foo.db",
+            "postgresql://ivre@localhost/ivre",
+        ):
+            with self.subTest(url=raw):
+                probe = _Probe(urlparse(raw))
+                self.assertEqual(probe.dburl, raw)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_init_creates_schema_on_duckdb(self):
+        # End-to-end: ``init()`` on each backend transparently
+        # drops every PG-only declaration DuckDB rejects
+        # (GIN/INET/ARRAY/partial indexes; ``ON DELETE
+        # CASCADE`` on FKs) and successfully materialises the
+        # IVRE schema on an in-memory engine.
+        from ivre.db import DBNmap, DBPassive, DBView
+
+        for cls in (DBNmap, DBView, DBPassive):
+            with self.subTest(cls=cls.__name__):
+                db = cls.from_url("duckdb:///:memory:")
+                db.init()
+                # The expected per-namespace tables exist.
+                from sqlalchemy import inspect
+
+                names = set(inspect(db.db).get_table_names())
+                self.assertTrue(
+                    {"n_scan", "n_port", "n_hostname"} <= names
+                    or {"v_scan", "v_port", "v_hostname"} <= names
+                    or {"passive"} <= names
+                )
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_init_restores_metadata_after_duckdb_run(self):
+        # ``DuckDBMixin.init`` strips a handful of
+        # PG-only schema declarations from the shared
+        # ``Base.metadata`` for the duration of
+        # ``create_all``; the ``finally`` clause must put them
+        # back so a parallel PG engine sharing the same
+        # in-process metadata sees its full schema.
+        from ivre.db import DBNmap
+        from ivre.db.sql.tables import Base
+
+        snapshot = {
+            tbl.name: {
+                "indexes": {
+                    ix.name: (
+                        ix.kwargs.get("postgresql_using"),
+                        ix.kwargs.get("postgresql_where") is not None,
+                    )
+                    for ix in tbl.indexes
+                },
+                "fk_actions": tuple(
+                    sorted(
+                        (str(fkc), fkc.ondelete, fkc.onupdate)
+                        for fkc in tbl.foreign_key_constraints
+                    )
+                ),
+            }
+            for tbl in Base.metadata.tables.values()
+        }
+
+        DBNmap.from_url("duckdb:///:memory:").init()
+
+        post = {
+            tbl.name: {
+                "indexes": {
+                    ix.name: (
+                        ix.kwargs.get("postgresql_using"),
+                        ix.kwargs.get("postgresql_where") is not None,
+                    )
+                    for ix in tbl.indexes
+                },
+                "fk_actions": tuple(
+                    sorted(
+                        (str(fkc), fkc.ondelete, fkc.onupdate)
+                        for fkc in tbl.foreign_key_constraints
+                    )
+                ),
+            }
+            for tbl in Base.metadata.tables.values()
+        }
+        self.assertEqual(snapshot, post)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_crud_roundtrip_on_duckdb(self):
+        # End-to-end CRUD: insert a scan + a hostname into
+        # DuckDB; read them back; ``internal2ip`` collapses
+        # the INET round-trip struct back to the original IP
+        # string.
+        from sqlalchemy import insert, select
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("duckdb:///:memory:")
+        db.init()
+        T = db.tables
+        with db.db.begin() as conn:
+            res = conn.execute(
+                insert(T.scan),
+                {"addr": "192.0.2.1", "source": "test", "schema_version": 22},
+            )
+            scan_id = res.inserted_primary_key[0]
+            conn.execute(
+                insert(T.hostname),
+                {
+                    "scan": scan_id,
+                    "name": "example.com",
+                    "type": "PTR",
+                    "domains": ["example.com", "com"],
+                },
+            )
+        with db.db.connect() as conn:
+            scan_row = conn.execute(select(T.scan.id, T.scan.addr)).one()
+            host_row = conn.execute(select(T.hostname.name, T.hostname.domains)).one()
+        self.assertEqual(scan_row[0], scan_id)
+        self.assertEqual(db.internal2ip(scan_row[1]), "192.0.2.1")
+        self.assertEqual(host_row[0], "example.com")
+        self.assertEqual(host_row[1], ["example.com", "com"])
+
+
+# ---------------------------------------------------------------------
 # SQLDBSearchFieldTests -- pin the shared ``_search_field``
 # dispatch on the SQL backends and the wire shape of the
 # search methods that delegate to it. Mirrors

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -2040,6 +2040,75 @@ class DuckDBBackendBootstrapTests(unittest.TestCase):
                 # equivalent.
                 self.assertIn("next_value", repr(col.server_default.arg))
 
+    def test_pk_column_appears_first_in_table(self):
+        # Regression: the ``Sequence``-driven PK refactor uses
+        # :func:`sqlalchemy.orm.declared_attr` to attach an
+        # ``id`` :func:`~sqlalchemy.orm.mapped_column` to each
+        # mixin subclass.  ``declared_attr`` is processed *after*
+        # the regular class attributes, so without the
+        # ``sort_order=-100`` override the ``id`` column lands
+        # at the *end* of the table's ``columns`` collection.
+        # That breaks every call site that unpacks
+        # ``select(self.tables.<table>)`` rows positionally and
+        # depends on the historical ``id`` -> ``scan`` -> ...
+        # column order -- e.g.
+        # :meth:`SQLDBView.get` /
+        # :meth:`SQLDBNmap.get` (``ports``, ``hostnames``,
+        # ``traces``, ``hops``, ``scripts`` unpacks).  In
+        # production this manifested as
+        # ``ValueError: invalid literal for int() with base 10:
+        # 'udp'`` from ``ivre scancli --honeyd`` -- the
+        # ``protocol`` string ended up where the ``port``
+        # integer was expected.  Pin the contract by asserting
+        # ``id`` is at index 0 on every table whose PK uses the
+        # mixin.
+        from ivre.db.sql.tables import (
+            Flow,
+            N_Category,
+            N_Hop,
+            N_Hostname,
+            N_Port,
+            N_Scan,
+            N_Tag,
+            N_Trace,
+            Passive,
+            V_Category,
+            V_Hop,
+            V_Hostname,
+            V_Port,
+            V_Scan,
+            V_Tag,
+            V_Trace,
+        )
+
+        for cls in (
+            Flow,
+            Passive,
+            N_Category,
+            V_Category,
+            N_Port,
+            V_Port,
+            N_Tag,
+            V_Tag,
+            N_Hostname,
+            V_Hostname,
+            N_Trace,
+            V_Trace,
+            N_Hop,
+            V_Hop,
+            N_Scan,
+            V_Scan,
+        ):
+            with self.subTest(cls=cls.__name__):
+                names = [c.name for c in cls.__table__.columns]
+                self.assertEqual(
+                    names[0],
+                    "id",
+                    f"{cls.__tablename__}.id must be the first column "
+                    f"(positional unpacks in ivre.db.sql depend on it); "
+                    f"got column order {names}",
+                )
+
     def test_create_table_emits_nextval_under_postgresql(self):
         # Sanity-pin that the Sequence-based PK refactor still
         # emits the canonical PG ``DEFAULT nextval('...')``
@@ -2226,10 +2295,10 @@ class DuckDBBackendBootstrapTests(unittest.TestCase):
         "duckdb-engine is required (install with the ``duckdb`` extras)",
     )
     def test_create_tmp_table_strips_pk_sequence_default(self):
-        # Regression: after the M4.1.2 ``Sequence``-driven PK
-        # refactor, ``Column.copy()`` on a source PK column
-        # propagates the ``server_default = nextval('seq_<table>_id')``
-        # clause to the temp-table mirror that
+        # Regression: ``Column.copy()`` on a source PK column
+        # propagates the
+        # ``server_default = nextval('seq_<table>_id')`` clause
+        # to the temp-table mirror that
         # :meth:`PostgresDB.create_tmp_table` builds for the
         # passive bulk-insert path.  PostgreSQL then refuses
         # ``DROP SEQUENCE seq_<table>_id`` while a pooled


### PR DESCRIPTION
Wires duckdb-engine in as a first-class SQL backend alongside the existing PostgreSQL one.  The duckdb-engine SQLAlchemy dialect inherits from the psycopg2 PG dialect, so the existing PostgresDB hierarchy supplies most of the implementation: a new DuckDBMixin layers in the dialect-specific overrides where the two engines genuinely diverge.

* Sequence-driven primary keys in ivre/db/sql/tables.py.  PG silently expanded ``Column(Integer, primary_key=True)`` to ``SERIAL``; DuckDB rejects both ``SERIAL`` and ``GENERATED AS IDENTITY``.  Every surrogate id column now binds an explicit per-tablename ``Sequence`` with ``server_default=seq.next_value()`` so ``CREATE TABLE`` resolves to ``DEFAULT nextval(...)`` on both dialects.  Mixin classes use ``declared_attr`` so each concrete subclass (``n_*`` and ``v_*``) gets its own sequence rather than interleaving IDs.

* DuckDBMixin in ivre/db/sql/duckdb.py overrides:
  - ``internal2ip`` to convert duckdb-engine's INET round-trip struct ``{'ip_type', 'address', 'mask'}`` back to a string. IPv6 storage is *biased* (signed HUGEINT minus 2**127) for sortability across the v4/v6 boundary; the override applies the inverse correction.
  - ``init()`` to transparently strip declarations DuckDB rejects: GIN indexes, partial indexes (``postgresql_where=...``), B-tree indexes keyed on INET or ARRAY columns, and ``ON DELETE CASCADE`` / ``SET NULL`` / ``SET DEFAULT`` referential actions on FKs (DuckDB only accepts the implicit RESTRICT).  Every edit is reverted in a ``finally`` block so other engines sharing the in-process ``Base.metadata`` (e.g. a parallel PG test run) keep their full schema.
  - ``copy_from`` / ``create_tmp_table`` / ``explain`` raise ``NotImplementedError`` with a clear message; per-row ``insert_or_update`` works today.

* Empty-netloc URL round-trip fix in SQLDB.__init__. ``urlparse('duckdb:///:memory:').geturl()`` collapses ``///`` down to ``/``, yielding ``duckdb:/:memory:`` which SQLAlchemy rejects.  Reconstruct the wire form explicitly so ``duckdb:///`` URLs survive while PG / Mongo / Elasticsearch URLs remain byte-for-byte identical.

* DBNmap / DBView / DBPassive register ``"duckdb"`` in their ``backends`` dicts.  Flow on SQL backends is still a stub (Flow's FK to ``host`` cannot be resolved on PG either) so DuckDBFlow is intentionally omitted; it ships alongside the rest of the flow work.

Adds ``DuckDBBackendBootstrapTests`` (20 cases) pinning the override surface, the index/FK classification helpers, the Sequence-based PK shape under both dialects, the URL workaround, end-to-end ``init()`` + CRUD on in-memory DuckDB, and the metadata-restoration invariant after a DuckDB run.