### PR TITLE
feat(db/sql): add searchscreenshot / searchsmbshares / removescreenshot

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -1941,6 +1941,9 @@ class SQLDBActive(SQLDB, DBActive):
                     recp["service_hostname"],
                     recp["service_ostype"],
                     recp["service_servicefp"],
+                    recp["screenshot"],
+                    recp["screendata"],
+                    recp["screenwords"],
                 ) = port
                 try:
                     recp["state_reason_ip"] = self.internal2ip(recp["state_reason_ip"])
@@ -2872,6 +2875,233 @@ class SQLDBActive(SQLDB, DBActive):
                     ),
                 )
             ]
+        )
+
+    @classmethod
+    def searchscreenshot(
+        cls,
+        port=None,
+        protocol="tcp",
+        service=None,
+        words=None,
+        neg=False,
+    ):
+        """Filter records that have (or, with ``neg=True``, lack)
+        a screenshot on at least one port.
+
+        Mirrors the contract of :meth:`MongoDB.searchscreenshot`.
+        ``port`` / ``protocol`` / ``service`` constrain the
+        matching port; ``words`` filters on the OCR word list:
+
+        * ``None``: only the existence (or absence, on
+          ``neg=True``) of a screenshot is checked.
+        * ``bool``: filter ports with (``True``) or without
+          (``False``) any OCR word; ``neg`` is ignored.
+        * ``str``: case-insensitive equality (after
+          lower-casing) against any element of the
+          ``screenwords`` array.
+        * regex: case-(in)sensitive regex match against any
+          element of the array.
+        * ``list``: every element must match (``$all`` on Mongo,
+          ``screenwords @> ARRAY[...]`` here).
+
+        With ``words is not None`` and ``neg=True`` the predicate
+        means "has a screenshot **without** the requested words",
+        matching the Mongo helper.
+
+        Note the Mongo-shape semantics for ``neg=True`` when no
+        port / service / words constraint is present:
+        ``{"ports.screenshot": {"$exists": false}}`` matches
+        hosts where **no** port has a screenshot, *not* hosts
+        with at least one port without one (which is almost
+        every host).  The SQL equivalent flips at the
+        ``EXISTS`` level (``base_filter(port=[(False, ...)])``)
+        rather than at the inner predicate.  Once a port /
+        service / words constraint is present the flip happens
+        at the inner predicate, matching Mongo's
+        ``$elemMatch`` semantics.
+        """
+        port_t = cls.tables.port
+        if words is None:
+            screenshot_exists = port_t.screenshot != None  # noqa: E711
+            if port is None and service is None:
+                # ``ports.screenshot.$exists: false`` means *no*
+                # port has a screenshot -- flip at the EXISTS
+                # level via the ``incl=False`` slot.
+                return cls.base_filter(port=[(not neg, screenshot_exists)])
+            conds = [
+                port_t.screenshot == None if neg else screenshot_exists,  # noqa: E711
+            ]
+            if port is not None:
+                conds.extend([port_t.port == port, port_t.protocol == protocol])
+            if service is not None:
+                conds.append(port_t.service_name == service)
+            return cls.base_filter(port=[(True, and_(*conds))])
+        # ``words`` is set: a screenshot must always exist.
+        conds = [port_t.screenshot != None]  # noqa: E711
+        if isinstance(words, bool):
+            conds.append(
+                port_t.screenwords == None  # noqa: E711
+                if not words
+                else port_t.screenwords != None  # noqa: E711
+            )
+        elif isinstance(words, list):
+            lowered = [w.lower() for w in words]
+            if neg:
+                # PG / DuckDB ``arr @> ARRAY[...]`` returns NULL
+                # when ``arr`` is NULL, and ``NOT NULL`` is NULL
+                # in three-valued logic -- a port with no OCR
+                # words would be silently dropped from the neg
+                # side.  Mongo's ``$ne`` matches missing fields,
+                # so add an explicit ``IS NULL`` branch to keep
+                # cross-backend parity.
+                conds.append(
+                    or_(
+                        port_t.screenwords == None,  # noqa: E711
+                        not_(port_t.screenwords.contains(lowered)),
+                    )
+                )
+            else:
+                conds.append(port_t.screenwords.contains(lowered))
+        elif isinstance(words, utils.REGEXP_T):
+            # Match any array element against the regex.  Wrap
+            # the ``unnest()`` SRF in a sub-SELECT projecting an
+            # explicit ``v`` column so the inner predicate
+            # references ``sub.c.v`` regardless of dialect:
+            # PostgreSQL accepts the bare table-function alias
+            # but DuckDB requires ``AS alias(col)`` syntax for
+            # the column name to be bindable; the sub-SELECT
+            # form normalises both ends.  ``unnest(NULL)`` is
+            # zero rows on both backends, so ``NOT EXISTS``
+            # naturally matches NULL ``screenwords`` -- no
+            # explicit ``IS NULL`` branch needed for the
+            # negated side here.
+            sw_subq = select(func.unnest(port_t.screenwords).label("v")).subquery()
+            sw_pred = cls._searchstring_re(sw_subq.c.v, words)
+            inner = exists(select(1).select_from(sw_subq).where(sw_pred))
+            conds.append(not_(inner) if neg else inner)
+        else:  # plain string
+            lowered = words.lower()
+            if neg:
+                # Same NULL-handling rationale as the list path
+                # above.
+                conds.append(
+                    or_(
+                        port_t.screenwords == None,  # noqa: E711
+                        not_(port_t.screenwords.any(lowered)),
+                    )
+                )
+            else:
+                conds.append(port_t.screenwords.any(lowered))
+        if port is not None:
+            conds.extend([port_t.port == port, port_t.protocol == protocol])
+        if service is not None:
+            conds.append(port_t.service_name == service)
+        return cls.base_filter(port=[(True, and_(*conds))])
+
+    @classmethod
+    def searchsmbshares(cls, access="", hidden=None):
+        """Filter SMB shares with the given ``access`` (default:
+        either read or write, accepted values 'r', 'w', 'rw').
+
+        ``hidden=True`` selects hidden shares only,
+        ``hidden=False`` non-hidden only, ``None`` (the default)
+        accepts either.
+
+        Mirrors :meth:`MongoDB.searchsmbshares`.  The Mongo
+        contract delegates to ``searchscript`` with a nested
+        ``$elemMatch`` / ``$or`` / ``$nin`` shape that the
+        existing SQL ``searchscript`` value-translator does not
+        cover; this implementation builds the equivalent
+        predicate directly against ``script.data['shares']``.
+        """
+        access_pattern = {
+            "": re.compile("^(READ|WRITE)"),
+            "r": re.compile("^READ(/|$)"),
+            "w": re.compile("(^|/)WRITE$"),
+            "rw": "READ/WRITE",
+            "wr": "READ/WRITE",
+        }[access.lower()]
+        excluded_share_types = (
+            "STYPE_IPC_HIDDEN",
+            "Not a file share",
+            "STYPE_IPC",
+            "STYPE_PRINTQ",
+        )
+        share_alias = func.jsonb_array_elements(
+            cls.tables.script.data.op("->")("shares")
+        ).alias("__share")
+        share_col = column("__share")
+        access_match = or_(
+            cls._search_field(share_col.op("->>")("Anonymous access"), access_pattern),
+            cls._search_field(
+                share_col.op("->>")("Current user access"), access_pattern
+            ),
+        )
+        type_col = share_col.op("->>")("Type")
+        if hidden is None:
+            type_match = type_col.notin_(excluded_share_types)
+        elif hidden:
+            type_match = type_col == "STYPE_DISKTREE_HIDDEN"
+        else:
+            type_match = type_col == "STYPE_DISKTREE"
+        share_name_match = share_col.op("->>")("Share") != "IPC$"
+        return cls.base_filter(
+            script=[
+                (
+                    True,
+                    and_(
+                        cls.tables.script.name == "smb-enum-shares",
+                        func.jsonb_typeof(cls.tables.script.data.op("->")("shares"))
+                        == "array",
+                        exists(
+                            select(1)
+                            .select_from(share_alias)
+                            .where(
+                                and_(
+                                    access_match,
+                                    type_match,
+                                    share_name_match,
+                                )
+                            )
+                        ),
+                    ),
+                )
+            ]
+        )
+
+    def removescreenshot(self, host, port=None, protocol="tcp"):
+        """Clear screenshot fields on the matching port row(s) of
+        the given host record (in the database) and on the
+        in-memory ``host`` dict (so subsequent caller logic sees
+        the post-removal shape).
+
+        Mirrors :meth:`MongoDB.removescreenshot`.
+        """
+        # Mutate the in-memory dict to match Mongo's behaviour.
+        for portrec in host.get("ports", []):
+            if port is not None and (
+                portrec.get("port") != port or portrec.get("protocol") != protocol
+            ):
+                continue
+            if "screenshot" not in portrec:
+                continue
+            portrec.pop("screendata", None)
+            portrec.pop("screenwords", None)
+            portrec.pop("screenshot", None)
+        # And issue the DB UPDATE.
+        port_t = self.tables.port
+        update_filter = port_t.scan == host.get("_id")
+        if port is not None:
+            update_filter = and_(
+                update_filter,
+                port_t.port == port,
+                port_t.protocol == protocol,
+            )
+        self._write(
+            update(port_t)
+            .where(update_filter)
+            .values(screenshot=None, screendata=None, screenwords=None)
         )
 
     @classmethod

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -730,6 +730,76 @@ class _DuckDBActiveSearchMixin:
             ]
         )
 
+    @override
+    @classmethod
+    def searchsmbshares(  # type: ignore[no-untyped-def, override]
+        cls, access="", hidden=None
+    ):
+        """DuckDB equivalent of :meth:`SQLDBActive.searchsmbshares`.
+
+        Same Mongo-shape contract; the JSON unwind goes through
+        DuckDB's :func:`json_each` table function and the type
+        guard uses :func:`json_type` (returning upper-case
+        ``'ARRAY'`` where PostgreSQL's :func:`jsonb_typeof`
+        returns lower-case ``'array'``).
+        """
+        access_pattern = {
+            "": re.compile("^(READ|WRITE)"),
+            "r": re.compile("^READ(/|$)"),
+            "w": re.compile("(^|/)WRITE$"),
+            "rw": "READ/WRITE",
+            "wr": "READ/WRITE",
+        }[access.lower()]
+        excluded_share_types = (
+            "STYPE_IPC_HIDDEN",
+            "Not a file share",
+            "STYPE_IPC",
+            "STYPE_PRINTQ",
+        )
+        share_alias = (
+            func.json_each(cls.tables.script.data.op("->")("shares"))
+            .table_valued(*_JSON_EACH_COLUMNS)
+            .alias("__share")
+        )
+        share_val = share_alias.c.value
+        access_match = or_(
+            cls._search_field(share_val.op("->>")("Anonymous access"), access_pattern),
+            cls._search_field(
+                share_val.op("->>")("Current user access"), access_pattern
+            ),
+        )
+        type_col = share_val.op("->>")("Type")
+        if hidden is None:
+            type_match = type_col.notin_(excluded_share_types)
+        elif hidden:
+            type_match = type_col == "STYPE_DISKTREE_HIDDEN"
+        else:
+            type_match = type_col == "STYPE_DISKTREE"
+        share_name_match = share_val.op("->>")("Share") != "IPC$"
+        return cls.base_filter(
+            script=[
+                (
+                    True,
+                    and_(
+                        cls.tables.script.name == "smb-enum-shares",
+                        func.json_type(cls.tables.script.data.op("->")("shares"))
+                        == "ARRAY",
+                        exists(
+                            select(1)
+                            .select_from(share_alias)
+                            .where(
+                                and_(
+                                    access_match,
+                                    type_match,
+                                    share_name_match,
+                                )
+                            )
+                        ),
+                    ),
+                )
+            ]
+        )
+
 
 class DuckDBNmap(DuckDBMixin, _DuckDBActiveSearchMixin, PostgresDBNmap):
     """DuckDB backend for the ``nmap`` (active-scan) data category."""

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -1564,12 +1564,16 @@ class PostgresDBNmap(PostgresDBActive, SQLDBNmap):
                     )
         for port in host.get("ports", []):
             scripts = port.pop("scripts", [])
-            # FIXME: handle screenshots
-            for fld in ["screendata", "screenshot", "screenwords", "service_method"]:
-                try:
-                    del port[fld]
-                except KeyError:
-                    pass
+            # ``service_method`` has no dedicated column on the
+            # ``_Port`` mixin -- it's an ephemeral nmap-detection
+            # tag (``probed`` / ``table``) that doesn't add value
+            # to a stored record.  ``screendata`` is normalised
+            # below: bytes are kept as-is for the ``LargeBinary``
+            # column, base64-encoded strings (some ingestion
+            # paths produce those) are decoded back to bytes.
+            port.pop("service_method", None)
+            if "screendata" in port and isinstance(port["screendata"], str):
+                port["screendata"] = utils.decode_b64(port["screendata"].encode())
             if "service_servicefp" in port:
                 port["service_fp"] = port.pop("service_servicefp")
             if "state_state" in port:
@@ -1717,12 +1721,11 @@ class PostgresDBView(PostgresDBActive, SQLDBView):
             )
         for port in host.get("ports", []):
             scripts = port.pop("scripts", [])
-            # FIXME: handle screenshots
-            for fld in ["screendata", "screenshot", "screenwords", "service_method"]:
-                try:
-                    del port[fld]
-                except KeyError:
-                    pass
+            # See :meth:`PostgresDBNmap._store_host` for the
+            # ``service_method`` and ``screendata`` rationale.
+            port.pop("service_method", None)
+            if "screendata" in port and isinstance(port["screendata"], str):
+                port["screendata"] = utils.decode_b64(port["screendata"].encode())
             if "service_servicefp" in port:
                 port["service_fp"] = port.pop("service_servicefp")
             if "state_state" in port:

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     Integer,
+    LargeBinary,
     Sequence,
     String,
     Text,
@@ -315,6 +316,17 @@ class _Port:
     service_hostname = Column(String(256))
     service_ostype = Column(String(64))
     service_fp = Column(Text)
+    # Screenshot fields. ``screenshot`` is a short text indicator
+    # (``"field"`` when the bytes are stored in ``screendata``,
+    # ``"empty"`` when the capture failed, or a filename for the
+    # nmap NSE script-on-disk variant). ``screendata`` keeps the
+    # raw bytes -- bytea on PostgreSQL, BLOB on DuckDB -- to match
+    # the Mongo backend's ``bson.Binary`` round-trip semantics.
+    # ``screenwords`` is the OCR word list extracted from the
+    # screenshot via :func:`ivre.utils.screenwords`.
+    screenshot = Column(String(256))
+    screendata = Column(LargeBinary)
+    screenwords = Column(SQLARRAY(Text))
 
 
 class _Tag:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -3856,6 +3856,324 @@ class SQLDBSearchCpeOsVulnTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBSearchSmbScreenshotTests -- pin the wire shape of
+# ``searchsmbshares`` / ``searchscreenshot`` / ``removescreenshot``
+# on the SQL backends.  Both PostgreSQL and DuckDB are exercised
+# so the dialect-aware split (PG :func:`jsonb_array_elements` /
+# :func:`jsonb_typeof` vs DuckDB :func:`json_each` /
+# :func:`json_type`) for the ``searchsmbshares`` JSON-array unwind
+# stays under regression coverage, alongside the new screenshot
+# columns on ``_Port``.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBSearchSmbScreenshotTests(unittest.TestCase):
+    """Behaviour-pin for ``SQLDBActive.searchsmbshares`` /
+    ``searchscreenshot`` / ``removescreenshot``.
+
+    * ``searchscreenshot`` is mostly column-based filtering on
+      the new ``screenshot`` / ``screenwords`` columns of
+      :class:`~ivre.db.sql.tables._Port`; the regex word-match
+      path wraps the ``screenwords`` array unwind in a
+      sub-SELECT projecting an explicit ``v`` column so the
+      same SQL compiles under both backends.
+    * ``searchsmbshares`` unwinds ``script.data['shares']`` and
+      AND-combines per-element predicates inside an ``EXISTS``;
+      the DuckDB lane swaps PostgreSQL's
+      :func:`jsonb_array_elements` / :func:`jsonb_typeof` for
+      :func:`json_each` / :func:`json_type` (and the
+      ``ARRAY`` / ``array`` casing flip).
+    * ``removescreenshot`` mutates the in-memory host record
+      (matching Mongo's helper) **and** issues an ``UPDATE``
+      on the port table to clear the three screenshot columns.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _compile_duckdb(stmt):
+        return str(
+            stmt.compile(
+                dialect=duckdb_engine.Dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    # -- searchscreenshot ----------------------------------------------
+
+    def test_searchscreenshot_no_args_short_circuits(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot()
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Existence check on the per-port ``screenshot`` column
+        # rather than a JSON unwind.
+        self.assertIn("n_port.screenshot IS NOT NULL", sql)
+        self.assertNotIn("jsonb_array_elements", sql)
+        self.assertNotIn("screenwords", sql)
+
+    def test_searchscreenshot_negation_flips_at_exists_level(self):
+        # ``Mongo``'s ``{"ports.screenshot": {"$exists": false}}``
+        # means **no** port has a screenshot, *not* "there is a
+        # port without a screenshot".  Pin that the SQL flip
+        # happens at the ``EXISTS`` (``incl=False``) level when
+        # no port / service constraint is present.
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot(neg=True)
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # NOT IN translation of the ``incl=False`` slot.
+        self.assertIn("NOT IN", sql)
+        self.assertIn("n_port.screenshot IS NOT NULL", sql)
+
+    def test_searchscreenshot_with_port_neg_flips_at_predicate(self):
+        # With a port / service constraint the flip happens at
+        # the inner predicate (``screenshot IS NULL``) so other
+        # ports of the same host can still have screenshots.
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot(port=80, neg=True)
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("n_port.screenshot IS NULL", sql)
+        self.assertIn("n_port.port = 80", sql)
+        self.assertNotIn("NOT IN", sql)
+
+    def test_searchscreenshot_words_string_lowercases(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot(words="WELCOME")
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Word match goes through ``ANY(screenwords)``, value
+        # is lower-cased to match Mongo's pre-stored shape.
+        self.assertIn("'welcome' = ANY (n_port.screenwords)", sql)
+
+    def test_searchscreenshot_words_list_uses_containment(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot(words=["Foo", "Bar"])
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # ``$all`` -> array containment, lower-cased.
+        self.assertIn("n_port.screenwords @> ARRAY['foo', 'bar']", sql)
+
+    def test_searchscreenshot_words_neg_handles_null(self):
+        # Mongo's ``$ne`` matches missing fields; the SQL path
+        # has to add an explicit ``IS NULL`` branch because
+        # three-valued logic on PG / DuckDB silently drops
+        # ``NULL @> ...`` rows from the negated side.
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        for words in ["welcome", ["welcome"]]:
+            with self.subTest(words=words):
+                flt = db.searchscreenshot(neg=True, words=words)
+                sql = self._compile_pg(
+                    flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+                )
+                self.assertIn("n_port.screenwords IS NULL", sql)
+
+    def test_searchscreenshot_words_regex_uses_subselect(self):
+        # The regex path wraps ``unnest()`` in a sub-SELECT
+        # projecting an explicit ``v`` column so the predicate
+        # references ``sub.c.v`` regardless of dialect (DuckDB
+        # rejects the implicit-row-deref shape PG accepts).
+        import re
+
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchscreenshot(words=re.compile("login", re.IGNORECASE))
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("unnest(n_port.screenwords)", sql)
+        self.assertIn(" AS v", sql)
+        self.assertIn("~*", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchscreenshot_duckdb_regex_uses_regexp_matches(self):
+        import re
+
+        sa = _sqlalchemy
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchscreenshot(words=re.compile("login", re.IGNORECASE))
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Same sub-SELECT shape, with the dialect-flipped regex.
+        self.assertIn("unnest(n_port.screenwords)", sql)
+        self.assertNotIn("~*", sql)
+        self.assertIn("regexp_matches(", sql)
+
+    # -- searchsmbshares -----------------------------------------------
+
+    def test_searchsmbshares_pg_unwinds_shares_array(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchsmbshares(access="rw", hidden=True)
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("n_script.name = 'smb-enum-shares'", sql)
+        self.assertIn("jsonb_array_elements(n_script.data -> 'shares')", sql)
+        self.assertIn("jsonb_typeof(n_script.data -> 'shares') = 'array'", sql)
+        # The Mongo recipe ANDs three predicates per share:
+        # access (OR over 'Anonymous access' and 'Current user
+        # access'), Type, and ``Share != 'IPC$'``.
+        self.assertIn("__share ->> 'Anonymous access'", sql)
+        self.assertIn("__share ->> 'Current user access'", sql)
+        self.assertIn("__share ->> 'Type'", sql)
+        self.assertIn("__share ->> 'Share'", sql)
+        self.assertIn("'IPC$'", sql)
+
+    def test_searchsmbshares_hidden_none_uses_notin_excluded(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchsmbshares()
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Mongo's ``$nin`` over the share-type sentinel list.
+        for excluded in (
+            "STYPE_IPC_HIDDEN",
+            "Not a file share",
+            "STYPE_IPC",
+            "STYPE_PRINTQ",
+        ):
+            self.assertIn(excluded, sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchsmbshares_duckdb_unwinds_with_json_each(self):
+        sa = _sqlalchemy
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchsmbshares(access="rw", hidden=True)
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("json_each(n_script.data -> 'shares')", sql)
+        self.assertIn("json_type(n_script.data -> 'shares') = 'ARRAY'", sql)
+        # DuckDB's ``json_each`` exposes the per-element JSON
+        # via the ``value`` column.
+        self.assertIn("__share.value ->>", sql)
+
+    # -- removescreenshot ----------------------------------------------
+
+    def test_removescreenshot_clears_in_memory_dict(self):
+        # Pure in-memory mutation -- no DB round-trip needed
+        # to pin the contract.
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        host = {
+            "_id": 1,
+            "ports": [
+                {
+                    "port": 80,
+                    "protocol": "tcp",
+                    "screenshot": "field",
+                    "screendata": b"PNG",
+                    "screenwords": ["foo"],
+                },
+                {
+                    "port": 443,
+                    "protocol": "tcp",
+                    "screenshot": "empty",
+                },
+            ],
+        }
+        # ``removescreenshot`` issues an ``UPDATE`` -- without
+        # a real DB, intercept the writer.
+        captured = []
+
+        def _capture(stmt):
+            captured.append(stmt)
+
+        # pylint: disable=protected-access
+        db._write = _capture  # type: ignore[method-assign]
+        db.removescreenshot(host)
+        # Both ports lost their screenshot fields.
+        for portrec in host["ports"]:
+            self.assertNotIn("screenshot", portrec)
+            self.assertNotIn("screendata", portrec)
+            self.assertNotIn("screenwords", portrec)
+        self.assertEqual(len(captured), 1)
+
+    def test_removescreenshot_port_filter_only_clears_match(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        host = {
+            "_id": 1,
+            "ports": [
+                {"port": 80, "protocol": "tcp", "screenshot": "field"},
+                {"port": 443, "protocol": "tcp", "screenshot": "empty"},
+            ],
+        }
+        # pylint: disable=protected-access
+        db._write = lambda stmt: None  # type: ignore[method-assign]
+        db.removescreenshot(host, port=80)
+        ports = {p["port"]: p for p in host["ports"]}
+        self.assertNotIn("screenshot", ports[80])
+        self.assertEqual(ports[443].get("screenshot"), "empty")
+
+    # -- schema --------------------------------------------------------
+
+    def test_port_schema_carries_screenshot_columns(self):
+        from ivre.db.sql.tables import N_Port, V_Port
+
+        for cls in (N_Port, V_Port):
+            with self.subTest(cls=cls.__name__):
+                for col in ("screenshot", "screendata", "screenwords"):
+                    self.assertIn(col, cls.__table__.columns)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Bring the Mongo-shape ``searchscreenshot`` / ``searchsmbshares`` / ``removescreenshot`` filters and the matching screenshot ingestion to ``SQLDBActive`` so PostgreSQL and DuckDB stop dropping per-port screenshot data and start matching the Mongo backend's contract.

Schema:

* Add ``screenshot`` / ``screendata`` / ``screenwords`` columns to the shared ``_Port`` mixin; both ``N_Port`` (active scans) and ``V_Port`` (merged view) inherit them.  ``screendata`` is ``LargeBinary`` -- bytea on PostgreSQL, BLOB on DuckDB -- to match Mongo's ``bson.Binary`` round-trip semantics; bytes are stored verbatim and read back as ``bytes`` regardless of backend.
* Drop the per-port ``del port[fld]`` strip that ``_store_host`` ran for ``screendata`` / ``screenshot`` / ``screenwords`` on both the Nmap and View ingestion paths. Some ingestion paths produce base64-encoded ``screendata`` strings rather than raw bytes; the value is normalised back to bytes via :func:`utils.decode_b64` before the INSERT so the column always holds raw bytes.  ``service_method`` retains its strip -- it has no dedicated column.
* Extend the port-row positional unpack in ``SQLDBActive.get`` to include the three new columns.

Search helpers (``SQLDBActive``):

* ``searchscreenshot(port, protocol, service, words, neg)`` matches the Mongo contract for every ``words`` shape:

  - ``None``: existence check on the per-port ``screenshot`` column.  With ``neg=True`` and no ``port`` / ``service`` constraint the flip lands at the ``EXISTS`` level (Mongo's ``{"ports.screenshot": {"$exists": false}}`` means *no* port has a screenshot, not "there is a port without a screenshot"); with a port / service constraint the flip lands at the inner predicate so other ports keep their screenshots.
  - ``bool``: ``screenwords IS NOT NULL`` / ``IS NULL``.
  - ``str``: ``ANY(screenwords)`` against the lower-cased word, matching Mongo's pre-stored shape.
  - ``list``: ``screenwords @> ARRAY[...]`` (Mongo's ``$all``).
  - regex: wraps ``unnest()`` in a sub-SELECT projecting an explicit ``v`` column so the inner predicate references ``sub.c.v`` regardless of dialect (DuckDB rejects the implicit-row-deref shape PG accepts).

  The ``neg`` branch on ``str`` / ``list`` adds an explicit
  ``screenwords IS NULL`` arm: PG / DuckDB three-valued logic
  silently drops ``NULL @> ...`` rows from the negated side,
  whereas Mongo's ``$ne`` matches missing fields.  The regex
  branch needs no such guard -- ``unnest(NULL)`` is zero rows
  on both backends, so ``NOT EXISTS`` already matches NULL
  ``screenwords``.

* ``searchsmbshares(access, hidden)`` builds the equivalent of the Mongo ``smb-enum-shares`` filter directly: PG unwinds ``script.data['shares']`` with :func:`jsonb_array_elements` and AND-combines per-element predicates inside an ``EXISTS`` (access regex / literal, share-type membership, ``Share != 'IPC$'``).  The previous SQL ``searchscript`` value-translator does not cover the nested ``$elemMatch`` / ``$or`` / ``$nin`` shape Mongo's helper produces.

* ``removescreenshot(host, port, protocol)`` clears the three screenshot columns via an ``UPDATE`` on the matching port rows and mirrors Mongo's in-memory mutation on the supplied ``host`` dict (so subsequent caller logic sees the post-removal shape).

DuckDB overrides (``_DuckDBActiveSearchMixin``):

* ``searchsmbshares`` swaps the JSON-array unwind for :func:`json_each` (with the 8-column shape declared up-front so the alias arity matches DuckDB's table-function output) and uses :func:`json_type` against ``'ARRAY'`` (DuckDB returns upper-case where PostgreSQL's :func:`jsonb_typeof` returns lower-case).  ``searchscreenshot`` and ``removescreenshot`` need no override -- the array operators (``@>``, ``ANY``, ``unnest()``) and the column-level ``UPDATE`` all compile cleanly under both backends.

Tests (``SQLDBSearchSmbScreenshotTests`` in
``tests/tests_no_backend.py``):

14 pin tests cover both backends -- per-helper SQL shape (short-circuit on no-args ``searchscreenshot``, ``EXISTS`` versus inner-predicate flip on negation, sub-SELECT shape for the regex word path), Mongo-equivalent ``$all`` /
``$nin`` translations, the ``IS NULL`` guard on negated word matches, and the new ``screenshot`` / ``screendata`` / ``screenwords`` columns on ``N_Port`` / ``V_Port``.