### PR TITLE
feat(db/sql): add searchcpe / searchos / searchvuln* on PG + DuckDB

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -156,7 +156,7 @@ class ScanCSVFile(CSVFile):
         self.fdesc = None
 
     def fixline(self, line):
-        for field in ["cpes", "extraports", "openports", "os", "traces"]:
+        for field in ["extraports", "openports", "traces"]:
             line.pop(field, None)
         line["addr"] = self.ip2internal(line["addr"])
         line["time_start"] = line.pop("starttime")
@@ -182,7 +182,7 @@ class ScanCSVFile(CSVFile):
                                 cert[fld] = utils.all2datetime(cert[fld]).timestamp()
             if "screendata" in port:
                 port["screendata"] = utils.encode_b64(port["screendata"])
-        for field in ["hostnames", "ports", "info"]:
+        for field in ["hostnames", "ports", "info", "cpes", "os"]:
             if field in line:
                 line[field] = json.dumps(line[field]).replace("\\", "\\\\")
         return [
@@ -2740,6 +2740,135 @@ class SQLDBActive(SQLDB, DBActive):
                         cls.tables.port.state == "open",
                         cls.tables.port.service_product == "vsftpd",
                         cls.tables.port.service_version == "2.3.4",
+                    ),
+                )
+            ]
+        )
+
+    @classmethod
+    def searchvulnintersil(cls):
+        # See MSF modules/auxiliary/admin/http/intersil_pass_reset.rb
+        return cls.base_filter(
+            port=[
+                (
+                    True,
+                    and_(
+                        cls.tables.port.protocol == "tcp",
+                        cls.tables.port.state == "open",
+                        cls.tables.port.service_product == "Boa HTTPd",
+                        cls._searchstring_re(
+                            cls.tables.port.service_version,
+                            re.compile(
+                                "^0\\.9(3([^0-9]|$)"
+                                "|4\\.([0-9]|0[0-9]|1[0-1])([^0-9]|$))"
+                            ),
+                        ),
+                    ),
+                )
+            ]
+        )
+
+    @classmethod
+    def searchcpe(cls, cpe_type=None, vendor=None, product=None, version=None):
+        """Filter records carrying a CPE matching the given criteria.
+        Each kwarg accepts a string, a list of strings, or a compiled
+        regex. With no argument the filter only checks for the
+        presence of at least one CPE entry.
+
+        Mirrors the contract of :meth:`MongoDB.searchcpe`. The CPE
+        list is stored verbatim from the Mongo-shape host record on
+        the ``scan.cpes`` JSONB column; matching is performed by
+        unwinding that array via :func:`jsonb_array_elements` and
+        AND-combining the per-field predicates inside an ``EXISTS``.
+        """
+        fields = [
+            ("type", cpe_type),
+            ("vendor", vendor),
+            ("product", product),
+            ("version", version),
+        ]
+        flt = [(field, value) for field, value in fields if value is not None]
+        if not flt:
+            return cls.base_filter(
+                main=cls.tables.scan.cpes != None,  # noqa: E711
+            )
+        cpe_alias = func.jsonb_array_elements(cls.tables.scan.cpes).alias("__cpe")
+        conds = [
+            cls._search_field(column("__cpe").op("->>")(fname), value)
+            for fname, value in flt
+        ]
+        return cls.base_filter(
+            main=and_(
+                cls.tables.scan.cpes != None,  # noqa: E711
+                exists(select(1).select_from(cpe_alias).where(and_(*conds))),
+            ),
+        )
+
+    @classmethod
+    def searchos(cls, txt):
+        """Filter records whose OS detection (``osclass`` array)
+        matches ``txt`` on at least one of vendor / family /
+        generation / type. ``txt`` may be a string or a compiled
+        regex.
+
+        Mirrors :meth:`MongoDB.searchos`. The Mongo-shape ``host['os']``
+        dict is stored verbatim on the ``scan.os`` JSONB column; the
+        ``osclass`` sub-array is unwound via :func:`jsonb_array_elements`
+        and the per-field predicates are OR-combined inside an
+        ``EXISTS``.
+        """
+        osclass_alias = func.jsonb_array_elements(
+            cls.tables.scan.os.op("->")("osclass")
+        ).alias("__osclass")
+        conds = or_(
+            *(
+                cls._searchstring_re(column("__osclass").op("->>")(fname), txt)
+                for fname in ("vendor", "osfamily", "osgen", "type")
+            )
+        )
+        return cls.base_filter(
+            main=and_(
+                cls.tables.scan.os != None,  # noqa: E711
+                func.jsonb_typeof(cls.tables.scan.os.op("->")("osclass")) == "array",
+                exists(select(1).select_from(osclass_alias).where(conds)),
+            ),
+        )
+
+    @classmethod
+    def searchvuln(cls, vulnid=None, state=None):
+        """Filter records that expose a vulnerability matching
+        ``vulnid`` and / or ``state``. With both args ``None`` the
+        filter accepts any host with at least one detected
+        vulnerability.
+
+        Mirrors :meth:`MongoDB.searchvuln`. Vulnerabilities are
+        stored as part of the script ``data`` JSONB at
+        ``data['vulns']`` (a list of ``{id, state, ...}`` entries
+        post-schema-v8 migration); the array is unwound via
+        :func:`jsonb_array_elements` and the per-field predicates
+        are AND-combined inside a correlated ``EXISTS``.
+        """
+        vuln_alias = func.jsonb_array_elements(
+            cls.tables.script.data.op("->")("vulns")
+        ).alias("__vuln")
+        inner_conds = []
+        if vulnid is not None:
+            inner_conds.append(
+                cls._search_field(column("__vuln").op("->>")("id"), vulnid)
+            )
+        if state is not None:
+            inner_conds.append(
+                cls._search_field(column("__vuln").op("->>")("state"), state)
+            )
+        inner_where = and_(*inner_conds) if inner_conds else true()
+        return cls.base_filter(
+            script=[
+                (
+                    True,
+                    and_(
+                        func.jsonb_typeof(cls.tables.script.data.op("->")("vulns"))
+                        == "array",
+                        exists(select(1).select_from(vuln_alias).where(inner_where)),
                     ),
                 )
             ]

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -43,10 +43,16 @@ placed *first* in the bases tuple of every concrete class so its
 methods win the MRO lookup against ``PostgresDB*``'s defaults.
 """
 
+# Tests like "expr == None" should be used for BinaryExpression instances
+# pylint: disable=singleton-comparison
+
+
+import re
 from typing import Any, override
 
-from sqlalchemy import event, exists, or_, select
+from sqlalchemy import and_, event, exists, func, not_, or_, select
 from sqlalchemy import text as sa_text
+from sqlalchemy import true
 from sqlalchemy.dialects import postgresql
 
 from ivre import utils
@@ -172,6 +178,36 @@ class DuckDBMixin:
     backend class so the MRO resolves these overrides ahead of
     PostgreSQL's defaults (see :pep:`3119` C3 linearisation).
     """
+
+    @override
+    @staticmethod
+    def _searchstring_re(field, value, neg=False):  # type: ignore[no-untyped-def, override]
+        """DuckDB equivalent of :meth:`SQLDB._searchstring_re`.
+
+        DuckDB's parser does not recognise PostgreSQL's
+        case-insensitive regex operator ``~*`` (only ``~`` is
+        accepted, and even that maps to plain regex match
+        rather than the POSIX semantics PG uses).  This override
+        rewrites the pattern in terms of the
+        :func:`regexp_matches` scalar, whose third argument
+        accepts an options string (``'i'`` for case-insensitive,
+        empty for case-sensitive).
+
+        For non-regex values, the parent's scalar / list /
+        equality dispatch shape is preserved verbatim.
+        """
+        if isinstance(value, utils.REGEXP_T):
+            options = "i" if (value.flags & re.IGNORECASE) else ""
+            if options:
+                flt = func.regexp_matches(field, value.pattern, options)
+            else:
+                flt = func.regexp_matches(field, value.pattern)
+            if neg:
+                return not_(flt)
+            return flt
+        if neg:
+            return field != value
+        return field == value
 
     @property
     def db(self) -> Any:
@@ -562,7 +598,140 @@ class DuckDBViewFilter(_DuckDBActiveFilterMixin, ViewFilter):
     predicates."""
 
 
-class DuckDBNmap(DuckDBMixin, PostgresDBNmap):
+# DuckDB's ``json_each`` table function returns 8 implicit
+# columns (``key``, ``value``, ``type``, ``atom``, ``id``,
+# ``parent``, ``fullkey``, ``path``).  ``.table_valued(*cols)``
+# declares the column shape the SQLAlchemy compiler exposes via
+# ``.c``; declaring all 8 keeps the emitted ``AS alias(...)``
+# matched to the function's actual arity (DuckDB rejects an
+# alias whose column count diverges from the function's
+# declared output).  Only ``value`` (the JSON of each element)
+# is actually consulted.
+_JSON_EACH_COLUMNS = (
+    "key",
+    "value",
+    "type",
+    "atom",
+    "id",
+    "parent",
+    "fullkey",
+    "path",
+)
+
+
+class _DuckDBActiveSearchMixin:
+    """DuckDB-flavoured implementations of the JSONB-array-driven
+    ``search*`` helpers (``searchcpe``, ``searchos``,
+    ``searchvuln``) that :class:`SQLDBActive` ships in PostgreSQL
+    dialect.
+
+    PostgreSQL's :func:`jsonb_array_elements` and
+    :func:`jsonb_typeof` have no direct DuckDB equivalents; this
+    mixin emits :func:`json_each` (DuckDB's table-valued JSON
+    unwind, with a fixed 8-column return shape) and
+    :func:`json_type` instead.  ``json_type`` returns its result
+    in upper-case (``'ARRAY'``, ``'OBJECT'``, ...) where
+    PostgreSQL's :func:`jsonb_typeof` returns lower-case
+    (``'array'``, ``'object'``, ...).
+
+    The query shape (``EXISTS`` over the unwound array, AND-
+    combined per-field text predicates) mirrors the PostgreSQL
+    implementation exactly so the two backends share a single
+    Mongo-shape contract.
+    """
+
+    @override
+    @classmethod
+    def searchcpe(  # type: ignore[no-untyped-def, override]
+        cls, cpe_type=None, vendor=None, product=None, version=None
+    ):
+        """DuckDB equivalent of :meth:`SQLDBActive.searchcpe`."""
+        fields = [
+            ("type", cpe_type),
+            ("vendor", vendor),
+            ("product", product),
+            ("version", version),
+        ]
+        flt = [(field, value) for field, value in fields if value is not None]
+        if not flt:
+            return cls.base_filter(
+                main=cls.tables.scan.cpes != None,  # noqa: E711
+            )
+        cpe_alias = (
+            func.json_each(cls.tables.scan.cpes)
+            .table_valued(*_JSON_EACH_COLUMNS)
+            .alias("__cpe")
+        )
+        conds = [
+            cls._search_field(cpe_alias.c.value.op("->>")(fname), value)
+            for fname, value in flt
+        ]
+        return cls.base_filter(
+            main=and_(
+                cls.tables.scan.cpes != None,  # noqa: E711
+                exists(select(1).select_from(cpe_alias).where(and_(*conds))),
+            ),
+        )
+
+    @override
+    @classmethod
+    def searchos(cls, txt):  # type: ignore[no-untyped-def, override]
+        """DuckDB equivalent of :meth:`SQLDBActive.searchos`."""
+        osclass_alias = (
+            func.json_each(cls.tables.scan.os.op("->")("osclass"))
+            .table_valued(*_JSON_EACH_COLUMNS)
+            .alias("__osclass")
+        )
+        conds = or_(
+            *(
+                cls._searchstring_re(osclass_alias.c.value.op("->>")(fname), txt)
+                for fname in ("vendor", "osfamily", "osgen", "type")
+            )
+        )
+        return cls.base_filter(
+            main=and_(
+                cls.tables.scan.os != None,  # noqa: E711
+                func.json_type(cls.tables.scan.os.op("->")("osclass")) == "ARRAY",
+                exists(select(1).select_from(osclass_alias).where(conds)),
+            ),
+        )
+
+    @override
+    @classmethod
+    def searchvuln(  # type: ignore[no-untyped-def, override]
+        cls, vulnid=None, state=None
+    ):
+        """DuckDB equivalent of :meth:`SQLDBActive.searchvuln`."""
+        vuln_alias = (
+            func.json_each(cls.tables.script.data.op("->")("vulns"))
+            .table_valued(*_JSON_EACH_COLUMNS)
+            .alias("__vuln")
+        )
+        inner_conds = []
+        if vulnid is not None:
+            inner_conds.append(
+                cls._search_field(vuln_alias.c.value.op("->>")("id"), vulnid)
+            )
+        if state is not None:
+            inner_conds.append(
+                cls._search_field(vuln_alias.c.value.op("->>")("state"), state)
+            )
+        inner_where = and_(*inner_conds) if inner_conds else true()
+        return cls.base_filter(
+            script=[
+                (
+                    True,
+                    and_(
+                        func.json_type(cls.tables.script.data.op("->")("vulns"))
+                        == "ARRAY",
+                        exists(select(1).select_from(vuln_alias).where(inner_where)),
+                    ),
+                )
+            ]
+        )
+
+
+class DuckDBNmap(DuckDBMixin, _DuckDBActiveSearchMixin, PostgresDBNmap):
     """DuckDB backend for the ``nmap`` (active-scan) data category."""
 
     base_filter = DuckDBNmapFilter
@@ -588,7 +757,7 @@ class DuckDBNmap(DuckDBMixin, PostgresDBNmap):
         return self.base_filter(text=[(not neg, text)])
 
 
-class DuckDBView(DuckDBMixin, PostgresDBView):
+class DuckDBView(DuckDBMixin, _DuckDBActiveSearchMixin, PostgresDBView):
     """DuckDB backend for the ``view`` (merged-host) data category."""
 
     base_filter = DuckDBViewFilter

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -46,6 +46,7 @@ from sqlalchemy import (
     insert,
     join,
     not_,
+    null,
     nulls_first,
     select,
     text,
@@ -1519,6 +1520,18 @@ class PostgresDBNmap(PostgresDBActive, SQLDBNmap):
                 state=host.get("state"),
                 state_reason=host.get("state_reason"),
                 state_reason_ttl=host.get("state_reason_ttl"),
+                # SQLAlchemy's JSON / JSONB ``bind_processor`` calls
+                # :func:`json.dumps` on whatever Python value it
+                # receives, so passing ``None`` would store the
+                # JSON literal ``'null'`` (and ``cpes IS NOT NULL``
+                # would still match the row).  Pass an explicit
+                # SQL ``NULL`` for absent / empty payloads so
+                # :meth:`searchcpe` / :meth:`searchos` match only
+                # records with real data, mirroring Mongo's
+                # ``{"$exists": true}`` semantics on the array
+                # field.
+                cpes=host["cpes"] if host.get("cpes") else null(),
+                os=host["os"] if host.get("os") else null(),
             )
             .on_conflict_do_nothing()
             .returning(self.tables.scan.id)
@@ -1629,11 +1642,9 @@ class PostgresDBNmap(PostgresDBActive, SQLDBNmap):
             extracols=[
                 Column("categories", ARRAY(String(32))),
                 Column("source", String(32)),
-                # Column("cpe", postgresql.JSONB),
                 # Column("extraports", postgresql.JSONB),
                 Column("hostnames", postgresql.JSONB),
                 # openports
-                # Column("os", postgresql.JSONB),
                 Column("ports", postgresql.JSONB),
                 # Column("traceroutes", postgresql.JSONB),
             ],
@@ -1657,6 +1668,14 @@ class PostgresDBView(PostgresDBActive, SQLDBView):
                 info=info,
                 time_start=host_tstart,
                 time_stop=host_tstop,
+                # See :meth:`PostgresDBNmap._store_host` for the
+                # ``null()`` rationale (a Python ``None`` would
+                # serialise to JSON ``'null'`` rather than SQL
+                # ``NULL`` on a JSONB column, defeating
+                # ``IS NOT NULL`` filters in :meth:`searchcpe` /
+                # :meth:`searchos`).
+                cpes=host["cpes"] if host.get("cpes") else null(),
+                os=host["os"] if host.get("os") else null(),
                 **{
                     key: host.get(key)
                     for key in ["state", "state_reason", "state_reason_ttl"]
@@ -1675,6 +1694,8 @@ class PostgresDBView(PostgresDBActive, SQLDBView):
                         self.tables.scan.time_stop,
                         insrt.excluded.time_stop,
                     ),
+                    "cpes": func.coalesce(insrt.excluded.cpes, self.tables.scan.cpes),
+                    "os": func.coalesce(insrt.excluded.os, self.tables.scan.os),
                 },
             )
             .returning(self.tables.scan.id, self.tables.scan.time_stop)

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -367,6 +367,8 @@ class _Scan:
     state_reason = Column(String(32))
     state_reason_ttl = Column(Integer)
     schema_version = Column(Integer, default=xmlnmap.SCHEMA_VERSION)
+    cpes = Column(SQLJSONB)
+    os = Column(SQLJSONB)
 
 
 # Nmap

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -3599,6 +3599,263 @@ class SQLDBSearchTextTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBSearchCpeOsVulnTests -- pin the wire shape of the
+# Mongo-shape ``searchcpe`` / ``searchos`` / ``searchvuln*``
+# helpers on the SQL backends.  Both PostgreSQL and DuckDB are
+# exercised so the dialect-aware split (PG :func:`jsonb_array_elements`
+# + :func:`jsonb_typeof` vs DuckDB :func:`json_each` +
+# :func:`json_type`, plus the ``~*`` -> :func:`regexp_matches`
+# rewrite) stays under regression coverage.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBSearchCpeOsVulnTests(unittest.TestCase):
+    """Behaviour-pin for ``SQLDBActive.searchcpe`` /
+    ``searchos`` / ``searchvuln`` / ``searchvulnintersil``.
+
+    Each method mirrors the contract of its counterpart on
+    :class:`MongoDB` (``cpes`` / ``os.osclass`` / ``ports.scripts.vulns``);
+    on the SQL backends the matching logic unwinds the JSONB
+    array column with PG's :func:`jsonb_array_elements` (or
+    DuckDB's :func:`json_each`) and AND-/OR-combines the
+    per-field text predicates inside an ``EXISTS``.
+
+    The DuckDB lane also exercises the
+    ``_searchstring_re`` -> :func:`regexp_matches` rewrite the
+    :class:`DuckDBMixin` ships, since DuckDB's parser does not
+    accept PostgreSQL's case-insensitive regex operator
+    ``~*``.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _compile_duckdb(stmt):
+        # ``duckdb_engine`` is the optional dependency the
+        # module-level try-import already gated behind
+        # ``_HAVE_DUCKDB_ENGINE``; reuse the module-scope
+        # binding rather than re-importing locally.
+        return str(
+            stmt.compile(
+                dialect=duckdb_engine.Dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    def _run_count_query(self, db_url, factory):
+        # Build an ``ActiveFilter`` from the connection URL and
+        # the supplied factory (``factory(db) -> filter``), then
+        # return the rendered ``SELECT count(*) ...`` query.
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url(db_url)
+        flt = factory(db)
+        return flt, flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+
+    # -- searchcpe -----------------------------------------------------
+
+    def test_searchcpe_no_args_emits_is_not_null(self):
+        from ivre.db import DBNmap, DBView
+
+        for cls in (DBNmap, DBView):
+            with self.subTest(cls=cls.__name__):
+                db = cls.from_url("postgresql://x@localhost/x")
+                flt = db.searchcpe()
+                sa = _sqlalchemy
+                sql = self._compile_pg(
+                    flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+                )
+                # A zero-arg call only checks for the column's
+                # presence: no ``EXISTS`` over the unwound array,
+                # just an ``IS NOT NULL`` on the JSONB column.
+                self.assertIn("cpes IS NOT NULL", sql)
+                self.assertNotIn("jsonb_array_elements", sql)
+
+    def test_searchcpe_pg_unwinds_with_jsonb_array_elements(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchcpe(vendor="apache", product="httpd")
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # PG: ``jsonb_array_elements(scan.cpes) AS __cpe`` and
+        # then ``__cpe ->> '<field>'`` per condition.
+        self.assertIn("jsonb_array_elements(n_scan.cpes) AS __cpe", sql)
+        self.assertIn("__cpe ->> ", sql)
+        # Two AND-combined predicates (vendor + product).
+        self.assertEqual(sql.count("__cpe ->>"), 2)
+
+    def test_searchcpe_pg_regex_emits_caseinsensitive_op(self):
+        import re
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchcpe(vendor=re.compile("^apache", re.IGNORECASE))
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # The case-insensitive flag maps to PG's ``~*`` operator.
+        self.assertIn("~*", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchcpe_duckdb_unwinds_with_json_each(self):
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchcpe(vendor="apache", product="httpd")
+        sa = _sqlalchemy
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # DuckDB: ``json_each(scan.cpes) AS __cpe(...)`` with
+        # the 8-column shape declared by ``_JSON_EACH_COLUMNS``.
+        self.assertIn("json_each(n_scan.cpes)", sql)
+        self.assertIn("__cpe", sql)
+        # Conditions reference ``__cpe.value -> '<field>'`` --
+        # the "value" column is the per-element JSON.
+        self.assertIn("__cpe.value ->>", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchcpe_duckdb_regex_uses_regexp_matches(self):
+        import re
+
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchcpe(vendor=re.compile("^apache", re.IGNORECASE))
+        sa = _sqlalchemy
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # DuckDB cannot parse ``~*``; the override emits a
+        # ``regexp_matches(field, pattern, 'i')`` call instead.
+        self.assertNotIn("~*", sql)
+        self.assertIn("regexp_matches(", sql)
+
+    # -- searchos ------------------------------------------------------
+
+    def test_searchos_pg_unwinds_osclass_array(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchos("Linux")
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # PG: unwinds ``scan.os -> 'osclass'`` and OR-combines
+        # the four per-field predicates.
+        self.assertIn("jsonb_array_elements(n_scan.os -> 'osclass')", sql)
+        self.assertIn("jsonb_typeof(n_scan.os -> 'osclass') = 'array'", sql)
+        for field in ("vendor", "osfamily", "osgen", "type"):
+            self.assertIn(f"__osclass ->> '{field}'", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchos_duckdb_unwinds_osclass_array(self):
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchos("Linux")
+        sa = _sqlalchemy
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("json_each(n_scan.os -> 'osclass')", sql)
+        # DuckDB ``json_type`` returns upper-case ARRAY where
+        # PG's :func:`jsonb_typeof` returns lower-case array.
+        self.assertIn("json_type(n_scan.os -> 'osclass') = 'ARRAY'", sql)
+
+    # -- searchvuln ----------------------------------------------------
+
+    def test_searchvuln_pg_unwinds_script_data_vulns(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchvuln(vulnid="CVE-2021-44228", state="VULNERABLE")
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # The vuln predicate lives on the ``script`` table and
+        # composes the EXISTS over ``script.data -> 'vulns'``.
+        self.assertIn("jsonb_array_elements(n_script.data -> 'vulns')", sql)
+        self.assertIn("jsonb_typeof(n_script.data -> 'vulns') = 'array'", sql)
+        # Two AND-combined predicates: id + state.
+        self.assertIn("__vuln ->> 'id'", sql)
+        self.assertIn("__vuln ->> 'state'", sql)
+
+    def test_searchvuln_no_args_keeps_existence_check(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchvuln()
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # No ``id`` / ``state`` predicates -- the inner WHERE
+        # collapses to ``true`` so any non-empty vulns array
+        # matches.
+        self.assertIn("jsonb_array_elements(n_script.data -> 'vulns')", sql)
+        self.assertNotIn("__vuln ->>", sql)
+
+    # -- searchvulnintersil --------------------------------------------
+
+    def test_searchvulnintersil_emits_port_predicates(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchvulnintersil()
+        sa = _sqlalchemy
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Pure port-table filter -- no JSON unwind.
+        self.assertNotIn("jsonb_array_elements", sql)
+        self.assertIn("n_port.protocol = 'tcp'", sql)
+        self.assertIn("n_port.state = 'open'", sql)
+        self.assertIn("n_port.service_product = 'Boa HTTPd'", sql)
+
+    # -- schema --------------------------------------------------------
+
+    def test_scan_schema_carries_cpes_and_os_columns(self):
+        # Pin that the new columns made it onto the shared
+        # ``_Scan`` mixin and are present on both ``n_scan``
+        # and ``v_scan``.
+        from ivre.db.sql.tables import N_Scan, V_Scan
+
+        for cls in (N_Scan, V_Scan):
+            with self.subTest(cls=cls.__name__):
+                self.assertIn("cpes", cls.__table__.columns)
+                self.assertIn("os", cls.__table__.columns)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Bring the Mongo-shape ``searchcpe`` / ``searchos`` / ``searchvuln`` / ``searchvulnintersil`` filters to ``SQLDBActive`` so PostgreSQL and DuckDB stop dropping the host-level CPE list and OS detection on ingestion and start matching the Mongo backend's contract.

Schema:

* Add ``cpes`` / ``os`` JSONB columns to ``_Scan``; both ``N_Scan`` (active scans) and ``V_Scan`` (merged view) inherit them.
* Populate the new columns in ``PostgresDBNmap._store_host`` and ``PostgresDBView._store_host``. Pass an explicit ``null()`` for absent / empty payloads -- a Python ``None`` would round-trip through SQLAlchemy's JSON ``bind_processor`` as the JSON literal ``'null'`` rather than SQL ``NULL``, defeating the ``IS NOT NULL`` filter ``searchcpe()`` / ``searchos()`` rely on.
* The view-level upsert keeps the latest non-null value via ``coalesce(insrt.excluded.<col>, scan.<col>)``; full Mongo-style per-CPE merge (``ivre.active.data.merge_host_docs``) stays a follow-up.
* Stop stripping ``cpes`` / ``os`` in ``ScanCSVFile.fixline`` so the COPY-FROM path keeps them too, and JSON-encode them alongside ``hostnames`` / ``ports`` / ``info``.

PostgreSQL search helpers (``SQLDBActive``):

* ``searchcpe`` unwinds ``scan.cpes`` with ``jsonb_array_elements`` and AND-combines per-field text predicates inside an ``EXISTS``; a zero-arg call collapses to ``cpes IS NOT NULL``.
* ``searchos`` unwinds ``scan.os -> 'osclass'`` and OR-combines the four per-field predicates (vendor / family / generation / type), gated on ``jsonb_typeof(...) = 'array'``.
* ``searchvuln`` lives on the script-table predicate and unwinds ``script.data -> 'vulns'``; ``vulnid`` / ``state`` are AND- combined inside the inner ``EXISTS``.
* ``searchvulnintersil`` is a pure port-table filter -- no JSON unwind.

DuckDB search helpers (``_DuckDBActiveSearchMixin`` wired into ``DuckDBNmap`` / ``DuckDBView``):

* DuckDB has no ``jsonb_array_elements`` / ``jsonb_typeof``; override emits ``json_each(col)`` (table-valued, 8-column shape declared up-front to keep the alias arity matched) and ``json_type(col) = 'ARRAY'`` (DuckDB returns upper-case where PG returns lower-case).
* ``DuckDBMixin._searchstring_re`` rewrites the regex predicate: DuckDB's parser does not accept PostgreSQL's case-insensitive ``~*`` operator, so the override emits ``regexp_matches(field, pattern, 'i')`` (or ``regexp_matches(field, pattern)`` for case-sensitive). Latent issue affecting any prior search* helper that flowed a case-insensitive ``REGEXP_T`` to DuckDB; fixed alongside the new helpers.

Tests (``tests/tests_no_backend.py::SQLDBSearchCpeOsVulnTests``):

11 pin tests cover both backends -- per-helper SQL shape (which function unwinds the array, which operator matches the regex, which type-check guards the unwind), zero-arg short-circuits (``cpes IS NOT NULL``), and the new ``cpes`` / ``os`` columns on ``N_Scan`` / ``V_Scan``.