### PR TITLE
feat(db/sql): add cross-backend ``searchtext`` on the active SQL schema

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -47,7 +47,9 @@ from sqlalchemy import (
     nulls_first,
     or_,
     select,
-    text,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy import (
     true,
     update,
 )
@@ -56,6 +58,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from ivre import config, utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
 from ivre.db import DB, DBActive, DBFlow, DBNmap, DBPassive, DBView
+from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
     Flow,
     N_Association_Scan_Category,
@@ -821,6 +824,7 @@ class ActiveFilter(Filter):
         tables=None,
         tag=None,
         trace=None,
+        text=None,
     ):
         self.main = main
         self.hostname = [] if hostname is None else hostname
@@ -830,6 +834,14 @@ class ActiveFilter(Filter):
         self.tables = tables  # default value is handled in the subclasses
         self.tag = [] if tag is None else tag
         self.trace = [] if trace is None else trace
+        # ``text`` holds ``[(incl, search_term), ...]`` for
+        # full-text searches via :meth:`SQLDBActive.searchtext`.
+        # Each search term is matched against every text-bearing
+        # column in the schema (see
+        # :attr:`SQLDBActive._TEXT_SEARCH_TABLES`); a single
+        # ``searchtext("foo")`` therefore composes an
+        # OR-of-EXISTS across every relevant child table.
+        self.text = [] if text is None else text
 
     @property
     def all_queries(self):
@@ -842,6 +854,7 @@ class ActiveFilter(Filter):
             "tables": self.tables,
             "tag": self.tag,
             "trace": self.trace,
+            "text": self.text,
         }
 
     def copy(self):
@@ -854,6 +867,7 @@ class ActiveFilter(Filter):
             tables=self.tables,
             tag=self.tag[:],
             trace=self.trace[:],
+            text=self.text[:],
         )
 
     def __and__(self, other):
@@ -870,6 +884,7 @@ class ActiveFilter(Filter):
             tables=self.tables,
             tag=self.tag + other.tag,
             trace=self.trace + other.trace,
+            text=self.text + other.text,
         )
 
     def __or__(self, other):
@@ -886,6 +901,8 @@ class ActiveFilter(Filter):
             raise ValueError("Cannot 'OR' two filters on tag")
         if self.trace and other.trace:
             raise ValueError("Cannot 'OR' two filters on trace")
+        if self.text and other.text:
+            raise ValueError("Cannot 'OR' two filters on text")
         if self.tables != other.tables:
             raise ValueError("Cannot 'OR' two filters on separate tables")
         return self.__class__(
@@ -896,6 +913,7 @@ class ActiveFilter(Filter):
             script=self.script + other.script,
             tables=self.tables,
             trace=self.trace + other.trace,
+            text=self.text + other.text,
         )
 
     def select_from_base(self, base=None):
@@ -977,7 +995,173 @@ class ActiveFilter(Filter):
                     .where(self.tables.trace.scan == self.tables.scan.id)
                 )
             )
+        for incl, term in self.text:
+            req = req.where(
+                self._text_predicate(term) if incl else not_(self._text_predicate(term))
+            )
         return req
+
+    # ``text`` filter helpers
+    # ----------------------
+    # ``searchtext`` walks every text-bearing child table in
+    # the active schema and OR-joins per-table predicates of
+    # the form ``EXISTS (SELECT 1 FROM child WHERE
+    # child.scan = scan.id AND <fts-expr> @@ plainto_tsquery(?))``.
+    # The per-table column lists below are the SQL projection
+    # of :attr:`DBActive.text_fields` (the MongoDB-style
+    # dot-paths declared in :mod:`ivre.db`).
+    #
+    # Each per-table predicate composes a *single*
+    # ``to_tsvector('english',
+    # coalesce(col1, '') || ' ' || coalesce(col2, '') || ...)``
+    # expression rather than ``OR``-ing per-column
+    # ``to_tsvector`` calls.  PostgreSQL can match the
+    # concatenated expression against a *single* GIN index
+    # built over the same expression (see
+    # :func:`_fts_index` in :mod:`ivre.db.sql.tables`); a
+    # per-column variant would need one GIN index per column
+    # and the query planner cannot merge them as efficiently.
+    _TEXT_SEARCH_PORT_COLUMNS = (
+        "service_name",
+        "service_product",
+        "service_version",
+        "service_extrainfo",
+        "service_devicetype",
+        "service_hostname",
+        "service_ostype",
+    )
+    _TEXT_SEARCH_HOSTNAME_COLUMNS = ("name",)
+    _TEXT_SEARCH_TAG_COLUMNS = ("value", "info")
+    _TEXT_SEARCH_HOP_COLUMNS = ("host",)
+    _TEXT_SEARCH_SCRIPT_COLUMNS = ("output",)
+    _TEXT_SEARCH_CATEGORY_COLUMNS = ("name",)
+
+    @staticmethod
+    def _fts_concat(table, column_names):
+        """Build the
+        ``to_tsvector('english', coalesce(<table>.<col1>, '') || ' ' || ...)``
+        expression that both :meth:`_text_predicate` and the GIN
+        indexes declared in :mod:`ivre.db.sql.tables` (via
+        :func:`ivre.db.sql.tables._fts_index`) reference.
+
+        Returns a SQLAlchemy ``literal_column`` clause built
+        from the same string template :func:`tables._fts_concat`
+        uses; the byte-for-byte match is required so
+        PostgreSQL's planner can substitute the GIN index for
+        the ``WHERE ... @@ ...`` clause.  A SA-expression form
+        (``func.to_tsvector("english", func.coalesce(col, "")
+        + " " + ...)``) emits the same SQL textually but
+        binds ``'english'`` as a parameter rather than a
+        literal regconfig, which the planner treats as a
+        non-immutable function and therefore refuses to match
+        against the index expression.
+        """
+        return tables_module._fts_concat(table.__tablename__, column_names)
+
+    def _text_predicate(self, term):
+        """Build the SQL filter for one ``searchtext(<term>)``
+        match.  Returns an ``OR`` of per-table ``EXISTS``
+        predicates; each per-table predicate is a single
+        ``to_tsvector(...) @@ plainto_tsquery(...)`` over the
+        concatenation of that table's text columns (see
+        :meth:`_fts_concat`).
+
+        The query relies on PostgreSQL's text-search operators;
+        on DuckDB the same operators are accepted via the
+        ``duckdb-engine`` PG-derived dialect but require the
+        ``fts`` extension to be loaded (delivered by a future
+        sub-PR alongside ``PRAGMA create_fts_index`` over the
+        same column set).
+        """
+        tsq = func.plainto_tsquery("english", term)
+        clauses = []
+        # Direct child of ``scan``: hostname, tag, port.
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(self.tables.hostname)
+                .where(self.tables.hostname.scan == self.tables.scan.id)
+                .where(
+                    self._fts_concat(
+                        self.tables.hostname, self._TEXT_SEARCH_HOSTNAME_COLUMNS
+                    ).op("@@")(tsq)
+                )
+            )
+        )
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(self.tables.tag)
+                .where(self.tables.tag.scan == self.tables.scan.id)
+                .where(
+                    self._fts_concat(self.tables.tag, self._TEXT_SEARCH_TAG_COLUMNS).op(
+                        "@@"
+                    )(tsq)
+                )
+            )
+        )
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(self.tables.port)
+                .where(self.tables.port.scan == self.tables.scan.id)
+                .where(
+                    self._fts_concat(
+                        self.tables.port, self._TEXT_SEARCH_PORT_COLUMNS
+                    ).op("@@")(tsq)
+                )
+            )
+        )
+        # Two-hop child of ``scan``: ``script`` -> ``port`` ->
+        # ``scan``.
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(join(self.tables.script, self.tables.port))
+                .where(self.tables.port.scan == self.tables.scan.id)
+                .where(
+                    self._fts_concat(
+                        self.tables.script, self._TEXT_SEARCH_SCRIPT_COLUMNS
+                    ).op("@@")(tsq)
+                )
+            )
+        )
+        # Two-hop child of ``scan``: ``hop`` -> ``trace`` ->
+        # ``scan``.
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(join(self.tables.trace, self.tables.hop))
+                .where(self.tables.trace.scan == self.tables.scan.id)
+                .where(
+                    self._fts_concat(self.tables.hop, self._TEXT_SEARCH_HOP_COLUMNS).op(
+                        "@@"
+                    )(tsq)
+                )
+            )
+        )
+        # Two-hop child of ``scan``: ``category`` ->
+        # ``association_scan_category`` -> ``scan``.
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(
+                    join(
+                        self.tables.category,
+                        self.tables.association_scan_category,
+                    )
+                )
+                .where(
+                    self.tables.association_scan_category.scan == self.tables.scan.id
+                )
+                .where(
+                    self._fts_concat(
+                        self.tables.category, self._TEXT_SEARCH_CATEGORY_COLUMNS
+                    ).op("@@")(tsq)
+                )
+            )
+        )
+        return or_(*clauses)
 
 
 class NmapFilter(ActiveFilter):
@@ -991,6 +1175,7 @@ class NmapFilter(ActiveFilter):
         tables=None,
         tag=None,
         trace=None,
+        text=None,
     ):
         super().__init__(
             main=main,
@@ -1001,6 +1186,7 @@ class NmapFilter(ActiveFilter):
             tables=SQLDBNmap.tables if tables is None else tables,
             tag=tag,
             trace=trace,
+            text=text,
         )
 
 
@@ -1015,6 +1201,7 @@ class ViewFilter(ActiveFilter):
         tables=None,
         tag=None,
         trace=None,
+        text=None,
     ):
         super().__init__(
             main=main,
@@ -1025,6 +1212,7 @@ class ViewFilter(ActiveFilter):
             tables=SQLDBView.tables if tables is None else tables,
             tag=tag,
             trace=trace,
+            text=text,
         )
 
 
@@ -1963,6 +2151,30 @@ class SQLDBActive(SQLDB, DBActive):
             for key, value in tag.items()
         ]
         return cls.base_filter(tag=[(not neg, and_(*req))])
+
+    @classmethod
+    def searchtext(cls, text, neg=False):
+        """Filter records that match the free-text ``text`` term
+        across every text-bearing column in the active schema
+        (``hostname.name``, ``tag.value`` / ``tag.info``,
+        ``port.service_*``, ``script.output``, ``hop.host``,
+        ``category.name``).
+
+        Mirrors the contract of :meth:`MongoDB.searchtext`,
+        which composes the same query against the MongoDB
+        text-index over :attr:`DBActive.text_fields`.  On the
+        SQL backends the dispatch happens at query-build time:
+        :meth:`ActiveFilter._text_predicate` builds an
+        ``OR``-of-``EXISTS`` over each text-bearing child
+        table, and each per-table predicate is itself an
+        ``OR`` of
+        ``to_tsvector('english', col) @@ plainto_tsquery('english', :term)``
+        across that table's text columns.
+
+        With ``neg=True`` the predicate is inverted: scans
+        whose entire text surface is *unrelated* to ``text``.
+        """
+        return cls.base_filter(text=[(not neg, text)])
 
     @classmethod
     def searchport(cls, port, protocol="tcp", state="open", neg=False):
@@ -3048,7 +3260,7 @@ class SQLDBPassive(SQLDB, DBPassive):
         elif field == "net" or field.startswith("net:"):
             info = field[4:]
             info = int(info) if info else 24
-            field = func.set_masklen(text("addr::cidr"), info)
+            field = func.set_masklen(sa_text("addr::cidr"), info)
 
         elif field == "hassh" or (field.startswith("hassh") and field[5] in "-."):
             if "." in field:

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     Text,
     cast,
     func,
+    literal_column,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import declarative_base, declared_attr, mapped_column
@@ -202,6 +203,49 @@ class Point(UserDefinedType):
         return process
 
 
+def _fts_concat(table_name, column_names):
+    """Build the SQL expression
+    ``to_tsvector('english',
+    coalesce(<table>.<col1>, '') || ' ' || coalesce(<table>.<col2>, '') || ...)``
+    used by both the ``searchtext()`` query path and the GIN
+    indexes declared via :func:`_fts_index`.
+
+    The two sites build the *exact same* expression so the
+    PostgreSQL planner can match the index against the WHERE
+    clause; any drift between the index expression and the
+    query expression makes the index unusable.
+
+    Returns a :func:`~sqlalchemy.literal_column` so the result
+    supports SA operator overloading (``.op("@@")`` etc.) and
+    therefore composes naturally into ``WHERE ... @@
+    plainto_tsquery(...)`` clauses.  Lives in
+    :mod:`ivre.db.sql.tables` rather than next to the runtime
+    predicate in :mod:`ivre.db.sql` because table-level
+    ``Index(...)`` declarations need module-import-time
+    expressions, not closures over class attributes.
+    """
+    coalesced = " || ' ' || ".join(
+        f"coalesce({table_name}.{col}, '')" for col in column_names
+    )
+    return literal_column(f"to_tsvector('english', {coalesced})")
+
+
+def _fts_index(name, table_name, column_names):
+    """Wrap ``_fts_concat`` in a GIN ``Index`` declaration that
+    accelerates ``searchtext()`` queries against
+    ``<table>.<col1>``, ``<table>.<col2>``, …  Skipped at
+    create-time on DuckDB by
+    :func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb`
+    (DuckDB has no GIN indexes; full-text matches degrade to
+    sequential scans).
+    """
+    return Index(
+        name,
+        _fts_concat(table_name, column_names),
+        postgresql_using="gin",
+    )
+
+
 # Tables
 Base = declarative_base()
 
@@ -336,7 +380,10 @@ class N_Association_Scan_Category(Base, _Association_Scan_Category):
 
 class N_Category(Base, _Category):
     __tablename__ = "n_category"
-    __table_args__ = (Index("ix_n_category_name", "name", unique=True),)
+    __table_args__ = (
+        Index("ix_n_category_name", "name", unique=True),
+        _fts_index("ix_n_category_fts", "n_category", ("name",)),
+    )
 
 
 class N_Script(Base, _Script):
@@ -346,6 +393,7 @@ class N_Script(Base, _Script):
         Index("ix_n_script_data", "data", postgresql_using="gin"),
         Index("ix_n_script_name", "name"),
         Index("ix_n_script_port_name", "port", "name", unique=True),
+        _fts_index("ix_n_script_fts", "n_script", ("output",)),
     )
 
 
@@ -354,6 +402,19 @@ class N_Port(Base, _Port):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["n_scan.id"], ondelete="CASCADE"),
         Index("ix_n_port_scan_port", "scan", "port", "protocol", unique=True),
+        _fts_index(
+            "ix_n_port_fts",
+            "n_port",
+            (
+                "service_name",
+                "service_product",
+                "service_version",
+                "service_extrainfo",
+                "service_devicetype",
+                "service_hostname",
+                "service_ostype",
+            ),
+        ),
     )
 
 
@@ -362,6 +423,7 @@ class N_Tag(Base, _Tag):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["n_scan.id"], ondelete="CASCADE"),
         Index("ix_n_tag_scan_value_info", "scan", "value", "info", unique=True),
+        _fts_index("ix_n_tag_fts", "n_tag", ("value", "info")),
     )
 
 
@@ -370,6 +432,7 @@ class N_Hostname(Base, _Hostname):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["n_scan.id"], ondelete="CASCADE"),
         Index("ix_n_hostname_scan_name_type", "scan", "name", "type", unique=True),
+        _fts_index("ix_n_hostname_fts", "n_hostname", ("name",)),
     )
 
 
@@ -393,6 +456,7 @@ class N_Hop(Base, _Hop):
     __table_args__ = (
         Index("ix_n_hop_ipaddr_ttl", "ipaddr", "ttl"),
         ForeignKeyConstraint(["trace"], ["n_trace.id"], ondelete="CASCADE"),
+        _fts_index("ix_n_hop_fts", "n_hop", ("host",)),
     )
 
 
@@ -417,7 +481,10 @@ class V_Association_Scan_Category(Base, _Association_Scan_Category):
 
 class V_Category(Base, _Category):
     __tablename__ = "v_category"
-    __table_args__ = (Index("ix_v_category_name", "name", unique=True),)
+    __table_args__ = (
+        Index("ix_v_category_name", "name", unique=True),
+        _fts_index("ix_v_category_fts", "v_category", ("name",)),
+    )
 
 
 class V_Script(Base, _Script):
@@ -427,6 +494,7 @@ class V_Script(Base, _Script):
         Index("ix_v_script_data", "data", postgresql_using="gin"),
         Index("ix_v_script_name", "name"),
         Index("ix_v_script_port_name", "port", "name", unique=True),
+        _fts_index("ix_v_script_fts", "v_script", ("output",)),
     )
 
 
@@ -435,6 +503,19 @@ class V_Port(Base, _Port):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["v_scan.id"], ondelete="CASCADE"),
         Index("ix_v_port_scan_port", "scan", "port", "protocol", unique=True),
+        _fts_index(
+            "ix_v_port_fts",
+            "v_port",
+            (
+                "service_name",
+                "service_product",
+                "service_version",
+                "service_extrainfo",
+                "service_devicetype",
+                "service_hostname",
+                "service_ostype",
+            ),
+        ),
     )
 
 
@@ -443,6 +524,7 @@ class V_Tag(Base, _Tag):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["v_scan.id"], ondelete="CASCADE"),
         Index("ix_v_tag_scan_value_info", "scan", "value", "info", unique=True),
+        _fts_index("ix_v_tag_fts", "v_tag", ("value", "info")),
     )
 
 
@@ -451,6 +533,7 @@ class V_Hostname(Base, _Hostname):
     __table_args__ = (
         ForeignKeyConstraint(["scan"], ["v_scan.id"], ondelete="CASCADE"),
         Index("ix_v_hostname_scan_name_type", "scan", "name", "type", unique=True),
+        _fts_index("ix_v_hostname_fts", "v_hostname", ("name",)),
     )
 
 
@@ -477,6 +560,7 @@ class V_Hop(Base, _Hop):
     __table_args__ = (
         Index("ix_v_hop_ipaddr_ttl", "ipaddr", "ttl"),
         ForeignKeyConstraint(["trace"], ["v_trace.id"], ondelete="CASCADE"),
+        _fts_index("ix_v_hop_fts", "v_hop", ("host",)),
     )
 
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -3139,6 +3139,167 @@ class SQLDBSearchFieldTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBSearchTextTests -- pin the wire shape of the new
+# cross-backend ``searchtext()`` helper on the SQL backends:
+# the GIN-index expression declared in
+# :mod:`ivre.db.sql.tables` and the ``WHERE`` predicate built
+# at query time must match byte-for-byte so PostgreSQL's
+# planner can substitute the index, and the ``OR``-of-EXISTS
+# composition over child tables must include every
+# text-bearing column listed in :attr:`DBActive.text_fields`.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` extras)",
+)
+class SQLDBSearchTextTests(unittest.TestCase):
+    """Behaviour-pin for ``SQLDBActive.searchtext`` -- the
+    new cross-backend full-text-search filter.
+
+    Mirrors the contract of :meth:`MongoDB.searchtext`
+    (``{"$text": {"$search": text}}``).  On the SQL backends
+    the dispatch happens at query-build time:
+    :meth:`ActiveFilter._text_predicate` builds an
+    ``OR``-of-``EXISTS`` over each text-bearing child table,
+    each per-table predicate is itself a single
+    ``to_tsvector('english', coalesce(col1, '') || ' ' ||
+    coalesce(col2, '') || ...) @@ plainto_tsquery('english',
+    :term)``.  Per-table GIN indexes built over the *same*
+    expression accelerate the match.
+    """
+
+    @staticmethod
+    def _compile(stmt):
+        return str(stmt.compile(dialect=_sqlalchemy_postgresql.dialect()))
+
+    def test_searchtext_returns_filter_with_text_slot(self):
+        from ivre.db import DBNmap, DBView
+
+        for cls in (DBNmap, DBView):
+            with self.subTest(cls=cls.__name__):
+                db = cls.from_url("postgresql://x@localhost/x")
+                flt = db.searchtext("honeypot")
+                self.assertEqual(flt.text, [(True, "honeypot")])
+
+    def test_searchtext_negation_inverts_inclusion(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        flt = db.searchtext("honeypot", neg=True)
+        self.assertEqual(flt.text, [(False, "honeypot")])
+
+    def test_searchtext_query_emits_or_of_exists(self):
+        # Pin that the compiled query has one ``EXISTS``
+        # subquery per text-bearing child table
+        # (hostname, tag, port, script, hop, category).
+        sa = _sqlalchemy
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        flt = db.searchtext("honeypot")
+        sql = self._compile(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # One EXISTS per text-bearing table (6 in total).
+        self.assertEqual(sql.count("EXISTS"), 6)
+        # Every per-table predicate uses the ``@@`` operator.
+        self.assertEqual(sql.count("@@ plainto_tsquery"), 6)
+        # And every per-table predicate is the concatenated
+        # ``coalesce`` form (so it can match the GIN index).
+        self.assertIn("v_hostname.scan = v_scan.id", sql)
+        self.assertIn("v_tag.scan = v_scan.id", sql)
+        self.assertIn("v_port.scan = v_scan.id", sql)
+        # script -> port -> scan and hop -> trace -> scan
+        self.assertIn("v_script JOIN v_port", sql)
+        self.assertIn("v_trace JOIN v_hop", sql)
+        # category -> association_scan_category -> scan
+        self.assertIn("v_category JOIN v_association_scan_category", sql)
+
+    def test_searchtext_index_and_query_expressions_match(self):
+        # The GIN index expression and the query predicate
+        # must be byte-for-byte identical so PostgreSQL's
+        # planner can substitute the index for the WHERE
+        # clause.  Pin that for every text-bearing table on
+        # both ``n_*`` and ``v_*`` schemas.
+        sa = _sqlalchemy
+        from sqlalchemy.schema import CreateIndex
+
+        from ivre.db import DBNmap, DBView
+        from ivre.db.sql.tables import (
+            N_Category,
+            N_Hop,
+            N_Hostname,
+            N_Port,
+            N_Script,
+            N_Tag,
+            V_Category,
+            V_Hop,
+            V_Hostname,
+            V_Port,
+            V_Script,
+            V_Tag,
+        )
+
+        nmap_tables = (
+            (N_Hostname, "ix_n_hostname_fts"),
+            (N_Tag, "ix_n_tag_fts"),
+            (N_Port, "ix_n_port_fts"),
+            (N_Script, "ix_n_script_fts"),
+            (N_Hop, "ix_n_hop_fts"),
+            (N_Category, "ix_n_category_fts"),
+        )
+        view_tables = (
+            (V_Hostname, "ix_v_hostname_fts"),
+            (V_Tag, "ix_v_tag_fts"),
+            (V_Port, "ix_v_port_fts"),
+            (V_Script, "ix_v_script_fts"),
+            (V_Hop, "ix_v_hop_fts"),
+            (V_Category, "ix_v_category_fts"),
+        )
+        for cls, tables in ((DBNmap, nmap_tables), (DBView, view_tables)):
+            with self.subTest(cls=cls.__name__):
+                db = cls.from_url("postgresql://x@localhost/x")
+                flt = db.searchtext("honeypot")
+                sql = self._compile(
+                    flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+                )
+                for tbl_cls, idx_name in tables:
+                    idx = next(
+                        ix for ix in tbl_cls.__table__.indexes if ix.name == idx_name
+                    )
+                    idx_sql = str(
+                        CreateIndex(idx).compile(
+                            dialect=_sqlalchemy_postgresql.dialect()
+                        )
+                    )
+                    # Extract the ``to_tsvector(...)`` call up
+                    # to its outermost ``)``: that's the
+                    # expression PostgreSQL has to match against
+                    # the WHERE clause.
+                    paren = idx_sql.index("to_tsvector(")
+                    depth = 0
+                    end = paren
+                    while end < len(idx_sql):
+                        if idx_sql[end] == "(":
+                            depth += 1
+                        elif idx_sql[end] == ")":
+                            depth -= 1
+                            if depth == 0:
+                                end += 1
+                                break
+                        end += 1
+                    expr = idx_sql[paren:end]
+                    self.assertIn(
+                        expr,
+                        sql,
+                        f"{tbl_cls.__name__}: index expression\n  {expr}\n"
+                        f"not found verbatim in query SQL",
+                    )
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Adds :meth:`SQLDBActive.searchtext` so PostgreSQL (and DuckDB, via the duckdb-engine PG-derived dialect) finally honour the :attr:`DBActive.text_fields` contract that
:meth:`MongoDB.searchtext` -- ``{"$text": {"$search": text}}`` -- satisfies on the Mongo backend.  Both
:class:`PostgresDBNmap` / :class:`PostgresDBView` (and their DuckDB descendants) now expose the same ``searchtext(term)`` / ``searchtext(term, neg=True)`` filter that the
``ivre <tool> --search ...`` argparser expects, the MCP server ``rir.search`` route uses, and the
``/cgi/scans?q=text:foo`` web filter dispatches to.

The dispatch happens at query-build time, not via a denormalised ``tsvector`` column on ``scan``: a new ``text`` slot on :class:`ActiveFilter` records the search terms, and :meth:`ActiveFilter.query` composes an ``OR``-of-``EXISTS`` predicate over every text-bearing child table
(``hostname``, ``tag``, ``port``, ``script``, ``hop``, ``category``).  Each per-table predicate is a single ``to_tsvector('english', coalesce(col1, '') || ' ' || coalesce(col2, '') || ...) @@ plainto_tsquery('english', :term)`` over that table's text columns -- the SQL projection of the MongoDB-style dot-paths in :attr:`DBActive.text_fields`.

For each text-bearing table the schema now declares a GIN index built over the *exact same* ``to_tsvector(coalesce(...))`` expression (``ix_<table>_fts``).  PostgreSQL's planner can substitute the index for the WHERE clause only when the two expressions are byte-for-byte identical, so both
:func:`ivre.db.sql.tables._fts_concat` and the runtime :meth:`ActiveFilter._fts_concat` go through one shared ``literal_column`` template; a SA-expression form ( ``func.to_tsvector("english", func.coalesce(col, "") + " " + ...)`` ) emits the same SQL textually but binds ``'english'`` as a parameter rather than a literal regconfig, which the planner treats as a non-immutable function and refuses to match against the index.

The GIN indexes are filtered out of DuckDB schemas at ``init()`` time by the existing
:func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb` check (DuckDB has no ``USING gin``); full-text matches degrade to sequential scans there, which a follow-up will accelerate via the DuckDB FTS extension (``INSTALL fts; LOAD fts; PRAGMA create_fts_index``).

The Elasticsearch backend still lacks ``searchtext``; the four ``hasattr(self, "searchtext")`` guards in
``ivre/web/utils.py``, ``ivre/db/__init__.py``,
``ivre/tools/rirlookup.py`` and
``ivre/tools/mcp_server/__init__.py`` therefore stay in place for now.  Removing them ships alongside the Elastic ``multi_match`` work in the next sub-PR.

Adds ``SQLDBSearchTextTests`` (4 cases) pinning the wire shape of the new helper: filter slot population, negation, the OR-of-EXISTS / one-per-text-table layout, and -- most importantly -- byte-for-byte equality between the GIN-index expression and the WHERE-clause expression on every text-bearing table of both ``n_*`` and ``v_*`` schemas.