### PR TITLE
feat(db/sql): close M4.4 -- residual topvalues + JOIN LATERAL

### DIFF
--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -45,11 +45,13 @@ from sqlalchemy import (
     func,
     insert,
     join,
+    lateral,
     not_,
     null,
     nulls_first,
     select,
     text,
+    true,
     tuple_,
     update,
 )
@@ -696,6 +698,86 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                         self.tables.port.service_name == info,
                     ),
                 )
+        elif field.startswith("cpe"):
+            # Mirrors :meth:`MongoDB.topvalues` ``cpe`` /
+            # ``cpe.<part>`` / ``cpe:<spec>`` /
+            # ``cpe.<part>:<spec>`` family (with ``<part>`` one
+            # of ``type`` / ``vendor`` / ``product`` /
+            # ``version`` -- or 1..4 -- and ``<spec>`` an
+            # optional ``:``-separated list of regex filters
+            # narrowing the unwound CPEs).  Mongo concats the
+            # selected fields into a single ``:``-separated
+            # string and the outputproc splits back into a
+            # tuple; SQL lets us group by the columns
+            # directly so we just project them as a tuple
+            # (``_topstructure`` returns ``result[1:]`` when
+            # there is more than one projection column).
+            try:
+                cpe_field, cpe_spec = field.split(":", 1)
+                cpe_spec_parts = cpe_spec.split(":", 3)
+            except ValueError:
+                cpe_field = field
+                cpe_spec_parts = []
+            try:
+                cpe_field = cpe_field.split(".", 1)[1]
+            except IndexError:
+                cpe_field = "version"
+            cpe_keys = ["type", "vendor", "product", "version"]
+            if cpe_field not in cpe_keys:
+                try:
+                    cpe_field = cpe_keys[int(cpe_field) - 1]
+                except (IndexError, ValueError):
+                    cpe_field = "version"
+            cpe_filters = list(
+                zip(
+                    cpe_keys,
+                    (utils.str2regexp(value) for value in cpe_spec_parts),
+                )
+            )
+            # ``searchcpe`` takes the same dict shape Mongo
+            # passes to its ``$elemMatch`` -- with ``type``
+            # renamed to ``cpe_type`` per the helper's API.
+            flt = self.flt_and(
+                flt,
+                self.searchcpe(
+                    **{
+                        ("cpe_type" if key == "type" else key): value
+                        for key, value in cpe_filters
+                    }
+                ),
+            )
+            # Project up to and including ``cpe_field``;
+            # filter on the spec keys that were supplied.
+            keep_count = max(cpe_keys.index(cpe_field) + 1, len(cpe_filters))
+            kept_keys = cpe_keys[:keep_count]
+            # ``lateral(...)`` is required so PostgreSQL
+            # correlates the JSON unwind with the outer
+            # ``v_scan`` row -- without the explicit lateral
+            # marker, SA emits a comma-join and PG flags it
+            # as a cartesian product
+            # (``SAWarning: SELECT statement has a cartesian
+            # product between FROM element(s) "cpe" and FROM
+            # element "v_scan"``).  Implicit-lateral on SRFs
+            # produces correct results today, but the warning
+            # leaks to stderr on every CLI ``--top`` call.
+            cpe_alias = lateral(func.jsonb_array_elements(self.tables.scan.cpes)).alias(
+                "cpe"
+            )
+            cpe_conds = [
+                self._searchstring_re(column("cpe").op("->>")(key), value)
+                for key, value in cpe_filters
+            ]
+            field = self._topstructure(
+                self.tables.scan,
+                [column("cpe").op("->>")(key) for key in kept_keys],
+                (
+                    and_(*cpe_conds)
+                    if cpe_conds
+                    else self.tables.scan.cpes != None  # noqa: E711
+                ),
+                None,
+                cpe_alias,
+            )
         elif field == "devicetype":
             field = self._topstructure(
                 self.tables.port,
@@ -810,6 +892,21 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                         self.tables.port.service_name == info,
                     ),
                 )
+        elif field == "addr":
+            # Mirrors :meth:`MongoDB.topvalues` ``addr``
+            # branch: top values of the host address column,
+            # decoded back to a printable IP via
+            # :meth:`SQLDB.internal2ip` (which handles both
+            # the ``str`` and ``dict`` round-trip shapes
+            # PostgreSQL / DuckDB use for ``INET``).
+            field = self._topstructure(self.tables.scan, [self.tables.scan.addr])
+
+            def outputproc(addr):
+                try:
+                    return self.internal2ip(addr)
+                except (TypeError, ValueError):
+                    return addr
+
         elif field == "asnum":
             field = self._topstructure(
                 self.tables.scan, [self.tables.scan.info["as_num"]]
@@ -903,8 +1000,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     [column("http_user_agent")],
                     self.tables.script.name == "http-user-agent",
                     None,
-                    func.jsonb_array_elements(
-                        self.tables.script.data["http-user-agent"],
+                    lateral(
+                        func.jsonb_array_elements(
+                            self.tables.script.data["http-user-agent"],
+                        )
                     ).alias("http_user_agent"),
                 )
             else:
@@ -921,8 +1020,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                         ),
                     ),
                     None,
-                    func.jsonb_array_elements(
-                        self.tables.script.data["http-user-agent"],
+                    lateral(
+                        func.jsonb_array_elements(
+                            self.tables.script.data["http-user-agent"],
+                        )
                     ).alias("http_user_agent"),
                 )
         elif field == "ja3-client" or (
@@ -944,8 +1045,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     [column("ssl_ja3_client").op("->>")(subfield)],
                     self.tables.script.name == "ssl-ja3-client",
                     None,
-                    func.jsonb_array_elements(
-                        self.tables.script.data["ssl-ja3-client"],
+                    lateral(
+                        func.jsonb_array_elements(
+                            self.tables.script.data["ssl-ja3-client"],
+                        )
                     ).alias("ssl_ja3_client"),
                 )
             else:
@@ -962,8 +1065,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                         ),
                     ),
                     None,
-                    func.jsonb_array_elements(
-                        self.tables.script.data["ssl-ja3-client"],
+                    lateral(
+                        func.jsonb_array_elements(
+                            self.tables.script.data["ssl-ja3-client"],
+                        )
                     ).alias("ssl_ja3_client"),
                 )
         elif field == "ja3-server" or (
@@ -1016,8 +1121,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 ],
                 condition,
                 None,
-                func.jsonb_array_elements(
-                    self.tables.script.data["ssl-ja3-server"],
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ssl-ja3-server"],
+                    )
                 ).alias("ssl_ja3_server"),
             )
         elif field == "jarm":
@@ -1035,6 +1142,80 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     & (self.tables.port.port == int(field[5:]))
                     & (self.tables.port.protocol == "tcp")
                 ),
+            )
+        elif field == "sshkey.bits":
+            # Mirrors :meth:`MongoDB.topvalues` ``sshkey.bits``
+            # branch: tuple of ``(type, bits)`` unwound from
+            # ``data.ssh-hostkey`` so the caller can correlate
+            # the bit count to the key algorithm.  The Mongo
+            # helper goes through ``searchsshkey()`` to scope
+            # the filter; we do the same on the SQL side.
+            flt = self.flt_and(flt, self.searchsshkey())
+            field = self._topstructure(
+                self.tables.script,
+                [
+                    column("sshkey").op("->>")("type"),
+                    column("sshkey").op("->>")("bits"),
+                ],
+                self.tables.script.name == "ssh-hostkey",
+                None,
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ssh-hostkey"],
+                    )
+                ).alias("sshkey"),
+            )
+        elif field.startswith("sshkey."):
+            # Mirrors :meth:`MongoDB.topvalues` ``sshkey.<other>``
+            # branch: scalar value of a single key on each
+            # unwound ``ssh-hostkey`` element.
+            subfield = field[7:]
+            flt = self.flt_and(flt, self.searchsshkey())
+            field = self._topstructure(
+                self.tables.script,
+                [column("sshkey").op("->>")(subfield)],
+                self.tables.script.name == "ssh-hostkey",
+                None,
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ssh-hostkey"],
+                    )
+                ).alias("sshkey"),
+            )
+        elif field == "ja4-client" or (
+            field.startswith("ja4-client") and field[10] in ":."
+        ):
+            # Mirrors :meth:`MongoDB.topvalues` ``ja4-client``
+            # branch: top values of a field on the unwound
+            # ``ssl-ja4-client`` array.  The Mongo helper
+            # supports the ``ja4-client[.<sub>][:<value>]``
+            # form -- ``<sub>`` defaults to ``ja4`` (the
+            # canonical fingerprint), ``<value>`` narrows the
+            # filter to a specific fingerprint string.
+            value = None
+            if ":" in field:
+                field, value = field.split(":", 1)
+            if "." in field:
+                _, subfield = field.split(".", 1)
+            else:
+                subfield = "ja4"
+            flt = self.flt_and(flt, self.searchja4client(value=value))
+            condition = self.tables.script.name == "ssl-ja4-client"
+            if value is not None:
+                condition = and_(
+                    condition,
+                    column("ssl_ja4_client").op("->>")("ja4") == value,
+                )
+            field = self._topstructure(
+                self.tables.script,
+                [column("ssl_ja4_client").op("->>")(subfield)],
+                condition,
+                None,
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ssl-ja4-client"],
+                    )
+                ).alias("ssl_ja4_client"),
             )
         elif field == "hassh" or (field.startswith("hassh") and field[5] in "-."):
             if "." in field:
@@ -1193,6 +1374,44 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     self.tables.script.data["s7-info"].has_key(subfield),  # noqa: W601
                 ),
             )
+        elif field.startswith("smb."):
+            # Mirrors :meth:`MongoDB.topvalues` ``smb.<key>``
+            # branch: top values of a key on the
+            # ``smb-os-discovery`` script's data document.  No
+            # friendly-name aliases (the Mongo helper passes
+            # the subkey through unchanged); :meth:`searchsmb`
+            # narrows the active filter to scans carrying the
+            # script.
+            subfield = field[4:]
+            flt = self.flt_and(flt, self.searchsmb())
+            field = self._topstructure(
+                self.tables.script,
+                [self.tables.script.data["smb-os-discovery"][subfield]],
+                and_(
+                    self.tables.script.name == "smb-os-discovery",
+                    self.tables.script.data["smb-os-discovery"].has_key(  # noqa: W601
+                        subfield
+                    ),
+                ),
+            )
+        elif field.startswith("mongo.dbs."):
+            # Mirrors :meth:`MongoDB.topvalues` ``mongo.dbs.<key>``
+            # branch: top values of a per-database field on the
+            # ``mongodb-databases`` script's data document.
+            subfield = field[10:]
+            flt = self.flt_and(flt, self.searchscript(name="mongodb-databases"))
+            field = self._topstructure(
+                self.tables.script,
+                [
+                    self.tables.script.data["mongodb-databases"][subfield],
+                ],
+                and_(
+                    self.tables.script.name == "mongodb-databases",
+                    self.tables.script.data["mongodb-databases"].has_key(  # noqa: W601
+                        subfield
+                    ),
+                ),
+            )
         elif field.startswith("enip."):
             # Mirrors :meth:`MongoDB.topvalues` ``enip.<key>``
             # branch: friendly-name aliases for the most common
@@ -1235,8 +1454,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 ],
                 self.tables.script.name == "ike-info",
                 None,
-                func.jsonb_array_elements(
-                    self.tables.script.data["ike-info"]["vendor_ids"],
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ike-info"]["vendor_ids"],
+                    )
                 ).alias("vendor_id"),
             )
         elif field == "ike.transforms":
@@ -1268,8 +1489,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     ),
                 ),
                 None,
-                func.jsonb_array_elements(
-                    self.tables.script.data["ike-info"]["transforms"],
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data["ike-info"]["transforms"],
+                    )
                 ).alias("transform"),
             )
         elif field == "ike.notification":
@@ -1321,8 +1544,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 [column("vuln").op("->>")("id")],
                 func.jsonb_typeof(self.tables.script.data.op("->")("vulns")) == "array",
                 None,
-                func.jsonb_array_elements(
-                    self.tables.script.data.op("->")("vulns"),
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data.op("->")("vulns"),
+                    )
                 ).alias("vuln"),
             )
         elif field.startswith("vulns."):
@@ -1341,8 +1566,10 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 ],
                 func.jsonb_typeof(self.tables.script.data.op("->")("vulns")) == "array",
                 None,
-                func.jsonb_array_elements(
-                    self.tables.script.data.op("->")("vulns"),
+                lateral(
+                    func.jsonb_array_elements(
+                        self.tables.script.data.op("->")("vulns"),
+                    )
                 ).alias("vuln"),
             )
         elif field == "screenwords":
@@ -1411,8 +1638,8 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 ],
                 self.tables.script.name == "http-headers",
                 [column("name"), column("value")],
-                func.jsonb_array_elements(
-                    self.tables.script.data["http-headers"]
+                lateral(
+                    func.jsonb_array_elements(self.tables.script.data["http-headers"])
                 ).alias("hdr"),
             )
         elif field.startswith("httphdr."):
@@ -1422,8 +1649,8 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 [column("hdr").op("->>")(field[8:]).label("topvalue")],
                 self.tables.script.name == "http-headers",
                 [column("topvalue")],
-                func.jsonb_array_elements(
-                    self.tables.script.data["http-headers"]
+                lateral(
+                    func.jsonb_array_elements(self.tables.script.data["http-headers"])
                 ).alias("hdr"),
             )
         elif field.startswith("httphdr:"):
@@ -1437,8 +1664,8 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     column("hdr").op("->>")("name") == subfield,
                 ),
                 [column("value")],
-                func.jsonb_array_elements(
-                    self.tables.script.data["http-headers"]
+                lateral(
+                    func.jsonb_array_elements(self.tables.script.data["http-headers"])
                 ).alias("hdr"),
             )
         elif field == "httpapp":
@@ -1451,9 +1678,9 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 ],
                 self.tables.script.name == "http-app",
                 [column("application"), column("version")],
-                func.jsonb_array_elements(self.tables.script.data["http-app"]).alias(
-                    "app"
-                ),
+                lateral(
+                    func.jsonb_array_elements(self.tables.script.data["http-app"])
+                ).alias("app"),
             )
         elif field.startswith("httpapp:"):
             subfield = field[8:]
@@ -1466,9 +1693,9 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                     column("app").op("->>")("application") == subfield,
                 ),
                 [column("version")],
-                func.jsonb_array_elements(self.tables.script.data["http-app"]).alias(
-                    "app"
-                ),
+                lateral(
+                    func.jsonb_array_elements(self.tables.script.data["http-app"])
+                ).alias("app"),
             )
         elif field == "schema_version":
             field = self._topstructure(
@@ -1522,7 +1749,7 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
                 self.tables.tag.value == subfield,
             )
         else:
-            raise NotImplementedError()
+            raise ValueError(f"Unknown field {field}")
         s_from = {
             self.tables.script: join(self.tables.script, self.tables.port),
             self.tables.port: self.tables.port,
@@ -1543,17 +1770,41 @@ class PostgresDBActive(PostgresDB, SQLDBActive):
             self.tables.tag: self.tables.tag.scan == base.c.id,
         }
         if field.base == self.tables.scan:
-            req = flt.query(
-                select(func.count().label("count"), *field.fields)
-                .select_from(self.tables.scan)
-                .group_by(*field.fields)
-            )
-        else:
-            req = select(func.count().label("count"), *field.fields).select_from(
-                s_from[field.base]
-            )
+            # ``extraselectfrom`` is supported on the
+            # scan-base path too (cpe.* unwinds the
+            # ``scan.cpes`` JSONB array via
+            # :func:`jsonb_array_elements`); it is added to
+            # the FROM list before the filter is applied so
+            # the predicates and projection see the unwound
+            # rows.  ``.join(extraselectfrom, true())``
+            # produces explicit ``JOIN LATERAL ... ON true``
+            # syntax SQLAlchemy recognises as a join,
+            # silencing the
+            # ``SAWarning: SELECT statement has a cartesian
+            # product`` it would otherwise emit on
+            # ``select_from(extraselectfrom)`` (a separate
+            # FROM element with no join condition); the
+            # behaviour at the database level is identical.
+            scan_from = self.tables.scan
             if field.extraselectfrom is not None:
-                req = req.select_from(field.extraselectfrom)
+                scan_from = join(scan_from, field.extraselectfrom, true())
+            req = (
+                select(func.count().label("count"), *field.fields)
+                .select_from(scan_from)
+                .group_by(*(field.fields if field.group_by is None else field.group_by))
+            )
+            req = flt.query(req)
+        else:
+            base_from = s_from[field.base]
+            # See :meth:`PostgresDBActive.topvalues`'s
+            # scan-base branch above for the explicit
+            # ``JOIN LATERAL ... ON true`` rationale -- same
+            # SQLAlchemy-warning workaround applies here.
+            if field.extraselectfrom is not None:
+                base_from = join(base_from, field.extraselectfrom, true())
+            req = select(func.count().label("count"), *field.fields).select_from(
+                base_from
+            )
             req = req.group_by(
                 *(field.fields if field.group_by is None else field.group_by)
             ).where(exists(select(1).select_from(base).where(where_clause[field.base])))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -312,23 +312,7 @@ class IvreTests(unittest.TestCase):
 
     def _check_top_value_cli(self, name, field, count=10, command="", **kwargs):
         res, out, err = RUN(["ivre", command, "--top", field, "--limit", str(count)])
-        if DATABASE != "postgres":
-            # The PostgreSQL ``topvalues`` paths for ``httphdr`` /
-            # ``httphdr.<key>`` / ``httphdr:<name>`` (and the
-            # parallel ``httpapp`` family) build the per-row
-            # ``jsonb_array_elements(...)`` virtual table via
-            # ``.alias("hdr")`` + ``select_from(extraselectfrom)``
-            # without an explicit join condition, which
-            # PostgreSQL reports as a cartesian product
-            # (``SAWarning: SELECT statement has a cartesian
-            # product between FROM element(s) "hdr" and FROM
-            # element "n_port"``). The fix is to wrap the
-            # subquery in ``CROSS JOIN LATERAL`` (SQLAlchemy:
-            # ``lateral()``) -- non-trivial refactor scheduled
-            # alongside the rest of the SQL ``topvalues`` parity
-            # work. Until that lands, the warning leaks to
-            # stderr on every ``httphdr*`` top-value CLI call.
-            self.assertFalse(err)
+        self.assertFalse(err)
         self.assertEqual(res, 0)
         listval = []
         for line in out.decode().split("\n"):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -4790,6 +4790,231 @@ class SQLDBTopValuesIotVulnTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBTopValuesResidualTests -- pin the wire shape of the
+# residual ``topvalues`` parity branches: ``addr`` /
+# ``cpe[.<part>][:<spec>]`` / ``smb.*`` / ``mongo.dbs.*`` /
+# ``sshkey.bits`` / ``sshkey.<key>`` / ``ja4-client[.<sub>][:<value>]``,
+# plus the ``CROSS JOIN LATERAL`` rewrite of every existing
+# ``jsonb_array_elements(...).alias("name")`` extraselectfrom
+# path (httphdr*/httpapp*/ja3-client/ja3-server/useragent/
+# ike.vendor_ids/ike.transforms/vulns.id/vulns.<other>/sshkey.*/
+# ja4-client/cpe).
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or ``duckdb`` extras)",
+)
+class SQLDBTopValuesResidualTests(unittest.TestCase):
+    """Behaviour-pin for the residual ``topvalues`` branches
+    closing M4.4 -- enough to delete the
+    ``raise NotImplementedError()`` catch-all
+    (``postgres.py:1735``) and unconditionally restore the
+    ``self.assertFalse(err)`` assertion that
+    ``_check_top_value_cli`` had to gate behind
+    ``DATABASE != "postgres"`` while the cartesian-product
+    warning was leaking on every ``httphdr*`` / ``httpapp*``
+    CLI call.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        return str(
+            stmt.compile(
+                dialect=_sqlalchemy_postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @staticmethod
+    def _capture_topvalues_sql(db, field):
+        captured = []
+
+        def _fake(stmt):
+            captured.append(stmt)
+            return iter([])
+
+        # pylint: disable=protected-access
+        original = db._read_iter
+        db._read_iter = _fake
+        try:
+            list(db.topvalues(field))
+        finally:
+            db._read_iter = original
+        assert captured, "topvalues did not call _read_iter"
+        return SQLDBTopValuesResidualTests._compile_pg(captured[-1])
+
+    # -- addr ----------------------------------------------------------
+
+    def test_topvalues_addr_groups_on_scan_addr(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "addr")
+        self.assertIn("v_scan.addr", sql)
+        self.assertIn("GROUP BY v_scan.addr", sql)
+
+    # -- cpe.* ---------------------------------------------------------
+
+    def test_topvalues_cpe_default_projects_all_four_fields(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "cpe")
+        for fld in ("type", "vendor", "product", "version"):
+            self.assertIn(f"cpe ->> '{fld}'", sql)
+
+    def test_topvalues_cpe_part_truncates_projection(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "cpe.vendor")
+        # ``cpe.vendor`` projects up to and including
+        # ``vendor`` (so ``type`` and ``vendor`` only).
+        self.assertIn("cpe ->> 'type'", sql)
+        self.assertIn("cpe ->> 'vendor'", sql)
+        self.assertNotIn("cpe ->> 'product'", sql)
+        self.assertNotIn("cpe ->> 'version'", sql)
+
+    def test_topvalues_cpe_numeric_part_resolves(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "cpe.1")
+        # ``cpe.1`` resolves to the first cpe key (``type``).
+        self.assertIn("cpe ->> 'type'", sql)
+        self.assertNotIn("cpe ->> 'vendor'", sql)
+
+    def test_topvalues_cpe_spec_filters_unwound_element(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "cpe.product:apache")
+        # The spec filters at both the host level (via
+        # ``searchcpe``) and the unwound element level.
+        self.assertIn("cpe ->> 'type'", sql)
+        # Host-level filter pulls in a ``searchcpe`` EXISTS.
+        self.assertIn("__cpe ->> 'type'", sql)
+
+    def test_topvalues_cpe_uses_lateral_unwind(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "cpe")
+        self.assertIn("LATERAL jsonb_array_elements(v_scan.cpes)", sql)
+
+    # -- smb.* ---------------------------------------------------------
+
+    def test_topvalues_smb_subkey_indexes_into_script_data(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "smb.os")
+        self.assertIn("v_script.name = 'smb-os-discovery'", sql)
+        self.assertIn("v_script.data['smb-os-discovery']['os']", sql)
+
+    # -- mongo.dbs.* ---------------------------------------------------
+
+    def test_topvalues_mongo_dbs_indexes_into_script_data(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "mongo.dbs.name")
+        self.assertIn("v_script.name = 'mongodb-databases'", sql)
+        self.assertIn("v_script.data['mongodb-databases']['name']", sql)
+
+    # -- sshkey.* ------------------------------------------------------
+
+    def test_topvalues_sshkey_bits_emits_type_bits_tuple(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "sshkey.bits")
+        self.assertIn("v_script.name = 'ssh-hostkey'", sql)
+        self.assertIn("sshkey ->> 'type'", sql)
+        self.assertIn("sshkey ->> 'bits'", sql)
+
+    def test_topvalues_sshkey_passthrough_other_key(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "sshkey.fingerprint")
+        self.assertIn("sshkey ->> 'fingerprint'", sql)
+
+    # -- ja4-client ----------------------------------------------------
+
+    def test_topvalues_ja4client_default_subfield_is_ja4(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(db, "ja4-client")
+        self.assertIn("v_script.name = 'ssl-ja4-client'", sql)
+        self.assertIn("ssl_ja4_client ->> 'ja4'", sql)
+
+    def test_topvalues_ja4client_value_filters_inner_unwind(self):
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        sql = self._capture_topvalues_sql(
+            db, "ja4-client:t13d1517h2_8daaf6152771_b1ff8ab2d16f"
+        )
+        self.assertIn(
+            "(ssl_ja4_client ->> 'ja4') = " "'t13d1517h2_8daaf6152771_b1ff8ab2d16f'",
+            sql,
+        )
+
+    # -- LATERAL rewrite -----------------------------------------------
+
+    def test_lateral_silences_cartesian_product_on_existing_paths(self):
+        # Pin that the existing ``jsonb_array_elements(...)``
+        # extraselectfrom paths now wrap their unwind in
+        # ``LATERAL`` -- silences the
+        # ``SAWarning: cartesian product`` PostgreSQL emits
+        # when a comma-joined SRF lacks an explicit join
+        # condition.
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        for field in (
+            "httphdr",
+            "httphdr.name",
+            "httphdr:server",
+            "httpapp",
+            "httpapp:Apache",
+            "ja3-client",
+            "ja3-server",
+            "useragent",
+            "useragent:Firefox",
+            "ike.vendor_ids",
+            "ike.transforms",
+            "vulns.id",
+            "vulns.state",
+            "sshkey.bits",
+            "sshkey.fingerprint",
+            "ja4-client",
+        ):
+            with self.subTest(field=field):
+                sql = self._capture_topvalues_sql(db, field)
+                self.assertIn("LATERAL", sql.upper())
+
+    # -- catch-all -----------------------------------------------------
+
+    def test_topvalues_unknown_field_raises_valueerror(self):
+        # The ``raise NotImplementedError()`` catch-all was
+        # replaced with a clearer
+        # ``raise ValueError(f"Unknown field {field}")``
+        # matching the Mongo helper's ``hassh`` branch
+        # (``mongo.py:3881``).
+        from ivre.db import DBView
+
+        db = DBView.from_url("postgresql://x@localhost/x")
+        with self.assertRaises(ValueError) as cm:
+            list(db.topvalues("definitely-not-a-field"))
+        self.assertIn("definitely-not-a-field", str(cm.exception))
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Last sub-PR for SQL ``topvalues`` parity on PG + DuckDB: implements every remaining branch the Mongo helper supports, rewrites every existing JSONB-array-unwind path to use explicit ``CROSS JOIN LATERAL ... ON true`` syntax (silencing the ``SAWarning: SELECT statement has a cartesian product`` SQLAlchemy emitted on the comma-joined SRF), and replaces the ``raise NotImplementedError()`` catch-all with a clearer ``raise ValueError(f"Unknown field {field}")`` (matching :meth:`MongoDB.topvalues`'s ``hassh`` branch).

New branches (``PostgresDBActive.topvalues``):

* ``addr`` -- top values of the host address column, decoded to a printable IP via :meth:`SQLDB.internal2ip` (handles both the ``str`` and ``dict`` round-trip shapes PostgreSQL / DuckDB use for ``INET``).
* ``cpe`` / ``cpe.<part>`` / ``cpe:<spec>`` / ``cpe.<part>:<spec>`` -- full Mongo-shape cpe family. ``<part>`` may be ``type`` / ``vendor`` / ``product`` / ``version`` (or ``1``..``4``); ``<spec>`` is a positional ``:``-separated list of regex filters narrowing the unwound CPEs.  ``searchcpe`` scopes the host filter and the inner ``EXISTS`` / unwound element gets the same predicate, exactly mirroring the Mongo helper's ``$match``-then-``$unwind`` shape.  The projection is a tuple of the kept cpe keys (``_topstructure`` returns ``result[1:]`` when there is more than one projection column) -- SQL groups by the columns directly so we skip the Mongo concat-then-split round-trip.
* ``smb.<key>`` -- pass-through to ``data.smb-os-discovery.<key>``.  ``searchsmb()`` scopes the filter.
* ``mongo.dbs.<key>`` -- pass-through to ``data.mongodb-databases.<key>``.
* ``sshkey.bits`` -- 2-tuple of ``(type, bits)`` unwound from ``data.ssh-hostkey``.  ``searchsshkey()`` scopes the filter.
* ``sshkey.<other>`` -- pass-through to ``data.ssh-hostkey.<other>``.
* ``ja4-client`` / ``ja4-client.<sub>`` / ``ja4-client:<value>`` -- top values of a key on the unwound ``ssl-ja4-client`` array; ``<sub>`` defaults to ``ja4`` (the canonical fingerprint), ``<value>`` narrows the inner predicate to a specific fingerprint string. ``searchja4client()`` scopes the host filter.

``CROSS JOIN LATERAL`` rewrite:

* Every ``func.jsonb_array_elements(...).alias("name")`` ``extraselectfrom`` is now wrapped in :func:`lateral` so the emitted SQL is ``LATERAL jsonb_array_elements(...) AS name`` (correlates the unwind with the outer scan / port row); ``select_from(...)`` is replaced with ``join(s_from, lateral_alias, true())`` so SQLAlchemy recognises the construct as a join rather than a separate FROM element and stops emitting ``SAWarning: SELECT statement has a cartesian product``. 18 paths covered: ``cpe``, ``httphdr`` / ``httphdr.<key>`` / ``httphdr:<name>``, ``httpapp`` / ``httpapp:<name>``, ``ja3-client``, ``ja3-server``, ``useragent`` / ``useragent:<value>``, ``ike.vendor_ids``, ``ike.transforms``, ``vulns.id``, ``vulns.<other>``, ``sshkey.bits``, ``sshkey.<other>``, ``ja4-client``.

Catch-all rewrite:

* ``raise NotImplementedError()`` -> ``raise ValueError(f"Unknown field {field}")`` for clearer error messages on truly unknown fields.

Tests:

* ``tests/tests.py`` no longer gates ``self.assertFalse(err)`` on ``DATABASE != "postgres"`` -- the cartesian-product warning that leaked to stderr on every ``httphdr*`` / ``httpapp*`` CLI call is silenced by the lateral rewrite, so the assertion runs unconditionally.
* New ``SQLDBTopValuesResidualTests`` in ``tests/tests_no_backend.py``: 14 pin tests cover the new branches (addr / cpe family with default-projection, part-truncation, numeric-part, spec-filter, lateral unwind / smb / mongo.dbs / sshkey.bits / sshkey.<other> / ja4-client default + value-filter) plus the ``LATERAL`` regression check across every existing unwind path and the ``ValueError`` catch-all.