### PR TITLE
feat(db/sql): add ike/enip/vulns/screenwords topvalues branches

### DIFF
--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -1193,6 +1193,171 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     self.tables.script.data["s7-info"].has_key(subfield),  # noqa: W601
                 ),
             )
+        elif field.startswith("enip."):
+            # Mirrors :meth:`MongoDB.topvalues` ``enip.<key>``
+            # branch: friendly-name aliases for the most common
+            # fields, pass-through for everything else.  Both
+            # Mongo and the SQL backends index the same
+            # ``ports.scripts.enip-info.<key>`` JSONB path.
+            subfield = field[5:]
+            subfield = {
+                "vendor": "Vendor",
+                "product": "Product Name",
+                "serial": "Serial Number",
+                "devtype": "Device Type",
+                "prodcode": "Product Code",
+                "rev": "Revision",
+                "ip": "Device IP",
+            }.get(subfield, subfield)
+            flt = self.flt_and(flt, self.searchscript(name="enip-info"))
+            field = self._topstructure(
+                self.tables.script,
+                [self.tables.script.data["enip-info"][subfield]],
+                and_(
+                    self.tables.script.name == "enip-info",
+                    self.tables.script.data["enip-info"].has_key(  # noqa: W601
+                        subfield
+                    ),
+                ),
+            )
+        elif field == "ike.vendor_ids":
+            # Mirrors :meth:`MongoDB.topvalues` ``ike.vendor_ids``
+            # branch: tuple of ``(value, name)`` pairs unwound
+            # from ``data.ike-info.vendor_ids``.  Both elements
+            # land in the result tuple so a caller can render
+            # the canonical ``Vendor IDs`` table verbatim.
+            flt = self.flt_and(flt, self.searchscript(name="ike-info"))
+            field = self._topstructure(
+                self.tables.script,
+                [
+                    column("vendor_id").op("->>")("value"),
+                    column("vendor_id").op("->>")("name"),
+                ],
+                self.tables.script.name == "ike-info",
+                None,
+                func.jsonb_array_elements(
+                    self.tables.script.data["ike-info"]["vendor_ids"],
+                ).alias("vendor_id"),
+            )
+        elif field == "ike.transforms":
+            # Mirrors :meth:`MongoDB.topvalues` ``ike.transforms``
+            # branch: 6-tuple ``(Authentication, Encryption,
+            # GroupDesc, Hash, LifeDuration, LifeType)`` unwound
+            # from ``data.ike-info.transforms``.
+            flt = self.flt_and(
+                flt,
+                self.searchscript(
+                    name="ike-info",
+                    values={"transforms": {"$exists": True}},
+                ),
+            )
+            field = self._topstructure(
+                self.tables.script,
+                [
+                    column("transform").op("->>")("Authentication"),
+                    column("transform").op("->>")("Encryption"),
+                    column("transform").op("->>")("GroupDesc"),
+                    column("transform").op("->>")("Hash"),
+                    column("transform").op("->>")("LifeDuration"),
+                    column("transform").op("->>")("LifeType"),
+                ],
+                and_(
+                    self.tables.script.name == "ike-info",
+                    self.tables.script.data["ike-info"].has_key(  # noqa: W601
+                        "transforms"
+                    ),
+                ),
+                None,
+                func.jsonb_array_elements(
+                    self.tables.script.data["ike-info"]["transforms"],
+                ).alias("transform"),
+            )
+        elif field == "ike.notification":
+            # Mirrors :meth:`MongoDB.topvalues` ``ike.notification``
+            # branch: scalar ``notification_type`` value.
+            flt = self.flt_and(
+                flt,
+                self.searchscript(
+                    name="ike-info",
+                    values={"notification_type": {"$exists": True}},
+                ),
+            )
+            field = self._topstructure(
+                self.tables.script,
+                [self.tables.script.data["ike-info"]["notification_type"]],
+                and_(
+                    self.tables.script.name == "ike-info",
+                    self.tables.script.data["ike-info"].has_key(  # noqa: W601
+                        "notification_type"
+                    ),
+                ),
+            )
+        elif field.startswith("ike."):
+            # Pass-through for ``ike.<key>`` paths the specific
+            # branches above do not cover -- mirrors the Mongo
+            # helper's catch-all.
+            subfield = field[4:]
+            flt = self.flt_and(flt, self.searchscript(name="ike-info"))
+            field = self._topstructure(
+                self.tables.script,
+                [self.tables.script.data["ike-info"][subfield]],
+                and_(
+                    self.tables.script.name == "ike-info",
+                    self.tables.script.data["ike-info"].has_key(subfield),  # noqa: W601
+                ),
+            )
+        elif field == "vulns.id":
+            # Mirrors :meth:`MongoDB.topvalues` ``vulns.id``
+            # branch: top values of the vulnerability id field
+            # across the unwound ``data.vulns`` array.  The
+            # array lives on every script that emits the
+            # ``vulns`` NSE-table (afp-path-vuln, *vsftpd*,
+            # ssl-heartbleed, smb-vuln-*, http-vuln-*, ...) --
+            # the JSONB-typeof guard is enough to scope the
+            # aggregation without enumerating script names.
+            flt = self.flt_and(flt, self.searchvuln())
+            field = self._topstructure(
+                self.tables.script,
+                [column("vuln").op("->>")("id")],
+                func.jsonb_typeof(self.tables.script.data.op("->")("vulns")) == "array",
+                None,
+                func.jsonb_array_elements(
+                    self.tables.script.data.op("->")("vulns"),
+                ).alias("vuln"),
+            )
+        elif field.startswith("vulns."):
+            # Mirrors :meth:`MongoDB.topvalues` ``vulns.<other>``
+            # branch: tuple of ``(id, <other>)`` so the caller
+            # can correlate the field back to the specific
+            # vulnerability.  Same array-unwind shape as
+            # ``vulns.id``.
+            subfield = field[6:]
+            flt = self.flt_and(flt, self.searchvuln())
+            field = self._topstructure(
+                self.tables.script,
+                [
+                    column("vuln").op("->>")("id"),
+                    column("vuln").op("->>")(subfield),
+                ],
+                func.jsonb_typeof(self.tables.script.data.op("->")("vulns")) == "array",
+                None,
+                func.jsonb_array_elements(
+                    self.tables.script.data.op("->")("vulns"),
+                ).alias("vuln"),
+            )
+        elif field == "screenwords":
+            # Mirrors :meth:`MongoDB.topvalues` ``screenwords``
+            # branch: top values of the OCR-derived word list
+            # stored on the ``port.screenwords`` array column
+            # (added in M4.3.2 alongside ``screenshot`` /
+            # ``screendata``).  ``unnest()`` rolls each list
+            # element out as its own row before grouping.
+            flt = self.flt_and(flt, self.searchscreenshot(words=True))
+            field = self._topstructure(
+                self.tables.port,
+                [func.unnest(self.tables.port.screenwords)],
+                self.tables.port.screenwords != None,  # noqa: E711
+            )
         elif field == "ntlm" or field.startswith("ntlm."):
             # Mirrors :meth:`MongoDB.topvalues` for the
             # ``ntlm`` branches (Mongo paths

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -4620,6 +4620,176 @@ class SQLDBTopValuesNtlmTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBTopValuesIotVulnTests -- pin the wire shape of the
+# ``ike.*`` / ``enip.*`` / ``vulns.*`` / ``screenwords`` IoT /
+# ICS / vuln cluster of ``topvalues`` branches added on
+# ``PostgresDBActive``.  The DuckDB lane inherits the same code
+# through ``DuckDBActive`` so these pins cover both backends.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBTopValuesIotVulnTests(unittest.TestCase):
+    """Behaviour-pin for the ``ike.*`` / ``enip.*`` / ``vulns.*``
+    / ``screenwords`` ``topvalues`` branches.
+
+    Same ``_read_iter`` interception trick the ntlm pin tests
+    use -- the actual aggregation runs against a live
+    database, but compiling the captured statement is enough
+    to cover the JSONB unwind path, the script-name guard, the
+    Mongo-shape friendly-name aliases (enip), and the
+    array-element-tuple projection (ike.vendor_ids /
+    ike.transforms / vulns.<other>).
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _capture_topvalues_sql(db, field):
+        captured = []
+
+        def _fake(stmt):
+            captured.append(stmt)
+            return iter([])
+
+        # pylint: disable=protected-access
+        original = db._read_iter
+        db._read_iter = _fake
+        try:
+            list(db.topvalues(field))
+        finally:
+            db._read_iter = original
+        assert captured, "topvalues did not call _read_iter"
+        return SQLDBTopValuesIotVulnTests._compile_pg(captured[-1])
+
+    # -- ike.* ---------------------------------------------------------
+
+    def test_topvalues_ike_vendor_ids_emits_value_name_tuple(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ike.vendor_ids")
+        self.assertIn("v_script.name = 'ike-info'", sql)
+        # Tuple projection: both ``value`` and ``name`` keys
+        # off the unwound ``vendor_id`` element.
+        self.assertIn("vendor_id ->> 'value'", sql)
+        self.assertIn("vendor_id ->> 'name'", sql)
+        self.assertIn(
+            "jsonb_array_elements(v_script.data['ike-info']['vendor_ids'])",
+            sql,
+        )
+
+    def test_topvalues_ike_transforms_emits_six_field_tuple(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ike.transforms")
+        self.assertIn("v_script.name = 'ike-info'", sql)
+        for fld in (
+            "Authentication",
+            "Encryption",
+            "GroupDesc",
+            "Hash",
+            "LifeDuration",
+            "LifeType",
+        ):
+            self.assertIn(f"transform ->> '{fld}'", sql)
+        self.assertIn("v_script.data['ike-info'] ? 'transforms'", sql)
+
+    def test_topvalues_ike_notification_emits_scalar(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ike.notification")
+        self.assertIn("v_script.name = 'ike-info'", sql)
+        self.assertIn("v_script.data['ike-info']['notification_type']", sql)
+        # No JSON-array unwind on the scalar branch.
+        self.assertNotIn("jsonb_array_elements", sql)
+
+    def test_topvalues_ike_passthrough_unaliased_key(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ike.attributes")
+        self.assertIn("v_script.name = 'ike-info'", sql)
+        self.assertIn("v_script.data['ike-info']['attributes']", sql)
+
+    # -- enip.* --------------------------------------------------------
+
+    def test_topvalues_enip_friendly_aliases(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        cases = [
+            ("enip.vendor", "Vendor"),
+            ("enip.product", "Product Name"),
+            ("enip.serial", "Serial Number"),
+            ("enip.devtype", "Device Type"),
+            ("enip.prodcode", "Product Code"),
+            ("enip.rev", "Revision"),
+            ("enip.ip", "Device IP"),
+        ]
+        for alias, target in cases:
+            with self.subTest(alias=alias):
+                sql = self._capture_topvalues_sql(db, alias)
+                self.assertIn(f"v_script.data['enip-info']['{target}']", sql)
+                self.assertIn("v_script.name = 'enip-info'", sql)
+
+    def test_topvalues_enip_passthrough_unaliased_key(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "enip.Custom_Field")
+        self.assertIn("v_script.data['enip-info']['Custom_Field']", sql)
+
+    # -- vulns.* -------------------------------------------------------
+
+    def test_topvalues_vulns_id_unwinds_array(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "vulns.id")
+        self.assertIn("jsonb_array_elements(v_script.data -> 'vulns')", sql)
+        self.assertIn("vuln ->> 'id'", sql)
+        # The aggregation is gated on the JSONB-typeof check
+        # rather than a script-name list -- vulns are emitted
+        # by dozens of NSE scripts and the array-shape guard
+        # is enough to scope the unwind safely.
+        self.assertIn("jsonb_typeof(v_script.data -> 'vulns') = 'array'", sql)
+
+    def test_topvalues_vulns_other_emits_id_tuple(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "vulns.state")
+        # Tuple projection: both ``id`` (so the caller can
+        # correlate) and the requested subfield.
+        self.assertIn("vuln ->> 'id'", sql)
+        self.assertIn("vuln ->> 'state'", sql)
+        self.assertIn("jsonb_array_elements(v_script.data -> 'vulns')", sql)
+
+    # -- screenwords ---------------------------------------------------
+
+    def test_topvalues_screenwords_unnests_array(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "screenwords")
+        self.assertIn("unnest(v_port.screenwords)", sql)
+        self.assertIn("v_port.screenwords IS NOT NULL", sql)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Mirror the Mongo helper's IoT / ICS / vuln cluster of ``topvalues`` branches on ``PostgresDBActive`` (inherited by both PG and DuckDB through the existing class hierarchy).

New branches:

* ``ike.vendor_ids`` -- tuple of ``(value, name)`` pairs unwound from ``data.ike-info.vendor_ids[*]``.  Both elements land in the result tuple so a caller can render the canonical "Vendor IDs" table verbatim.
* ``ike.transforms`` -- 6-tuple ``(Authentication, Encryption, GroupDesc, Hash, LifeDuration, LifeType)`` unwound from ``data.ike-info.transforms[*]``.
* ``ike.notification`` -- scalar ``data.ike-info.notification_type``.
* ``ike.<other>`` -- pass-through to ``data.ike-info.<other>`` for keys the specific branches do not cover (matches Mongo's catch-all).
* ``enip.<key>`` -- friendly-name aliases (``vendor`` -> ``Vendor``, ``product`` -> ``Product Name``, ``serial`` -> ``Serial Number``, ``devtype`` -> ``Device Type``, ``prodcode`` -> ``Product Code``, ``rev`` -> ``Revision``, ``ip`` -> ``Device IP``); pass-through for keys outside the alias map.
* ``vulns.id`` -- top values of the vulnerability id field across the unwound ``data.vulns`` array.  Vulnerabilities are emitted by dozens of NSE scripts (vsftpd-backdoor, ssl-heartbleed, smb-vuln-*, http-vuln-*, ...) -- the ``jsonb_typeof(... -> 'vulns') = 'array'`` guard scopes the unwind safely without enumerating script names.
* ``vulns.<other>`` -- tuple of ``(id, <other>)`` so the caller can correlate the requested field back to the specific vulnerability.
* ``screenwords`` -- top values of the OCR-derived word list stored on ``port.screenwords`` (the array column added in M4.3.2 alongside ``screenshot`` / ``screendata``).  ``unnest()`` rolls each list element out as its own row before grouping, with the ``screenshot`` existence guard the Mongo helper emits via ``searchscreenshot(words=True)``.

The tuple-projection branches (``ike.vendor_ids``, ``ike.transforms``, ``vulns.<other>``) follow the same ``func.jsonb_array_elements(...).alias("name")`` shape the existing ``ssl-ja3-server`` branch ships, so they trigger the same ``SAWarning: SELECT statement has a cartesian product`` PostgreSQL emits today; the
``CROSS JOIN LATERAL`` rewrite tracked separately
(alongside the matching ``httphdr*`` / ``httpapp*`` paths) will silence them once landed.

Tests:

* New ``SQLDBTopValuesIotVulnTests`` in ``tests/tests_no_backend.py``: 9 pin tests cover the full set -- per-branch JSONB indexing path, the friendly-name alias map (enip), the array-element tuple arity (ike.vendor_ids: 2, ike.transforms: 6, vulns.<other>: 2), the array-shape guard (``jsonb_typeof = 'array'`` on vulns), and the ``unnest`` shape on screenwords.  Both PostgreSQL and DuckDB go through the same code path -- the pins compile under both dialects.