### PR TITLE
feat(db/elastic): add Tier-1 search* helpers (source/hostname/domain)

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -1346,6 +1346,65 @@ return result;
         """
         return cls._search_field("categories", cat, neg=neg)
 
+    @classmethod
+    def searchsource(cls, src, neg=False):
+        """Filter records by ``source`` (a free-form tag the
+        scanner / ingestion pipeline assigns to each scan run).
+
+        Mirrors :meth:`MongoDB.searchsource`: a ``match`` query
+        against the ``source`` field, with the regex / list /
+        scalar dispatch :meth:`_search_field` already provides.
+        On the view backend ``source`` lands as an array of
+        strings (one per merged scan); Elasticsearch's
+        ``match`` against an array field returns a hit if any
+        element matches, so the same predicate works for both
+        Nmap and View shapes without a custom branch.
+        """
+        return cls._search_field("source", src, neg=neg)
+
+    @classmethod
+    def searchdomain(cls, name, neg=False):
+        """Filter records by hostname domain (matches the
+        domain at any level: ``foo.example.com`` matches
+        ``example.com`` and ``com``).
+
+        Mirrors :meth:`MongoDB.searchdomain`: a ``match`` query
+        against the indexed ``hostnames.domains`` field (which
+        ingestion populates with every suffix of every
+        hostname).
+        """
+        return cls._search_field("hostnames.domains", name, neg=neg)
+
+    @classmethod
+    def searchhostname(cls, name=None, neg=False):
+        """Filter records by hostname.
+
+        With ``name=None`` the filter only checks for the
+        existence (or absence, on ``neg=True``) of any hostname
+        on the record.  With a ``name`` argument the predicate
+        ANDs an indexed ``hostnames.domains`` lookup with the
+        non-indexed ``hostnames.name`` match (so the hot path
+        still goes through the index even though the exact
+        ``hostnames.name`` field is not indexed).
+
+        Mirrors :meth:`MongoDB.searchhostname`.
+        """
+        if name is None:
+            # ``hostnames.domains`` is the indexed field; gate
+            # on its existence rather than ``hostnames.name``
+            # so a query without a specific hostname still
+            # benefits from the index.
+            res = Q("exists", field="hostnames.domains")
+            if neg:
+                return ~res
+            return res
+        if neg:
+            return cls._search_field("hostnames.name", name, neg=True)
+        # Positive match: combine the indexed domain lookup
+        # (so the query goes through the index) with the
+        # ``hostnames.name`` match.
+        return cls.searchdomain(name) & cls._search_field("hostnames.name", name)
+
     @staticmethod
     def searchopenport(neg=False):
         "Filters records with at least one open port."

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1521,6 +1521,157 @@ class ElasticDBSearchTextTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# ElasticDBSearchTier1Tests -- pin the wire shape of the
+# Tier-1 ``search*`` parity helpers added on
+# ``ElasticDBActive``: ``searchsource`` / ``searchhostname`` /
+# ``searchdomain`` (the three that previously raised
+# ``NotImplementedError`` or were missing entirely on the
+# Elastic backend).  ``searchntlm`` / ``searchsmb`` /
+# ``searchsshkey`` already work via the
+# :meth:`ElasticDBActive.searchscript` inheritance chain;
+# ``test_inherited_helpers_compose_through_searchscript``
+# pins that.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_ELASTICSEARCH_DSL,
+    "elasticsearch_dsl is required (install with the ``elasticsearch`` extras)",
+)
+class ElasticDBSearchTier1Tests(unittest.TestCase):
+    """Behaviour-pin for ``ElasticDBActive.searchsource`` /
+    ``searchhostname`` / ``searchdomain``, plus a regression
+    pin that the script-delegating helpers (``searchntlm`` /
+    ``searchsmb`` / ``searchsshkey``) keep producing valid
+    Elasticsearch nested queries.
+    """
+
+    @staticmethod
+    def _ED():
+        # Local import: ``elasticsearch_dsl`` may not be
+        # installed in the no-backend lane.
+        from ivre.db.elastic import ElasticDBView
+
+        return ElasticDBView
+
+    # -- searchsource --------------------------------------------------
+
+    def test_searchsource_scalar(self):
+        body = self._ED().searchsource("scan-2024").to_dict()
+        self.assertEqual(body, {"match": {"source": "scan-2024"}})
+
+    def test_searchsource_neg(self):
+        body = self._ED().searchsource("scan-2024", neg=True).to_dict()
+        self.assertEqual(
+            body, {"bool": {"must_not": [{"match": {"source": "scan-2024"}}]}}
+        )
+
+    def test_searchsource_regex_uses_regexp_query(self):
+        import re
+
+        body = self._ED().searchsource(re.compile("^scan-")).to_dict()
+        # ``_get_pattern`` strips the leading anchor and adds
+        # ``.*`` to match Elasticsearch's
+        # anchored-by-default ``regexp`` semantics.
+        self.assertEqual(body, {"regexp": {"source": "scan-.*"}})
+
+    def test_searchsource_list_uses_terms_query(self):
+        body = self._ED().searchsource(["a", "b"]).to_dict()
+        self.assertEqual(body, {"terms": {"source": ["a", "b"]}})
+
+    # -- searchdomain --------------------------------------------------
+
+    def test_searchdomain_scalar(self):
+        body = self._ED().searchdomain("example.com").to_dict()
+        self.assertEqual(body, {"match": {"hostnames.domains": "example.com"}})
+
+    def test_searchdomain_neg(self):
+        body = self._ED().searchdomain("example.com", neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"match": {"hostnames.domains": "example.com"}}]}},
+        )
+
+    # -- searchhostname ------------------------------------------------
+
+    def test_searchhostname_no_args_uses_existence_check(self):
+        body = self._ED().searchhostname().to_dict()
+        # Existence is gated on the indexed
+        # ``hostnames.domains`` field rather than the
+        # non-indexed ``hostnames.name``.
+        self.assertEqual(body, {"exists": {"field": "hostnames.domains"}})
+
+    def test_searchhostname_no_args_neg(self):
+        body = self._ED().searchhostname(neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"exists": {"field": "hostnames.domains"}}]}},
+        )
+
+    def test_searchhostname_positive_combines_indexed_lookup_and_name(self):
+        body = self._ED().searchhostname("foo.example.com").to_dict()
+        # Positive match ANDs the indexed domain lookup (so
+        # the query goes through the ``hostnames.domains``
+        # index) with the ``hostnames.name`` match.
+        self.assertEqual(
+            body,
+            {
+                "bool": {
+                    "must": [
+                        {"match": {"hostnames.domains": "foo.example.com"}},
+                        {"match": {"hostnames.name": "foo.example.com"}},
+                    ]
+                }
+            },
+        )
+
+    def test_searchhostname_negation_skips_indexed_lookup(self):
+        # The Mongo helper's ``neg=True`` path only excludes
+        # records matching the supplied name on
+        # ``hostnames.name`` -- it does *not* ``$nin`` the
+        # indexed ``hostnames.domains`` lookup (the latter
+        # would silently exclude legitimate non-matches).
+        # Pin the same shape on the Elastic side.
+        body = self._ED().searchhostname("foo.example.com", neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"match": {"hostnames.name": "foo.example.com"}}]}},
+        )
+
+    # -- inherited (delegate to searchscript) --------------------------
+
+    def test_inherited_helpers_compose_through_searchscript(self):
+        # ``searchntlm`` / ``searchsmb`` / ``searchsshkey``
+        # already inherit from ``DBActive`` and route through
+        # :meth:`ElasticDBActive.searchscript`.  Pin that they
+        # produce the canonical
+        # ``Nested(ports) -> Nested(ports.scripts) -> Bool``
+        # shape so a future refactor of the inherited helpers
+        # cannot silently break Tier-1 parity.
+        # ``searchsshkey`` is the only one of the three that
+        # is an *instance* method on ``DBActive`` (it has no
+        # ``@classmethod`` decorator), so the dispatch needs
+        # a real instance rather than the class itself.
+        db = self._ED().from_url("elastic://x:9200")
+        for method, kwargs, script_id in [
+            ("searchntlm", {"protocol": "smb"}, "ntlm-info"),
+            ("searchsmb", {"os": "Windows 10"}, "smb-os-discovery"),
+            ("searchsshkey", {"keytype": "rsa"}, "ssh-hostkey"),
+        ]:
+            with self.subTest(method=method):
+                body = getattr(db, method)(**kwargs).to_dict()
+                self.assertIn("nested", body)
+                self.assertEqual(body["nested"]["path"], "ports")
+                inner = body["nested"]["query"]
+                self.assertIn("nested", inner)
+                self.assertEqual(inner["nested"]["path"], "ports.scripts")
+                # Every script-delegating helper anchors the
+                # match on ``ports.scripts.id``.
+                must = inner["nested"]["query"]["bool"]["must"]
+                self.assertIn({"match": {"ports.scripts.id": script_id}}, must)
+
+
+# ---------------------------------------------------------------------
 # PostgresExplainTests -- defence-in-depth check that values
 # inlined into the ``EXPLAIN`` statement go through SQLAlchemy's
 # per-type literal binding, not Python ``repr``.


### PR DESCRIPTION
Close the M4.5 Tier-1 ``search*`` parity gap on Elasticsearch view: implement the three helpers that were missing on ``ElasticDBActive`` and document why the other three (``searchntlm`` / ``searchsmb`` / ``searchsshkey``) need no explicit override.

New helpers (``ElasticDBActive``):

* ``searchsource(src, neg=False)`` -- filter records by ``source``.  Mirrors :meth:`MongoDB.searchsource` (which used to raise ``NotImplementedError`` here -- the base ``DBActive.searchsource`` stub did).  ``_search_field`` already does the regex / list / scalar dispatch; the only view-specific quirk is that ``source`` lands as an array of strings (one per merged scan), and Elasticsearch's ``match`` against an array hits if any element matches, so the same predicate works for both Nmap and View shapes without a custom branch.
* ``searchdomain(name, neg=False)`` -- filter by hostname domain via the indexed ``hostnames.domains`` field (ingestion populates it with every suffix of every hostname, so a single ``match`` covers ``com`` / ``example.com`` / ``foo.example.com``).
* ``searchhostname(name=None, neg=False)`` -- ``name=None`` checks for the existence of any hostname via the indexed ``hostnames.domains`` field; with a name the positive branch ANDs ``searchdomain(name)`` (indexed) with a ``hostnames.name`` ``match`` (non-indexed), the negative branch only excludes ``hostnames.name`` so the indexed domain filter does not silently drop legitimate non-matches.  Mirrors :meth:`MongoDB.searchhostname`.

Inherited (no-op on Elastic):

* ``searchntlm`` / ``searchsmb`` / ``searchsshkey`` already work via :class:`DBActive`'s ``searchscript``-delegating defaults composed with :meth:`ElasticDBActive.searchscript` (the Tier-1 audit verified the inherited path produces the canonical ``Nested(ports) -> Nested(ports.scripts) -> Bool`` shape with the right ``ports.scripts.id`` anchor). No override needed; pinned via the regression test below.

Tests (``ElasticDBSearchTier1Tests`` in
``tests/tests_no_backend.py``):

* 10 pin tests covering each new helper -- scalar / regex / list / negation shapes for ``searchsource``; the indexed existence check and the AND of indexed-domain + ``hostnames.name`` for ``searchhostname`` (positive), the ``hostnames.name``-only exclusion for the negation; and the ``regexp_matches`` / ``terms`` / ``match`` / ``bool.must_not`` dispatch for ``searchdomain``.
* 1 regression pin (``test_inherited_helpers_compose_through_searchscript``) that ``searchntlm`` / ``searchsmb`` / ``searchsshkey`` keep producing the canonical ``Nested(ports) -> Nested(ports.scripts)`` shape with the right ``ports.scripts.id`` anchor; protects future refactors of the inherited helpers from silently breaking Tier-1 parity.