### PR TITLE
feat(db/sql): add ntlm.* topvalues branch on PG + DuckDB

### DIFF
--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -1193,6 +1193,49 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     self.tables.script.data["s7-info"].has_key(subfield),  # noqa: W601
                 ),
             )
+        elif field == "ntlm" or field.startswith("ntlm."):
+            # Mirrors :meth:`MongoDB.topvalues` for the
+            # ``ntlm`` branches (Mongo paths
+            # ``ports.scripts.ntlm-info`` / ``...ntlm-info.<key>``).
+            # The same friendly-name aliases the Mongo helper
+            # exposes (``os`` -> ``Product_Version``,
+            # ``domain`` -> ``NetBIOS_Domain_Name``, etc.) are
+            # applied here so callers get identical results
+            # across backends.
+            flt = self.flt_and(flt, self.searchntlm())
+            if field == "ntlm":
+                # ``ntlm`` (no subkey) groups by the entire
+                # ``ntlm-info`` JSONB document.
+                field = self._topstructure(
+                    self.tables.script,
+                    [self.tables.script.data["ntlm-info"]],
+                    self.tables.script.name == "ntlm-info",
+                )
+            else:
+                subfield = field[5:]
+                # Friendly-name aliases per
+                # :meth:`MongoDB.topvalues` "ntlm." branch.
+                subfield = {
+                    "name": "Target_Name",
+                    "server": "NetBIOS_Computer_Name",
+                    "domain": "NetBIOS_Domain_Name",
+                    "workgroup": "Workgroup",
+                    "domain_dns": "DNS_Domain_Name",
+                    "forest": "DNS_Tree_Name",
+                    "fqdn": "DNS_Computer_Name",
+                    "os": "Product_Version",
+                    "version": "NTLM_Version",
+                }.get(subfield, subfield)
+                field = self._topstructure(
+                    self.tables.script,
+                    [self.tables.script.data["ntlm-info"][subfield]],
+                    and_(
+                        self.tables.script.name == "ntlm-info",
+                        self.tables.script.data["ntlm-info"].has_key(  # noqa: W601
+                            subfield
+                        ),
+                    ),
+                )
         elif field == "httphdr":
             flt = self.flt_and(flt, self.searchhttphdr())
             field = self._topstructure(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4278,14 +4278,11 @@ class IvreTests(unittest.TestCase):
         self.check_view_top_value("view_top_hop", "hop")
         self.check_view_top_value("view_top_hop_10+", "hop>10")
 
-        if DATABASE != "postgres":
-            self.check_view_top_value("view_top_ntlm_protocol", "ntlm.protocol")
-            self.check_view_top_value("view_top_ntlm_os", "ntlm.os")
-            self.check_view_top_value("view_top_ntlm_os", "ntlm.Product_Version")
-            self.check_view_top_value("view_top_ntlm_domain", "ntlm.domain")
-            self.check_view_top_value(
-                "view_top_ntlm_domain", "ntlm.NetBIOS_Domain_Name"
-            )
+        self.check_view_top_value("view_top_ntlm_protocol", "ntlm.protocol")
+        self.check_view_top_value("view_top_ntlm_os", "ntlm.os")
+        self.check_view_top_value("view_top_ntlm_os", "ntlm.Product_Version")
+        self.check_view_top_value("view_top_ntlm_domain", "ntlm.domain")
+        self.check_view_top_value("view_top_ntlm_domain", "ntlm.NetBIOS_Domain_Name")
 
         print("Filters")
         # Check schema version

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -4511,6 +4511,115 @@ class SQLDBResidualGapsTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBTopValuesNtlmTests -- pin the wire shape of the
+# ``ntlm`` / ``ntlm.<key>`` branches in ``topvalues``.  Both
+# PostgreSQL and DuckDB are exercised so the friendly-name
+# alias map (Mongo's ``ntlm.os`` -> ``Product_Version`` etc.)
+# stays under regression coverage on both backends.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBTopValuesNtlmTests(unittest.TestCase):
+    """Behaviour-pin for the ``ntlm`` and ``ntlm.<key>``
+    ``topvalues`` branches added on ``PostgresDBActive``.
+
+    ``topvalues`` returns a generator and the actual
+    aggregation runs against a live database, so the pin
+    intercepts ``_read_iter`` to capture the rendered SQL
+    statement instead of executing it -- enough to cover the
+    JSONB lookup path, the ``ntlm-info`` script-name guard,
+    and the friendly-name alias map.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _capture_topvalues_sql(db, field):
+        """Run ``db.view.topvalues(field)`` with ``_read_iter``
+        patched to capture the underlying SQL statement.
+        Returns the rendered PostgreSQL string."""
+        captured = []
+
+        def _fake(stmt):
+            captured.append(stmt)
+            return iter([])
+
+        # pylint: disable=protected-access
+        original = db._read_iter
+        db._read_iter = _fake
+        try:
+            list(db.topvalues(field))
+        finally:
+            db._read_iter = original
+        assert captured, "topvalues did not call _read_iter"
+        return SQLDBTopValuesNtlmTests._compile_pg(captured[-1])
+
+    def test_topvalues_ntlm_groups_by_full_doc(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ntlm")
+        self.assertIn("v_script.name = 'ntlm-info'", sql)
+        # SA emits the JSONB lookup as bracket notation
+        # (``data['ntlm-info']``); both PostgreSQL and DuckDB
+        # accept it as a synonym for ``->``.
+        self.assertIn("v_script.data['ntlm-info']", sql)
+
+    def test_topvalues_ntlm_friendly_aliases(self):
+        # The Mongo helper exposes friendly names that map to
+        # the underlying ``ntlm-info`` JSONB keys; pin the
+        # alias map here so the SQL backend keeps the same
+        # public contract.
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        cases = [
+            ("ntlm.name", "Target_Name"),
+            ("ntlm.server", "NetBIOS_Computer_Name"),
+            ("ntlm.domain", "NetBIOS_Domain_Name"),
+            ("ntlm.workgroup", "Workgroup"),
+            ("ntlm.domain_dns", "DNS_Domain_Name"),
+            ("ntlm.forest", "DNS_Tree_Name"),
+            ("ntlm.fqdn", "DNS_Computer_Name"),
+            ("ntlm.os", "Product_Version"),
+            ("ntlm.version", "NTLM_Version"),
+        ]
+        for alias, target in cases:
+            with self.subTest(alias=alias):
+                sql = self._capture_topvalues_sql(db, alias)
+                self.assertIn(f"v_script.data['ntlm-info']['{target}']", sql)
+                # Every branch routes through the
+                # ``ntlm-info`` script name and the
+                # ``has_key`` guard.
+                self.assertIn("v_script.name = 'ntlm-info'", sql)
+                self.assertIn(f"v_script.data['ntlm-info'] ? '{target}'", sql)
+
+    def test_topvalues_ntlm_passthrough_unaliased_key(self):
+        # Keys outside the alias map (e.g. ``protocol``,
+        # ``Target_Name`` directly) are passed through
+        # verbatim -- matching the Mongo helper's
+        # ``.get(arg, arg)`` fallback.
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ntlm.protocol")
+        self.assertIn("v_script.data['ntlm-info']['protocol']", sql)
+        sql_target = self._capture_topvalues_sql(db, "ntlm.Target_Name")
+        self.assertIn("v_script.data['ntlm-info']['Target_Name']", sql_target)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Mirror the Mongo helper's ``topvalues("ntlm")`` and ``topvalues("ntlm.<key>")`` branches on ``PostgresDBActive`` (inherited by both ``PostgresDBNmap`` / ``PostgresDBView`` and, through the DuckDB hierarchy, by ``DuckDBNmap`` / ``DuckDBView``):

* ``ntlm`` (no subkey) groups by the entire ``ntlm-info`` JSONB document, matching Mongo's ``ports.scripts.ntlm-info`` path.
* ``ntlm.<key>`` groups by a specific nested key.  The Mongo helper exposes friendly-name aliases (``os`` -> ``Product_Version``, ``domain`` -> ``NetBIOS_Domain_Name``, ``server`` -> ``NetBIOS_Computer_Name``, ``name`` -> ``Target_Name``, ``workgroup`` -> ``Workgroup``, ``domain_dns`` -> ``DNS_Domain_Name``, ``forest`` -> ``DNS_Tree_Name``, ``fqdn`` -> ``DNS_Computer_Name``, ``version`` -> ``NTLM_Version``); the SQL branch applies the exact same alias map so callers get identical results across backends. Keys outside the alias map (e.g. ``protocol``, ``Target_Name`` directly) pass through verbatim.
* Both branches AND the predicate with the existing :meth:`searchntlm` filter so the aggregation only sees documents that actually carry an ``ntlm-info`` script, and the ``has_key`` guard scopes the per-key projection to rows where the value is set.

The ``raise NotImplementedError()`` at the end of the ``topvalues`` ``elif`` chain (``postgres.py``) was the visible gap; the catch-all stays for the remaining branches the roadmap covers in follow-up sub-PRs.

Tests:

* New ``SQLDBTopValuesNtlmTests`` in ``tests/tests_no_backend.py``: 3 pin tests cover the full-doc grouping, the friendly-name alias map (all 9 entries), and the unaliased-key passthrough -- intercepting ``_read_iter`` to capture and assert the rendered SQL without a live DB connection.
* Drop the ``if DATABASE != "postgres"`` skip block at ``tests/tests.py:4281`` that disabled the ``check_view_top_value("view_top_ntlm_*", "ntlm.*")`` assertions on the PostgreSQL CI lane; the postgres workflow now exercises ntlm topvalues end-to-end.