### PR TITLE
feat(db/sql): close residual mongo-vs-sql parity gaps

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -182,7 +182,7 @@ class ScanCSVFile(CSVFile):
                                 cert[fld] = utils.all2datetime(cert[fld]).timestamp()
             if "screendata" in port:
                 port["screendata"] = utils.encode_b64(port["screendata"])
-        for field in ["hostnames", "ports", "info", "cpes", "os"]:
+        for field in ["hostnames", "ports", "info", "cpes", "os", "addresses"]:
             if field in line:
                 line[field] = json.dumps(line[field]).replace("\\", "\\\\")
         return [
@@ -1855,6 +1855,9 @@ class SQLDBActive(SQLDB, DBActive):
                 self.tables.scan.state_reason,
                 self.tables.scan.state_reason_ttl,
                 self.tables.scan.schema_version,
+                self.tables.scan.cpes,
+                self.tables.scan.os,
+                self.tables.scan.addresses,
             ).select_from(flt.select_from)
         )
         for key, way in sort or []:
@@ -1882,6 +1885,9 @@ class SQLDBActive(SQLDB, DBActive):
                 rec["state_reason"],
                 rec["state_reason_ttl"],
                 rec["schema_version"],
+                rec["cpes"],
+                rec["os"],
+                rec["addresses"],
             ) = scanrec
             try:
                 rec["addr"] = self.internal2ip(rec["addr"])
@@ -1889,6 +1895,9 @@ class SQLDBActive(SQLDB, DBActive):
                 pass
             if not rec["infos"]:
                 del rec["infos"]
+            for key in ("cpes", "os", "addresses"):
+                if not rec[key]:
+                    del rec[key]
             categories = (
                 select(self.tables.association_scan_category.category)
                 .where(self.tables.association_scan_category.scan == rec["_id"])
@@ -2964,21 +2973,39 @@ class SQLDBActive(SQLDB, DBActive):
             else:
                 conds.append(port_t.screenwords.contains(lowered))
         elif isinstance(words, utils.REGEXP_T):
-            # Match any array element against the regex.  Wrap
-            # the ``unnest()`` SRF in a sub-SELECT projecting an
-            # explicit ``v`` column so the inner predicate
-            # references ``sub.c.v`` regardless of dialect:
-            # PostgreSQL accepts the bare table-function alias
-            # but DuckDB requires ``AS alias(col)`` syntax for
-            # the column name to be bindable; the sub-SELECT
-            # form normalises both ends.  ``unnest(NULL)`` is
-            # zero rows on both backends, so ``NOT EXISTS``
-            # naturally matches NULL ``screenwords`` -- no
-            # explicit ``IS NULL`` branch needed for the
-            # negated side here.
-            sw_subq = select(func.unnest(port_t.screenwords).label("v")).subquery()
-            sw_pred = cls._searchstring_re(sw_subq.c.v, words)
-            inner = exists(select(1).select_from(sw_subq).where(sw_pred))
+            # Match any array element against the regex.  Use
+            # the table-valued-function ``AS __sw(v)`` form
+            # (PostgreSQL and DuckDB both accept it) so the
+            # SRF's single column is exposed as ``__sw.v``.
+            #
+            # The ``render_derived`` keyword is what makes
+            # SQLAlchemy emit the explicit column-list alias
+            # ``AS __sw(v)`` rather than the bare ``AS __sw``
+            # shape ``table_valued`` defaults to -- without it
+            # PostgreSQL would reject ``__sw.v`` (column
+            # doesn't exist) and DuckDB would parse the alias
+            # as a STRUCT column.  Side benefit: SA emits the
+            # SRF directly in the ``FROM`` clause without
+            # wrapping it in a sub-SELECT, so the SRF stays
+            # implicitly lateral on PostgreSQL (and DuckDB
+            # treats the inline SRF the same way) -- a plain
+            # ``select(...).subquery()`` wrapper *decorrelates*
+            # the call and makes the unwind expand over every
+            # ``port.screenwords`` row in the database, which
+            # silently matches every host with a screenshot
+            # whenever the predicate matches anywhere.
+            #
+            # ``unnest(NULL)`` is zero rows on both backends,
+            # so ``NOT EXISTS`` naturally matches NULL
+            # ``screenwords`` -- no explicit ``IS NULL`` branch
+            # needed for the negated side here.
+            sw_alias = (
+                func.unnest(port_t.screenwords)
+                .table_valued("v")
+                .render_derived(name="__sw", with_types=False)
+            )
+            sw_pred = cls._searchstring_re(sw_alias.c.v, words)
+            inner = exists(select(1).select_from(sw_alias).where(sw_pred))
             conds.append(not_(inner) if neg else inner)
         else:  # plain string
             lowered = words.lower()
@@ -3103,6 +3130,201 @@ class SQLDBActive(SQLDB, DBActive):
             .where(update_filter)
             .values(screenshot=None, screendata=None, screenwords=None)
         )
+
+    def setscreenshot(self, host, port, data, protocol="tcp", overwrite=False):
+        """Set the content of a port's screenshot on the matching
+        port row.  Mirrors :meth:`MongoDB.setscreenshot`.
+
+        Trims the image (drops uniform borders via
+        :func:`ivre.utils.trim_image`); if trimming consumes the
+        whole picture the screenshot is recorded as ``"empty"``
+        with no ``screendata``.  Otherwise the trimmed bytes
+        land in ``screendata`` and the OCR word list is derived
+        via :func:`ivre.utils.screenwords` and written to
+        ``screenwords``.
+
+        ``overwrite=False`` is a no-op when the port already has
+        a screenshot.
+        """
+        port_t = self.tables.port
+        # Locate the port subdoc on the in-memory record so we
+        # can mirror Mongo's mutation behaviour and short-circuit
+        # the no-op when ``overwrite=False``.
+        try:
+            port_rec = next(
+                p
+                for p in host.get("ports", [])
+                if p.get("port") == port and p.get("protocol") == protocol
+            )
+        except StopIteration as exc:
+            raise KeyError(f"Port {protocol}/{port} does not exist") from exc
+        if "screenshot" in port_rec and not overwrite:
+            return
+        trim_result = utils.trim_image(data)
+        update_filter = and_(
+            port_t.scan == host.get("_id"),
+            port_t.port == port,
+            port_t.protocol == protocol,
+        )
+        if trim_result is False:
+            # Image vanished after trim -- record the empty
+            # marker and clear any leftover data / words.
+            port_rec["screenshot"] = "empty"
+            port_rec.pop("screendata", None)
+            port_rec.pop("screenwords", None)
+            self._write(
+                update(port_t)
+                .where(update_filter)
+                .values(screenshot="empty", screendata=None, screenwords=None)
+            )
+            return
+        port_rec["screenshot"] = "field"
+        if trim_result is not True:
+            data = trim_result
+        port_rec["screendata"] = data
+        screenwords = utils.screenwords(data)
+        if screenwords is not None:
+            port_rec["screenwords"] = screenwords
+        self._write(
+            update(port_t)
+            .where(update_filter)
+            .values(
+                screenshot="field",
+                screendata=data,
+                screenwords=screenwords,
+            )
+        )
+
+    def setscreenwords(self, host, port=None, protocol="tcp", overwrite=False):
+        """(Re)compute the OCR word list for ports that have a
+        screenshot but lack ``screenwords`` (or all of them when
+        ``overwrite=True``).  Mirrors
+        :meth:`MongoDB.setscreenwords`.
+        """
+        port_t = self.tables.port
+        for port_rec in host.get("ports", []):
+            if port is not None and (
+                port_rec.get("port") != port or port_rec.get("protocol") != protocol
+            ):
+                continue
+            if "screenshot" not in port_rec:
+                continue
+            if "screenwords" in port_rec and not overwrite:
+                continue
+            data = port_rec.get("screendata")
+            if not data:
+                continue
+            words = utils.screenwords(data)
+            if words is None:
+                continue
+            port_rec["screenwords"] = words
+            self._write(
+                update(port_t)
+                .where(
+                    and_(
+                        port_t.scan == host.get("_id"),
+                        port_t.port == port_rec["port"],
+                        port_t.protocol == port_rec["protocol"],
+                    )
+                )
+                .values(screenwords=words)
+            )
+
+    @classmethod
+    def searchtimeago(cls, delta, neg=False):
+        """Filter scans whose ``time_stop`` (i.e. last activity)
+        is more recent (or older, with ``neg=True``) than
+        ``datetime.now() - delta``.  Mirrors the Mongo helper at
+        :meth:`MongoDB.searchtimeago` (active class).
+
+        ``delta`` can be a :class:`datetime.timedelta` or a
+        scalar number of seconds.
+        """
+        if not isinstance(delta, datetime.timedelta):
+            delta = datetime.timedelta(seconds=delta)
+        cutoff = datetime.datetime.now() - delta
+        time_stop = cls.tables.scan.time_stop
+        return cls.base_filter(main=time_stop < cutoff if neg else time_stop >= cutoff)
+
+    @classmethod
+    def searchmac(cls, mac=None, neg=False):
+        """Filter active scans by MAC address.  ``mac`` may be a
+        string (case-insensitive equality, lower-cased to match
+        the stored shape), a regex, or ``None`` (existence check).
+
+        Mirrors :meth:`MongoDB.searchmac` for the active class.
+        The Mongo path queries ``addresses.mac`` directly; here
+        the same JSONB array is unwound via
+        :func:`jsonb_array_elements_text` and each element is
+        matched per-row inside an ``EXISTS``.  ``LATERAL`` is
+        required so the inner SRF correlates with the outer
+        ``scan`` row -- without it the unwind decorrelates and
+        any matching MAC anywhere in the database would match
+        every scan.
+
+        Existence is a portable ``addresses -> 'mac' IS NOT NULL``
+        check rather than the PG-only ``?`` operator (DuckDB's
+        JSON dialect does not provide it).
+        """
+        scan = cls.tables.scan
+        mac_field = scan.addresses.op("->")("mac")
+        if mac is None:
+            has_mac = mac_field != None  # noqa: E711
+            return cls.base_filter(main=not_(has_mac) if neg else has_mac)
+        # See :meth:`searchscreenshot` for the
+        # ``table_valued().render_derived()`` rationale (clean
+        # ``AS __mac(v)`` syntax that both PostgreSQL and DuckDB
+        # accept, with the SRF's outer-row reference staying
+        # correlated rather than decorrelated by a sub-SELECT
+        # wrapper).
+        mac_alias = (
+            func.jsonb_array_elements_text(mac_field)
+            .table_valued("v")
+            .render_derived(name="__mac", with_types=False)
+        )
+        if isinstance(mac, utils.REGEXP_T):
+            mac = re.compile(mac.pattern, mac.flags | re.IGNORECASE)
+            elt_pred = cls._searchstring_re(mac_alias.c.v, mac)
+        else:
+            elt_pred = mac_alias.c.v == mac.lower()
+        inner = exists(select(1).select_from(mac_alias).where(elt_pred))
+        return cls.base_filter(
+            main=and_(
+                scan.addresses != None,  # noqa: E711
+                func.jsonb_typeof(mac_field) == "array",
+                not_(inner) if neg else inner,
+            )
+        )
+
+    def get_mean_open_ports(self, flt):
+        """Server-side equivalent of the Python-loop fallback
+        :meth:`DBActive.get_mean_open_ports` ships in the base
+        class.  Returns an iterable of ``{"id", "mean"}`` dicts
+        where ``mean`` is ``count_of_open_ports * sum_of_open_port_numbers``.
+
+        Mongo runs the same arithmetic via the aggregation
+        framework; the SQL backends compute it in a single
+        ``GROUP BY scan.id`` against the ``port`` table joined
+        with the active filter.
+        """
+        scan_t = self.tables.scan
+        port_t = self.tables.port
+        base = flt.query(select(scan_t.id).select_from(flt.select_from)).cte(
+            "scans_in_flt"
+        )
+        cnt = func.count(port_t.id)
+        port_sum = func.coalesce(func.sum(port_t.port), 0)
+        stmt = (
+            select(scan_t.id.label("id"), (cnt * port_sum).label("mean"))
+            .select_from(scan_t)
+            .where(scan_t.id.in_(select(base.c.id)))
+            .outerjoin(
+                port_t,
+                and_(port_t.scan == scan_t.id, port_t.state == "open"),
+            )
+            .group_by(scan_t.id)
+        )
+        return [{"id": row[0], "mean": row[1]} for row in self._read_iter(stmt)]
 
     @classmethod
     def searchhassh(cls, value_or_hash=None, server=None):
@@ -3311,6 +3533,18 @@ class SQLDBView(SQLDBActive, DBView):
                 cls.tables.scan.info["as_name"].astext, asname, neg=neg
             )
         )
+
+    @classmethod
+    def searchhaslocation(cls, neg=False):
+        """Filter records carrying GeoIP coordinates on
+        ``info.loc`` (or, with ``neg=True``, records that
+        don't).  Mirrors :meth:`MongoDB.searchhaslocation` --
+        the Mongo path checks ``{"infos.loc": {"$exists":
+        not neg}}``.
+        """
+        loc = cls.tables.scan.info.op("->")("loc")
+        has_loc = loc != None  # noqa: E711
+        return cls.base_filter(main=not_(has_loc) if neg else has_loc)
 
 
 class PassiveFilter(Filter):
@@ -3550,6 +3784,81 @@ class SQLDBPassive(SQLDB, DBPassive):
         vals.update(otherfields)
         self._insert_or_update(
             timestamp, vals, lastseen=lastseen, replacecount=replacecount
+        )
+
+    def insert_or_update_mix(self, spec, getinfos=None, replacecount=False):
+        """Mix-merge a record into the passive table.  Uses
+        ``firstseen`` / ``lastseen`` / ``count`` carried in the
+        spec rather than synthesising them from a single
+        observation timestamp; on conflict the existing row's
+        ``firstseen`` / ``lastseen`` / ``count`` are merged via
+        ``least`` / ``greatest`` / ``+`` (or replaced wholesale
+        when ``replacecount=True``).
+
+        Useful when copying records from one IVRE database to
+        another, or for the ``_migrate_update_record`` callback
+        that schema migrations route through.
+
+        Mirrors :meth:`MongoDB.insert_or_update_mix`.
+        """
+        if spec is None:
+            return
+        spec = dict(spec)
+        try:
+            spec["addr"] = self.ip2internal(spec["addr"])
+        except (KeyError, ValueError):
+            pass
+        if getinfos is not None and "infos" not in spec:
+            infos = getinfos(spec)
+            if infos:
+                spec["infos"] = infos
+        try:
+            spec.update(spec.pop("infos"))
+        except KeyError:
+            pass
+        addr = spec.pop("addr", None)
+        if addr:
+            addr = self.ip2internal(addr)
+        # ``firstseen`` defaults to ``now()`` for spec dicts that
+        # omit it (matching the regular ``insert_or_update`` path
+        # where the caller has to supply a timestamp).
+        firstseen = utils.all2datetime(spec.pop("firstseen", datetime.datetime.now()))
+        lastseen_raw = spec.pop("lastseen", None)
+        lastseen = (
+            utils.all2datetime(lastseen_raw) if lastseen_raw is not None else firstseen
+        )
+        count_val = spec.pop("count", 1)
+        if spec.get("recontype") in {"SSL_SERVER", "SSL_CLIENT"} and spec.get(
+            "source"
+        ) in {"cert", "cacert"}:
+            for fld in ["not_before", "not_after"]:
+                if fld in spec:
+                    if isinstance(spec[fld], datetime.datetime):
+                        spec[fld] = spec[fld].timestamp()
+                    elif isinstance(spec[fld], str):
+                        spec[fld] = utils.all2datetime(spec[fld]).timestamp()
+        otherfields = {
+            key: spec.pop(key, "")
+            for key in ["sensor", "source", "targetval", "recontype", "value"]
+        }
+        info = {
+            key: spec.pop(key)
+            for key in ["distance", "signature", "version"]
+            if key in spec
+        }
+        vals = {
+            "addr": addr,
+            "count": count_val,
+            "firstseen": firstseen,
+            "lastseen": lastseen,
+            "port": spec.pop("port", -1),
+            "info": info,
+            "moreinfo": spec,
+            "schema_version": spec.pop("schema_version", None),
+        }
+        vals.update(otherfields)
+        self._insert_or_update(
+            firstseen, vals, lastseen=lastseen, replacecount=replacecount
         )
 
     def topvalues(

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -800,6 +800,41 @@ class _DuckDBActiveSearchMixin:
             ]
         )
 
+    @override
+    @classmethod
+    def searchmac(cls, mac=None, neg=False):  # type: ignore[no-untyped-def, override]
+        """DuckDB equivalent of :meth:`SQLDBActive.searchmac`.
+
+        DuckDB has no :func:`jsonb_array_elements_text` SRF;
+        the JSON array is parsed to a typed ``VARCHAR`` list
+        via :func:`from_json` and unwound with :func:`unnest`.
+        ``json_type`` replaces PostgreSQL's :func:`jsonb_typeof`
+        (with the ``ARRAY`` / ``array`` casing flip).
+        """
+        scan = cls.tables.scan
+        mac_field = scan.addresses.op("->")("mac")
+        if mac is None:
+            has_mac = mac_field != None  # noqa: E711
+            return cls.base_filter(main=not_(has_mac) if neg else has_mac)
+        mac_alias = (
+            func.unnest(func.from_json(mac_field, '["VARCHAR"]'))
+            .table_valued("v")
+            .render_derived(name="__mac", with_types=False)
+        )
+        if isinstance(mac, utils.REGEXP_T):
+            mac = re.compile(mac.pattern, mac.flags | re.IGNORECASE)
+            elt_pred = cls._searchstring_re(mac_alias.c.v, mac)
+        else:
+            elt_pred = mac_alias.c.v == mac.lower()
+        inner = exists(select(1).select_from(mac_alias).where(elt_pred))
+        return cls.base_filter(
+            main=and_(
+                scan.addresses != None,  # noqa: E711
+                func.json_type(mac_field) == "ARRAY",
+                not_(inner) if neg else inner,
+            )
+        )
+
 
 class DuckDBNmap(DuckDBMixin, _DuckDBActiveSearchMixin, PostgresDBNmap):
     """DuckDB backend for the ``nmap`` (active-scan) data category."""

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -1532,6 +1532,7 @@ class PostgresDBNmap(PostgresDBActive, SQLDBNmap):
                 # field.
                 cpes=host["cpes"] if host.get("cpes") else null(),
                 os=host["os"] if host.get("os") else null(),
+                addresses=(host["addresses"] if host.get("addresses") else null()),
             )
             .on_conflict_do_nothing()
             .returning(self.tables.scan.id)
@@ -1680,6 +1681,7 @@ class PostgresDBView(PostgresDBActive, SQLDBView):
                 # :meth:`searchos`).
                 cpes=host["cpes"] if host.get("cpes") else null(),
                 os=host["os"] if host.get("os") else null(),
+                addresses=(host["addresses"] if host.get("addresses") else null()),
                 **{
                     key: host.get(key)
                     for key in ["state", "state_reason", "state_reason_ttl"]
@@ -1700,6 +1702,9 @@ class PostgresDBView(PostgresDBActive, SQLDBView):
                     ),
                     "cpes": func.coalesce(insrt.excluded.cpes, self.tables.scan.cpes),
                     "os": func.coalesce(insrt.excluded.os, self.tables.scan.os),
+                    "addresses": func.coalesce(
+                        insrt.excluded.addresses, self.tables.scan.addresses
+                    ),
                 },
             )
             .returning(self.tables.scan.id, self.tables.scan.time_stop)

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -381,6 +381,11 @@ class _Scan:
     schema_version = Column(Integer, default=xmlnmap.SCHEMA_VERSION)
     cpes = Column(SQLJSONB)
     os = Column(SQLJSONB)
+    # ``addresses`` is a Mongo-shape ``{type: [addr, ...]}`` dict
+    # holding non-IP host addresses (currently only ``mac``).
+    # Stored verbatim from the host record so :meth:`searchmac`
+    # can unwind ``addresses->'mac'`` and match any element.
+    addresses = Column(SQLJSONB)
 
 
 # Nmap

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -4003,11 +4003,15 @@ class SQLDBSearchSmbScreenshotTests(unittest.TestCase):
                 )
                 self.assertIn("n_port.screenwords IS NULL", sql)
 
-    def test_searchscreenshot_words_regex_uses_subselect(self):
-        # The regex path wraps ``unnest()`` in a sub-SELECT
-        # projecting an explicit ``v`` column so the predicate
-        # references ``sub.c.v`` regardless of dialect (DuckDB
-        # rejects the implicit-row-deref shape PG accepts).
+    def test_searchscreenshot_words_regex_uses_correlated_unnest(self):
+        # Pin the table-valued ``AS __sw(v)`` shape -- the
+        # SRF stays inline in the FROM clause (implicitly
+        # lateral on PG, accepted as such by DuckDB) so the
+        # ``port.screenwords`` reference correlates with the
+        # outer ``port`` row rather than decorrelating into a
+        # cross-DB scan.  Earlier versions wrapped ``unnest()``
+        # in ``select(...).subquery()`` which silently
+        # decorrelated the call; that shape is gone now.
         import re
 
         sa = _sqlalchemy
@@ -4018,9 +4022,8 @@ class SQLDBSearchSmbScreenshotTests(unittest.TestCase):
         sql = self._compile_pg(
             flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
         )
-        self.assertIn("unnest(n_port.screenwords)", sql)
-        self.assertIn(" AS v", sql)
-        self.assertIn("~*", sql)
+        self.assertIn("unnest(n_port.screenwords) AS __sw(v)", sql)
+        self.assertIn("__sw.v ~*", sql)
 
     @unittest.skipUnless(
         _HAVE_DUCKDB_ENGINE,
@@ -4037,8 +4040,8 @@ class SQLDBSearchSmbScreenshotTests(unittest.TestCase):
         sql = self._compile_duckdb(
             flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
         )
-        # Same sub-SELECT shape, with the dialect-flipped regex.
-        self.assertIn("unnest(n_port.screenwords)", sql)
+        # Same ``AS __sw(v)`` shape, dialect-flipped regex.
+        self.assertIn("unnest(n_port.screenwords) AS __sw(v)", sql)
         self.assertNotIn("~*", sql)
         self.assertIn("regexp_matches(", sql)
 
@@ -4171,6 +4174,340 @@ class SQLDBSearchSmbScreenshotTests(unittest.TestCase):
             with self.subTest(cls=cls.__name__):
                 for col in ("screenshot", "screendata", "screenwords"):
                     self.assertIn(col, cls.__table__.columns)
+
+
+# ---------------------------------------------------------------------
+# SQLDBResidualGapsTests -- pin the wire shape of the
+# ``searchtimeago`` / ``searchmac`` (active) / ``searchhaslocation``
+# (view) / ``setscreenshot`` / ``setscreenwords`` / ``get_mean_open_ports``
+# / ``insert_or_update_mix`` (passive) helpers, plus the new
+# ``addresses`` JSONB column on ``_Scan`` and the cpes/os/addresses
+# round-trip through ``SQLDBActive.get``.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBResidualGapsTests(unittest.TestCase):
+    """Behaviour-pin for the residual-gap parity helpers added
+    after :meth:`searchcpe` / :meth:`searchos` / :meth:`searchvuln`
+    (M4.3.1) and :meth:`searchscreenshot` / :meth:`searchsmbshares`
+    / :meth:`removescreenshot` (M4.3.2).
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _compile_duckdb(stmt):
+        return str(
+            stmt.compile(
+                dialect=duckdb_engine.Dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    # -- searchtimeago -------------------------------------------------
+
+    def test_searchtimeago_predicate_uses_time_stop(self):
+        sa = _sqlalchemy
+        import datetime
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchtimeago(datetime.timedelta(days=30))
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Must filter on ``time_stop`` (Mongo's ``endtime``)
+        # with a ``>=`` comparison; the negated arm flips to
+        # ``<``.
+        self.assertIn("n_scan.time_stop >= ", sql)
+
+    def test_searchtimeago_neg_flips_to_less_than(self):
+        sa = _sqlalchemy
+        import datetime
+
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchtimeago(datetime.timedelta(days=30), neg=True)
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("n_scan.time_stop < ", sql)
+
+    # -- searchmac (active) --------------------------------------------
+
+    def test_searchmac_no_args_uses_existence_check(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchmac()
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Portable existence check on the JSONB sub-key
+        # rather than the PG-only ``?`` operator.
+        self.assertIn("(n_scan.addresses -> 'mac') IS NOT NULL", sql)
+        self.assertNotIn("jsonb_array_elements_text", sql)
+
+    def test_searchmac_pg_unwinds_with_jsonb_array_elements_text(self):
+        sa = _sqlalchemy
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        flt = db.searchmac("AA:BB:CC:DD:EE:FF")
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # Inline SRF (implicitly lateral on PG) with the
+        # explicit ``AS __mac(v)`` column-list alias so the
+        # outer-row reference correlates per-scan.
+        self.assertIn(
+            "jsonb_array_elements_text(n_scan.addresses -> 'mac') " "AS __mac(v)",
+            sql,
+        )
+        self.assertIn("jsonb_typeof(n_scan.addresses -> 'mac') = 'array'", sql)
+        # MAC value is lower-cased before matching.
+        self.assertIn("__mac.v = 'aa:bb:cc:dd:ee:ff'", sql)
+
+    @unittest.skipUnless(
+        _HAVE_DUCKDB_ENGINE,
+        "duckdb-engine is required (install with the ``duckdb`` extras)",
+    )
+    def test_searchmac_duckdb_uses_from_json(self):
+        sa = _sqlalchemy
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        db = DuckDBNmap.from_url("duckdb:///:memory:")
+        flt = db.searchmac("AA:BB:CC:DD:EE:FF")
+        sql = self._compile_duckdb(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        # DuckDB has no ``jsonb_array_elements_text`` SRF;
+        # the override parses the JSON array via
+        # ``from_json(..., '["VARCHAR"]')`` and unwinds with
+        # ``unnest()``.
+        self.assertIn("from_json(n_scan.addresses -> 'mac', ", sql)
+        self.assertIn(" AS __mac(v)", sql)
+        self.assertIn("json_type(n_scan.addresses -> 'mac') = 'ARRAY'", sql)
+
+    # -- searchhaslocation (view) --------------------------------------
+
+    def test_searchhaslocation_uses_info_loc(self):
+        sa = _sqlalchemy
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        flt = db.searchhaslocation()
+        sql = self._compile_pg(
+            flt.query(sa.select(sa.func.count()).select_from(flt.select_from))
+        )
+        self.assertIn("(v_scan.info -> 'loc') IS NOT NULL", sql)
+
+        flt_neg = db.searchhaslocation(neg=True)
+        sql_neg = self._compile_pg(
+            flt_neg.query(sa.select(sa.func.count()).select_from(flt_neg.select_from))
+        )
+        self.assertIn("(v_scan.info -> 'loc') IS NULL", sql_neg)
+
+    # -- get_mean_open_ports -------------------------------------------
+
+    def test_get_mean_open_ports_emits_count_times_sum(self):
+        # Pin the SQL aggregation shape via reading the SA
+        # constructs directly (the method returns a list, so
+        # we patch the read iterator to capture the rendered
+        # statement instead).  ``coalesce`` is required so
+        # hosts with no open port land at ``mean = 0``,
+        # matching Mongo's ``count * sum`` arithmetic when one
+        # of the operands collapses to an empty array.
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        captured = []
+
+        def _fake_read_iter(stmt):
+            captured.append(stmt)
+            return iter([])
+
+        # pylint: disable=protected-access
+        db._read_iter = _fake_read_iter  # type: ignore[method-assign]
+        result = db.get_mean_open_ports(db.flt_empty)
+        self.assertEqual(result, [])
+        self.assertEqual(len(captured), 1)
+        sql = self._compile_pg(captured[0])
+        self.assertIn("count(n_port.id)", sql)
+        self.assertIn("coalesce(sum(n_port.port), 0)", sql)
+        self.assertIn("n_port.state = 'open'", sql)
+        self.assertIn("GROUP BY n_scan.id", sql)
+
+    # -- setscreenshot / setscreenwords --------------------------------
+
+    def test_setscreenshot_raises_on_missing_port(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        host = {"_id": 1, "ports": []}
+        with self.assertRaises(KeyError):
+            db.setscreenshot(host, 80, b"data")
+
+    def test_setscreenshot_skips_when_already_set_without_overwrite(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        host = {
+            "_id": 1,
+            "ports": [
+                {
+                    "port": 80,
+                    "protocol": "tcp",
+                    "screenshot": "field",
+                    "screendata": b"old",
+                }
+            ],
+        }
+        # pylint: disable=protected-access
+        db._write = lambda stmt: None  # type: ignore[method-assign]
+        db.setscreenshot(host, 80, b"new")
+        self.assertEqual(host["ports"][0]["screendata"], b"old")
+
+    def test_setscreenwords_skips_when_already_set_without_overwrite(self):
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        host = {
+            "_id": 1,
+            "ports": [
+                {
+                    "port": 80,
+                    "protocol": "tcp",
+                    "screenshot": "field",
+                    "screendata": b"data",
+                    "screenwords": ["existing"],
+                }
+            ],
+        }
+        # pylint: disable=protected-access
+        db._write = lambda stmt: None  # type: ignore[method-assign]
+        db.setscreenwords(host)
+        # No overwrite: existing words are kept.
+        self.assertEqual(host["ports"][0]["screenwords"], ["existing"])
+
+    # -- insert_or_update_mix (passive) --------------------------------
+
+    def test_insert_or_update_mix_routes_to_underlying_insert(self):
+        # Pin that the helper extracts firstseen / lastseen /
+        # count from the spec and forwards them to
+        # ``_insert_or_update`` so the upsert merges via
+        # ``least`` / ``greatest`` / ``+`` (or ``replacecount``
+        # replaces wholesale).
+        import datetime
+
+        from ivre.db import DBPassive
+        from ivre.db.sql.postgres import PostgresDBPassive
+
+        captured = []
+
+        def _fake_iou(self_, timestamp, values, lastseen=None, replacecount=False):
+            captured.append(
+                {
+                    "timestamp": timestamp,
+                    "values": values,
+                    "lastseen": lastseen,
+                    "replacecount": replacecount,
+                }
+            )
+
+        original = PostgresDBPassive._insert_or_update
+        PostgresDBPassive._insert_or_update = _fake_iou
+        try:
+            db = DBPassive.from_url("postgresql://x@localhost/x")
+            db.insert_or_update_mix(
+                {
+                    "addr": "1.2.3.4",
+                    "recontype": "MAC_ADDRESS",
+                    "source": "DHCP",
+                    "value": "aa:bb",
+                    "firstseen": datetime.datetime(2024, 1, 1),
+                    "lastseen": datetime.datetime(2024, 6, 1),
+                    "count": 17,
+                }
+            )
+        finally:
+            PostgresDBPassive._insert_or_update = original
+        self.assertEqual(len(captured), 1)
+        call = captured[0]
+        self.assertEqual(call["timestamp"], datetime.datetime(2024, 1, 1))
+        self.assertEqual(call["lastseen"], datetime.datetime(2024, 6, 1))
+        self.assertEqual(call["values"]["count"], 17)
+        self.assertEqual(call["values"]["recontype"], "MAC_ADDRESS")
+        self.assertFalse(call["replacecount"])
+
+    def test_insert_or_update_mix_replacecount_pass_through(self):
+        import datetime
+
+        from ivre.db import DBPassive
+        from ivre.db.sql.postgres import PostgresDBPassive
+
+        captured = []
+
+        def _fake_iou(self_, timestamp, values, lastseen=None, replacecount=False):
+            captured.append(replacecount)
+
+        original = PostgresDBPassive._insert_or_update
+        PostgresDBPassive._insert_or_update = _fake_iou
+        try:
+            db = DBPassive.from_url("postgresql://x@localhost/x")
+            db.insert_or_update_mix(
+                {
+                    "addr": "1.2.3.4",
+                    "recontype": "MAC_ADDRESS",
+                    "source": "DHCP",
+                    "value": "aa:bb",
+                    "firstseen": datetime.datetime(2024, 1, 1),
+                    "lastseen": datetime.datetime(2024, 6, 1),
+                    "count": 17,
+                },
+                replacecount=True,
+            )
+        finally:
+            PostgresDBPassive._insert_or_update = original
+        self.assertEqual(captured, [True])
+
+    # -- schema --------------------------------------------------------
+
+    def test_scan_schema_carries_addresses_column(self):
+        from ivre.db.sql.tables import N_Scan, V_Scan
+
+        for cls in (N_Scan, V_Scan):
+            with self.subTest(cls=cls.__name__):
+                self.assertIn("addresses", cls.__table__.columns)
+
+    def test_get_projects_cpes_os_addresses(self):
+        # The scan-row positional unpack must surface the
+        # three host-level JSONB columns added in M4.3.1 /
+        # M4.3.3 -- otherwise consumers calling ``db.nmap.get(...)``
+        # would never see them and the round-trip would
+        # silently lose data.
+        from ivre.db import DBNmap
+
+        db = DBNmap.from_url("postgresql://x@localhost/x")
+        # pylint: disable=protected-access
+        stmt = db._get(db.flt_empty)
+        sql = self._compile_pg(stmt)
+        for col in ("n_scan.cpes", "n_scan.os", "n_scan.addresses"):
+            self.assertIn(col, sql)
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Round out the cross-backend ``search*`` / ``set*`` / ``insert*`` parity with the last batch of helpers exposed by ``MongoDB`` but still unimplemented (or broken) on the SQL backends.

New helpers (``SQLDBActive`` -- inherited by both ``SQLDBNmap`` and ``SQLDBView``):

* ``searchtimeago(delta, neg=False)`` filters scans whose ``time_stop`` is more recent (or older, with ``neg``) than ``now() - delta``.  The ``--timeago`` CLI flag wired through ``DBActive.parse_args`` was raising ``AttributeError: 'PostgresDBNmap' has no attribute 'searchtimeago'`` on PG / DuckDB.
* ``searchmac(mac=None, neg=False)`` filters by MAC address. Stored on a new ``addresses`` JSONB column on ``_Scan``; PostgreSQL unwinds the array via :func:`jsonb_array_elements_text`, DuckDB via :func:`from_json` + :func:`unnest` (no :func:`jsonb_array_elements_text` SRF).  The ``--mac`` CLI flag was failing with the same ``AttributeError`` shape on active scans.
* ``setscreenshot(host, port, data, protocol, overwrite)`` trims the image via :func:`ivre.utils.trim_image` and stores the bytes on the per-port ``screendata`` column added in M4.3.2; ``setscreenwords`` re-derives the OCR word list via :func:`ivre.utils.screenwords` for ports that have a screenshot but no ``screenwords`` (or all of them when ``overwrite=True``).  Both mirror the in-memory mutation semantics of the Mongo helpers.
* ``get_mean_open_ports(flt)`` replaces the Python-loop fallback that ``DBActive`` ships with a single SQL aggregation (``count(port) * sum(port) GROUP BY scan.id`` over an outer join scoped to ``state = 'open'``).  Mongo runs the same arithmetic via the aggregation framework.

New helper on ``SQLDBView`` (mirroring :meth:`MongoDB.searchhaslocation`):

* ``searchhaslocation(neg=False)`` filters records that carry GeoIP coordinates on ``info.loc``.  The Mongo helper checks ``{"infos.loc": {"$exists": not neg}}``; here the predicate collapses to ``info -> 'loc' IS NOT NULL`` (or its negation).

New helper on ``SQLDBPassive`` (mirroring
:meth:`MongoDBPassive.insert_or_update_mix`):

* ``insert_or_update_mix(spec, getinfos=None, replacecount=False)`` extracts ``firstseen`` / ``lastseen`` / ``count`` from the spec rather than synthesising them from a single observation timestamp; on conflict the existing row's ``firstseen`` / ``lastseen`` / ``count`` are merged via ``least`` / ``greatest`` / ``+`` (or replaced wholesale when ``replacecount=True``), reusing the existing ``_insert_or_update`` plumbing.

Schema additions:

* Add ``addresses`` JSONB column to ``_Scan``; both ``N_Scan`` and ``V_Scan`` inherit it.  Populated in both ``_store_host`` paths with the same ``null()`` guard the other host-level JSONB columns use (a Python ``None`` would serialise to JSON ``'null'`` rather than SQL ``NULL`` and defeat the ``IS NOT NULL`` check ``searchmac()`` relies on).
* Extend ``SQLDBActive._get`` to project ``cpes`` / ``os`` / ``addresses`` and ``SQLDBActive.get`` to unpack them onto the returned host record.  The two host-level JSONB columns added in M4.3.1 (``cpes`` / ``os``) were stored at ingestion but never surfaced by ``get(...)``: any consumer iterating the read path would silently observe an empty record.  The ``store / retrieve`` round-trip now matches Mongo for all three columns.

DuckDB overrides (``_DuckDBActiveSearchMixin``):

* ``searchmac`` swaps PG's :func:`jsonb_array_elements_text` SRF for :func:`unnest` over a :func:`from_json`-parsed ``VARCHAR[]`` (DuckDB has no :func:`jsonb_array_elements_text`), and :func:`json_type` against ``'ARRAY'`` (case-flipped from PG's lower-case :func:`jsonb_typeof`).

Bug fix carried in this PR (regression introduced in M4.3.2):

* The regex word-match path in ``searchscreenshot`` wrapped ``unnest(port.screenwords)`` in ``select(...).subquery()`` to dodge a DuckDB-specific shape issue on the implicit-row deref.  PostgreSQL silently *decorrelated* that subquery -- ``FROM n_port`` re-introduced a fresh table scan rather than referencing the outer-EXISTS row -- so any matching word anywhere in the database matched every host with a screenshot, not just the host whose port carried the word. The fix replaces the wrapper with the table-valued ``func.unnest(...).table_valued("v").render_derived(name="__sw")`` shape: SQLAlchemy emits ``unnest(port.screenwords) AS __sw(v)``, which both PG and DuckDB parse, *and* the SRF stays inline in the ``FROM`` clause (implicitly lateral on PG, accepted as such on DuckDB).  ``searchmac`` follows the same shape from day one.

Tests (``SQLDBResidualGapsTests`` in
``tests/tests_no_backend.py``):

14 pin tests cover both backends -- per-helper SQL shape (``time_stop`` predicate, ``addresses -> 'mac'`` existence, ``AS __mac(v)`` correlated unwind, ``searchhaslocation`` ``info -> 'loc'`` check, ``count * sum GROUP BY scan.id`` aggregation), DuckDB-specific ``from_json`` rewrite, ``setscreenshot`` / ``setscreenwords`` no-op short-circuit without ``overwrite``, ``insert_or_update_mix`` argument forwarding, and the new ``addresses`` column /
``cpes`` + ``os`` + ``addresses`` projection on ``_Scan``. The M4.3.2 ``test_searchscreenshot_words_regex_uses_subselect`` pin is renamed to
``test_searchscreenshot_words_regex_uses_correlated_unnest`` and updated to assert the new ``AS __sw(v)`` shape.