### PR TITLE
feat(db/sql/duckdb): wire the FTS extension for searchtext()

### DIFF
--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -31,6 +31,11 @@ the two engines:
 * ``COPY ... FROM STDIN`` and ``CREATE TEMP TABLE`` based bulk
   paths are PG-specific implementation details; bulk-insert
   parity with PostgreSQL is deferred to a follow-up milestone.
+* ``to_tsvector`` / ``plainto_tsquery`` / ``@@`` are not
+  available on DuckDB; full-text search uses the ``fts``
+  extension's ``PRAGMA create_fts_index`` +
+  ``fts_main_<table>.match_bm25(...)`` API instead -- see
+  :class:`DuckDBNmapFilter` / :class:`DuckDBViewFilter`.
 
 The class hierarchy mirrors :mod:`ivre.db.sql.postgres`: a
 :class:`DuckDBMixin` carries the dialect-specific overrides and is
@@ -40,15 +45,61 @@ methods win the MRO lookup against ``PostgresDB*``'s defaults.
 
 from typing import Any, override
 
+from sqlalchemy import event, exists, or_, select
+from sqlalchemy import text as sa_text
 from sqlalchemy.dialects import postgresql
 
 from ivre import utils
+from ivre.db.sql import NmapFilter, ViewFilter
 from ivre.db.sql.postgres import (
     PostgresDBNmap,
     PostgresDBPassive,
     PostgresDBView,
 )
 from ivre.db.sql.tables import Base
+
+# Column lists for the DuckDB FTS index, mirroring
+# :attr:`SQLDBActive._TEXT_SEARCH_*_COLUMNS`.  Indexed by
+# ``self.tables.<attr>`` so the same spec works for both
+# ``n_*`` (DuckDBNmap) and ``v_*`` (DuckDBView) schemas.
+_FTS_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
+    "hostname": ("name",),
+    "tag": ("value", "info"),
+    "port": (
+        "service_name",
+        "service_product",
+        "service_version",
+        "service_extrainfo",
+        "service_devicetype",
+        "service_hostname",
+        "service_ostype",
+    ),
+    "script": ("output",),
+    "hop": ("host",),
+    "category": ("name",),
+}
+
+
+def _install_fts_on_connect(dbapi_connection: Any, _connection_record: Any) -> None:
+    """SQLAlchemy ``connect`` event listener that loads
+    DuckDB's ``fts`` extension on every new connection.
+
+    The extension is required for any
+    ``fts_main_<table>.match_bm25(...)`` call ``searchtext()``
+    emits; without ``LOAD fts`` the function is unresolved and
+    DuckDB raises ``Catalog Error: Scalar Function with name
+    match_bm25 does not exist``.  Each ``ivre <tool>``
+    subprocess opens its own engine, so the load has to happen
+    per-connection, not once at process startup.  ``INSTALL
+    fts`` is idempotent on DuckDB (it's a no-op once the
+    extension is downloaded into the per-user cache).
+    """
+    cur = dbapi_connection.cursor()
+    try:
+        cur.execute("INSTALL fts")
+        cur.execute("LOAD fts")
+    finally:
+        cur.close()
 
 
 def _is_unsupported_on_duckdb(index: Any) -> bool:
@@ -121,6 +172,84 @@ class DuckDBMixin:
     backend class so the MRO resolves these overrides ahead of
     PostgreSQL's defaults (see :pep:`3119` C3 linearisation).
     """
+
+    @property
+    def db(self) -> Any:
+        """Lazily build the SQLAlchemy engine and attach the
+        ``fts`` extension loader to every new connection.
+
+        :meth:`SQLDB.db` caches the engine on ``self._db``; we
+        delegate to it to materialise the engine, then register
+        the :func:`_install_fts_on_connect` listener once.
+        Subsequent ``self.db`` accesses short-circuit through
+        the cached attribute.
+        """
+        try:
+            return self._db  # type: ignore[attr-defined]
+        except AttributeError:
+            # Defer to ``SQLDB.db`` (the parent's lazy-init
+            # property) to actually build and cache the engine,
+            # then attach the FTS loader.  ``event.listen``
+            # only fires on *future* connections; the engine
+            # itself doesn't open a connection on creation, so
+            # the first ``Connection`` IVRE checks out (e.g.
+            # via ``self.drop()``) sees the ``LOAD fts``.  The
+            # local import is required to break the
+            # ``ivre.db.sql`` <-> ``ivre.db.sql.duckdb`` import
+            # cycle at module-load time.
+            # pylint: disable=import-outside-toplevel
+            from ivre.db.sql import SQLDB
+
+            # pylint: disable-next=assignment-from-no-return
+            engine = SQLDB.db.fget(self)  # type: ignore[union-attr]
+            event.listen(engine, "connect", _install_fts_on_connect)
+            return engine
+
+    def _create_fts_indexes(self) -> None:
+        """Build (or rebuild) the per-table FTS indexes
+        DuckDB's ``fts`` extension uses for full-text search.
+
+        DuckDB's FTS index is *static*: it doesn't track row
+        inserts / updates after creation.  Re-running
+        ``PRAGMA create_fts_index(... overwrite=1)`` rebuilds
+        the index from the current table contents, which is
+        why :meth:`searchtext` calls into this method on every
+        full-text query.
+
+        Each index is keyed by ``rowid``, the DuckDB
+        pseudo-column that uniquely identifies a row regardless
+        of declared primary key.  ``rowid`` works equally for
+        tables with a single-column ``id`` and for tables with
+        composite primary keys (``n_script`` / ``v_script``,
+        which have ``(port, name)`` PKs and no surrogate
+        column); the FTS extension's
+        ``match_bm25(<id>, '<term>')`` accepts whatever column
+        the index was built on.
+
+        No-op on backends without text-bearing tables (e.g.
+        :class:`DuckDBPassive`); checked via ``getattr`` on
+        :attr:`self.tables`.
+        """
+        if not hasattr(self, "tables"):
+            return
+        statements = []
+        for tname, cols in _FTS_TABLE_COLUMNS.items():
+            tbl = getattr(self.tables, tname, None)
+            if tbl is None:
+                continue
+            cols_sql = ", ".join(f"'{c}'" for c in cols)
+            # The FTS PRAGMA cannot be parameterised; the
+            # column names are class-level constants (not
+            # user input), so the f-string is safe.
+            statements.append(
+                f"PRAGMA create_fts_index('{tbl.__tablename__}', "
+                f"'rowid', {cols_sql}, overwrite=1)"
+            )
+        if not statements:
+            return
+        with self.db.begin() as conn:
+            for stmt in statements:
+                conn.execute(sa_text(stmt))
 
     @staticmethod
     def ip2internal(addr: str | int | None) -> str | None:
@@ -321,6 +450,12 @@ class DuckDBMixin:
             except AttributeError:
                 pass
             self.create()
+            # Initial empty FTS indexes -- the schema's
+            # text-bearing tables are still empty here, so
+            # ``PRAGMA create_fts_index`` builds zero-row
+            # indexes that subsequent ``searchtext()`` calls
+            # rebuild via ``overwrite=1`` once data is in.
+            self._create_fts_indexes()
         finally:
             for table, indexes in saved_indexes.items():
                 for ix in indexes:
@@ -334,12 +469,140 @@ class DuckDBMixin:
                     col.table.foreign_keys.add(fk)
 
 
+class _DuckDBActiveFilterMixin:
+    """Mixin overriding :meth:`ActiveFilter._text_predicate` for
+    DuckDB.
+
+    DuckDB lacks PostgreSQL's text-search primitives
+    (``to_tsvector``, ``plainto_tsquery``, ``@@``).  Full-text
+    search is delegated to the ``fts`` extension's
+    ``fts_main_<table>.match_bm25(<id>, '<term>')`` function:
+    the BM25 score is non-NULL when the row matches and NULL
+    otherwise, so ``WHERE ... IS NOT NULL`` is the equivalent
+    of PG's ``@@`` predicate.
+
+    Each per-table predicate keeps the same ``EXISTS``-on-the-
+    child shape :meth:`ActiveFilter._text_predicate` uses on
+    PostgreSQL, so the filter composes cleanly with the rest
+    of :class:`ActiveFilter`'s slots.
+    """
+
+    @staticmethod
+    def _bm25_predicate(table_name: str, term: str) -> Any:  # type: ignore[no-untyped-def]
+        """``fts_main_<table>.match_bm25(<table>.rowid, :term)
+        IS NOT NULL`` -- the DuckDB FTS-extension predicate used
+        in place of PostgreSQL's
+        ``to_tsvector(...) @@ plainto_tsquery(...)``.
+        """
+        return sa_text(
+            f"fts_main_{table_name}.match_bm25({table_name}.rowid, :fts_term) "
+            "IS NOT NULL"
+        ).bindparams(fts_term=term)
+
+    def _text_predicate(self, term: str) -> Any:  # type: ignore[no-untyped-def]
+        clauses = []
+        # Direct children of ``scan``: hostname, tag, port.
+        for tname in ("hostname", "tag", "port"):
+            tbl = getattr(self.tables, tname)
+            clauses.append(
+                exists(
+                    select(1)
+                    .select_from(tbl)
+                    .where(tbl.scan == self.tables.scan.id)
+                    .where(self._bm25_predicate(tbl.__tablename__, term))
+                )
+            )
+        # Two-hop child of ``scan``: ``script`` -> ``port`` ->
+        # ``scan``.
+        script_tbl = self.tables.script
+        port_tbl = self.tables.port
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(script_tbl.__table__.join(port_tbl.__table__))
+                .where(port_tbl.scan == self.tables.scan.id)
+                .where(self._bm25_predicate(script_tbl.__tablename__, term))
+            )
+        )
+        # Two-hop child of ``scan``: ``hop`` -> ``trace`` ->
+        # ``scan``.
+        hop_tbl = self.tables.hop
+        trace_tbl = self.tables.trace
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(trace_tbl.__table__.join(hop_tbl.__table__))
+                .where(trace_tbl.scan == self.tables.scan.id)
+                .where(self._bm25_predicate(hop_tbl.__tablename__, term))
+            )
+        )
+        # Two-hop child of ``scan``: ``category`` ->
+        # ``association_scan_category`` -> ``scan``.
+        cat_tbl = self.tables.category
+        assoc_tbl = self.tables.association_scan_category
+        clauses.append(
+            exists(
+                select(1)
+                .select_from(cat_tbl.__table__.join(assoc_tbl.__table__))
+                .where(assoc_tbl.scan == self.tables.scan.id)
+                .where(self._bm25_predicate(cat_tbl.__tablename__, term))
+            )
+        )
+        return or_(*clauses)
+
+
+class DuckDBNmapFilter(_DuckDBActiveFilterMixin, NmapFilter):
+    """``NmapFilter`` with DuckDB-flavoured full-text-search
+    predicates (FTS extension's ``match_bm25`` instead of
+    PostgreSQL's ``to_tsvector @@ plainto_tsquery``)."""
+
+
+class DuckDBViewFilter(_DuckDBActiveFilterMixin, ViewFilter):
+    """``ViewFilter`` with DuckDB-flavoured full-text-search
+    predicates."""
+
+
 class DuckDBNmap(DuckDBMixin, PostgresDBNmap):
     """DuckDB backend for the ``nmap`` (active-scan) data category."""
+
+    base_filter = DuckDBNmapFilter
+
+    # The override is an instance method (``self``) where the
+    # parent :meth:`SQLDBActive.searchtext` is a ``@classmethod``
+    # (``cls``); pylint compares positionally and reports the
+    # ``cls`` -> ``self`` rename as a renamed parameter.  The
+    # mismatch is by design: this override needs engine access
+    # (``self.db``) to rebuild the FTS index, which a
+    # classmethod cannot do.
+    @override
+    def searchtext(  # pylint: disable=arguments-renamed
+        self, text: str, neg: bool = False
+    ) -> Any:  # type: ignore[no-untyped-def, override]
+        # DuckDB's FTS index is static -- it doesn't track row
+        # inserts after creation.  Rebuild it before every
+        # ``searchtext()`` query so the result is always fresh.
+        # The cost is a full text-column scan per text-bearing
+        # table, which is acceptable for the embedded /
+        # single-host workloads DuckDB targets.
+        self._create_fts_indexes()
+        return self.base_filter(text=[(not neg, text)])
 
 
 class DuckDBView(DuckDBMixin, PostgresDBView):
     """DuckDB backend for the ``view`` (merged-host) data category."""
+
+    base_filter = DuckDBViewFilter
+
+    # See :meth:`DuckDBNmap.searchtext` for the
+    # classmethod-to-instance-method override rationale.
+    @override
+    def searchtext(  # pylint: disable=arguments-renamed
+        self, text: str, neg: bool = False
+    ) -> Any:  # type: ignore[no-untyped-def, override]
+        # See :meth:`DuckDBNmap.searchtext` for the
+        # rebuild-on-every-search rationale.
+        self._create_fts_indexes()
+        return self.base_filter(text=[(not neg, text)])
 
 
 class DuckDBPassive(DuckDBMixin, PostgresDBPassive):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -2604,6 +2604,184 @@ class DuckDBBackendBootstrapTests(unittest.TestCase):
         self.assertEqual(host_row[0], "example.com")
         self.assertEqual(host_row[1], ["example.com", "com"])
 
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_fts_extension_loaded_on_connect(self):
+        # Pin that the ``connect`` event listener registered by
+        # :meth:`DuckDBMixin.db` runs ``INSTALL fts; LOAD fts;``
+        # on every new DuckDB connection so the FTS extension's
+        # ``match_bm25`` function is callable from the
+        # subsequent searchtext queries.  Without the listener
+        # ``match_bm25`` resolves with ``Catalog Error: Scalar
+        # Function with name match_bm25 does not exist``.
+        #
+        # Search term ``apache`` is intentional: DuckDB's
+        # Snowball-based default stemmer filters out common
+        # English stopwords (``hello``, ``world``, ``the``,
+        # ...) that would silently return NULL scores on every
+        # row regardless of the index loading correctly.
+        from sqlalchemy import text as sa_text
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("duckdb:///:memory:")
+        with db.db.begin() as conn:
+            conn.execute(sa_text("CREATE TABLE fts_probe (id_col INTEGER, t VARCHAR)"))
+            conn.execute(sa_text("INSERT INTO fts_probe VALUES (1, 'apache')"))
+            conn.execute(sa_text("PRAGMA create_fts_index('fts_probe', 'id_col', 't')"))
+            rows = conn.execute(
+                sa_text(
+                    "SELECT id_col, fts_main_fts_probe.match_bm25(id_col, "
+                    "'apache') FROM fts_probe"
+                )
+            ).fetchall()
+        # Single row, score is non-NULL (BM25 weight) when the
+        # index is loaded and the term matches.
+        self.assertEqual(len(rows), 1)
+        self.assertIsNotNone(rows[0][1])
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_fts_indexes_created_at_init(self):
+        # ``DuckDBMixin.init`` calls ``_create_fts_indexes``
+        # after ``create()`` so every text-bearing table gets
+        # an empty FTS index ready for ``searchtext()`` to
+        # rebuild.  Pin that an FTS index exists for each
+        # expected table after a fresh init.
+        from sqlalchemy import text as sa_text
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("duckdb:///:memory:")
+        db.init()
+        with db.db.connect() as conn:
+            schemas = {
+                row[0]
+                for row in conn.execute(
+                    sa_text(
+                        "SELECT schema_name FROM information_schema.schemata "
+                        "WHERE schema_name LIKE 'fts_main_n_%'"
+                    )
+                ).fetchall()
+            }
+        # One ``fts_main_<table>`` schema per text-bearing
+        # active table (hostname, tag, port, script, hop,
+        # category).
+        self.assertSetEqual(
+            schemas,
+            {
+                "fts_main_n_hostname",
+                "fts_main_n_tag",
+                "fts_main_n_port",
+                "fts_main_n_script",
+                "fts_main_n_hop",
+                "fts_main_n_category",
+            },
+        )
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchtext_uses_bm25_on_duckdb(self):
+        # The DuckDB filter override emits ``match_bm25``
+        # predicates instead of the PostgreSQL
+        # ``to_tsvector @@ plainto_tsquery`` -- the latter
+        # would raise ``Catalog Error: Scalar Function with
+        # name to_tsvector does not exist`` on DuckDB.  Pin
+        # that the compiled SQL goes through the BM25 API.
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("duckdb:///:memory:")
+        db.init()
+        flt = db.searchtext("honeypot")
+        # Filter type: ``DuckDBNmapFilter`` (or subclass).
+        from ivre.db.sql.duckdb import DuckDBNmapFilter
+
+        self.assertIsInstance(flt, DuckDBNmapFilter)
+        # Compile the WHERE clause through the DuckDB dialect
+        # and assert the BM25 wire shape.
+        from sqlalchemy import func as sa_func
+        from sqlalchemy import select as sa_select
+
+        sql = str(
+            flt.query(sa_select(sa_func.count()).select_from(flt.select_from)).compile(
+                dialect=db.db.dialect
+            )
+        )
+        self.assertIn("match_bm25", sql)
+        self.assertIn("IS NOT NULL", sql)
+        # And there is *no* PG-only call.
+        self.assertNotIn("to_tsvector", sql)
+        self.assertNotIn("plainto_tsquery", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchtext_end_to_end_on_duckdb(self):
+        # Insert a host whose text fields cover several of the
+        # FTS-indexed tables, then exercise positive /
+        # negative ``searchtext()`` queries.  Without the
+        # rebuild-on-every-search behaviour
+        # (:meth:`DuckDBNmap.searchtext` calls
+        # :meth:`_create_fts_indexes` before returning) the
+        # search would miss every row inserted after init.
+        from sqlalchemy import insert
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("duckdb:///:memory:")
+        db.init()
+        with db.db.begin() as conn:
+            res = conn.execute(
+                insert(db.tables.scan),
+                {"addr": "192.0.2.1", "source": "test", "schema_version": 22},
+            )
+            scan_id = res.inserted_primary_key[0]
+            conn.execute(
+                insert(db.tables.hostname),
+                {
+                    "scan": scan_id,
+                    "name": "honeypot.example.com",
+                    "type": "PTR",
+                    "domains": ["example.com", "com"],
+                },
+            )
+            conn.execute(
+                insert(db.tables.port),
+                {
+                    "scan": scan_id,
+                    "port": 80,
+                    "protocol": "tcp",
+                    "service_name": "http",
+                    "service_product": "nginx",
+                    "state": "open",
+                },
+            )
+            conn.execute(
+                insert(db.tables.tag),
+                {
+                    "scan": scan_id,
+                    "value": "HONEYPOT",
+                    "info": "kibana stack",
+                    "type": "warning",
+                },
+            )
+        # Positive matches across hostname / port / tag.
+        self.assertEqual(db.count(db.searchtext("honeypot")), 1)
+        self.assertEqual(db.count(db.searchtext("nginx")), 1)
+        self.assertEqual(db.count(db.searchtext("kibana")), 1)
+        # Non-match.
+        self.assertEqual(db.count(db.searchtext("nonexistent")), 0)
+        # Negation flips the inclusion.
+        self.assertEqual(db.count(db.searchtext("honeypot", neg=True)), 0)
+        self.assertEqual(db.count(db.searchtext("nonexistent", neg=True)), 1)
+
 
 # ---------------------------------------------------------------------
 # SQLDBSearchFieldTests -- pin the shared ``_search_field``


### PR DESCRIPTION
DuckDB has none of PostgreSQL's text-search primitives -- no ``to_tsvector``, no ``plainto_tsquery``, no ``@@`` operator (``Catalog Error: Scalar Function with name to_tsvector does not exist``).  The previous searchtext landing therefore emitted SQL that compiled but crashed at runtime on the DuckDB backend.

Replace the PG-shaped predicate on DuckDB with the FTS extension's ``match_bm25`` API.  Three pieces wire together:

* A ``connect`` event listener attached lazily by an override of :meth:`SQLDB.db` runs ``INSTALL fts; LOAD fts;`` on every new DuckDB connection so the extension's functions resolve. Each ``ivre <tool>`` subprocess opens its own engine, so the load has to happen per-connection, not once at process startup.

* :meth:`DuckDBMixin._create_fts_indexes` runs ``PRAGMA create_fts_index(<table>, 'rowid', col1, col2, ..., overwrite=1)`` for every text-bearing active table (``hostname``, ``tag``, ``port``, ``script``, ``hop``, ``category``).  ``rowid`` -- DuckDB's pseudo-column for per-row identity -- works equally for tables with a single-column ``id`` and for ``script`` (composite ``(port, name)`` PK, no surrogate column).  The PRAGMA is invoked once at ``init()`` time to seed empty indexes and again from the searchtext code path before every query to refresh stale ones (DuckDB's FTS index is *static*, see the docstring on the method).

* :class:`DuckDBNmapFilter` / :class:`DuckDBViewFilter` override :meth:`ActiveFilter._text_predicate` to emit ``EXISTS (SELECT 1 FROM <child> WHERE <child>.scan = <scan>.id AND fts_main_<child>.match_bm25(<child>.rowid, :term) IS NOT NULL)`` per text-bearing child table -- the same ``OR``-of-``EXISTS`` shape PG uses, only swapping the per-table predicate.  Hooked in via ``DuckDB{Nmap,View}.base_filter`` overrides.

The DuckDB ``searchtext()`` override is an instance method where the ``SQLDBActive.searchtext`` parent is a
``@classmethod``: it needs engine access
(``self._create_fts_indexes()``) to rebuild the index before each query, which a classmethod cannot do.  The signature mismatch is silenced with a per-line ``arguments-renamed`` disable; the SA dialect import is renamed to ``sa_text`` to avoid shadowing the ``text`` parameter.

Adds four pinning tests under ``DuckDBBackendBootstrapTests``: the connect-time FTS load, the per-table FTS index creation at ``init()`` time, the BM25 wire shape in the compiled SQL (no ``to_tsvector`` leaks), and end-to-end searchtext over populated hostname / port / tag rows including negation.