### PR TITLE
feat(db/elastic): add Tier-2 search* helpers

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -1405,6 +1405,310 @@ return result;
         # ``hostnames.name`` match.
         return cls.searchdomain(name) & cls._search_field("hostnames.name", name)
 
+    # -- traces.hops -- mirroring :meth:`MongoDB.searchhop` /
+    # ``searchhopname`` / ``searchhopdomain``.  ``traces.hops``
+    # is *not* declared in :attr:`nested_fields`, so each
+    # ``match`` flattens against the array directly: a query
+    # combining ``ipaddr`` and ``ttl`` matches host records
+    # where any single hop satisfies both predicates *or*
+    # different hops satisfy them separately.  The latter is a
+    # well-known limitation of non-nested array-of-objects on
+    # Elasticsearch and is consistent with the rest of the
+    # schema (e.g. ``hostnames.*``).
+    @classmethod
+    def searchhop(cls, hop, ttl=None, neg=False):
+        """Filter records that have a traceroute hop with the
+        supplied address (and optional TTL).
+
+        Mirrors :meth:`MongoDB.searchhop`; ``traces.hops.ipaddr``
+        is mapped as Elasticsearch's native ``ip`` type, so the
+        match takes a printable IP string directly without the
+        ``ip2internal`` split the Mongo helper applies.
+        """
+        res = Q("match", **{"traces.hops.ipaddr": hop})
+        if ttl is not None:
+            res &= Q("match", **{"traces.hops.ttl": ttl})
+        if neg:
+            return ~res
+        return res
+
+    @classmethod
+    def searchhopdomain(cls, hop, neg=False):
+        """Filter records by traceroute-hop domain.
+
+        Mirrors :meth:`MongoDB.searchhopdomain`: a ``match``
+        against the indexed ``traces.hops.domains`` field.
+        """
+        return cls._search_field("traces.hops.domains", hop, neg=neg)
+
+    @classmethod
+    def searchhopname(cls, hop, neg=False):
+        """Filter records by traceroute-hop hostname.
+
+        Mirrors :meth:`MongoDB.searchhopname`: positive matches
+        AND the indexed ``traces.hops.domains`` lookup with the
+        non-indexed ``traces.hops.host`` match (so the hot path
+        still goes through the index even though
+        ``traces.hops.host`` is not indexed); negative matches
+        only exclude ``traces.hops.host`` so the indexed filter
+        does not silently drop legitimate non-matches.
+        """
+        if neg:
+            return cls._search_field("traces.hops.host", hop, neg=True)
+        return cls.searchhopdomain(hop) & cls._search_field("traces.hops.host", hop)
+
+    # -- per-port "fingerprint" filters --------------------
+    @staticmethod
+    def searchldapanon():
+        """Filter records exposing an LDAP service that allows
+        anonymous binds.
+
+        Mirrors :meth:`MongoDB.searchldapanon`: a single
+        ``match`` against ``ports.service_extrainfo`` -- the
+        nmap LDAP probe records ``"Anonymous bind OK"`` in
+        the service extra-info string when the bind succeeds
+        without credentials.
+        """
+        return Q("match", ports__service_extrainfo="Anonymous bind OK")
+
+    @staticmethod
+    def searchvsftpdbackdoor():
+        """Filter records exposing the vsftpd 2.3.4 backdoor
+        (CVE-2011-2523).
+
+        Mirrors :meth:`MongoDB.searchvsftpdbackdoor`: a nested
+        match on the canonical product / version / state
+        fingerprint Metasploit's ``ftp/vsftpd_234_backdoor``
+        module checks.
+        """
+        return Q(
+            "nested",
+            path="ports",
+            query=(
+                Q("match", ports__protocol="tcp")
+                & Q("match", ports__state_state="open")
+                & Q("match", ports__service_product="vsftpd")
+                & Q("match", ports__service_version="2.3.4")
+            ),
+        )
+
+    @staticmethod
+    def searchwebmin():
+        """Filter records exposing a Webmin admin interface.
+
+        Mirrors :meth:`MongoDB.searchwebmin`: nmap's HTTP
+        service probe identifies Webmin via
+        ``service_product == "MiniServ"`` while leaving
+        ``service_extrainfo`` set to something *other* than
+        ``"Webmin httpd"`` (which is the regular Apache /
+        nginx hosting the admin UI).
+        """
+        return Q(
+            "nested",
+            path="ports",
+            query=(
+                Q("match", ports__service_name="http")
+                & Q("match", ports__service_product="MiniServ")
+                & ~Q("match", ports__service_extrainfo="Webmin httpd")
+            ),
+        )
+
+    @classmethod
+    def searchhttptitle(cls, title):
+        """Filter records by HTTP / HTML page title.
+
+        Mirrors :meth:`MongoDB.searchhttptitle`: delegates to
+        :meth:`searchscript` with ``name=["http-title",
+        "html-title"]`` so both the modern http-title and the
+        legacy html-title NSE script outputs are matched.
+        """
+        return cls.searchscript(name=["http-title", "html-title"], output=title)
+
+    # -- screenshot / screenwords -----------------------------
+    @classmethod
+    def searchscreenshot(
+        cls,
+        port=None,
+        protocol="tcp",
+        service=None,
+        words=None,
+        neg=False,
+    ):
+        """Filter records that have (or, with ``neg=True``,
+        lack) a screenshot on at least one port.
+
+        Mirrors :meth:`MongoDB.searchscreenshot`.  ``port`` /
+        ``protocol`` / ``service`` constrain the matching
+        port; ``words`` filters on the OCR word list.  The
+        Mongo-shape semantics are preserved: ``neg=True`` with
+        no port / service constraint means *no* port has a
+        screenshot (the existence check inverts at the host
+        level), whereas ``neg=True`` with a port / service
+        constraint inverts the inner predicate so other ports
+        on the same host can still keep their screenshots.
+
+        The Elastic implementation routes everything through a
+        ``Nested(ports, ...)`` query so the per-port filter is
+        evaluated against a single port subdoc; ``ports`` is
+        in :attr:`nested_fields`.
+        """
+        # ``words=None``, no port / service: existence check
+        # at the host level (inverts at the EXISTS level on
+        # ``neg=True``).
+        if words is None and port is None and service is None:
+            res = Q(
+                "nested",
+                path="ports",
+                query=Q("exists", field="ports.screenshot"),
+            )
+            if neg:
+                return ~res
+            return res
+        # ``words`` is set: a screenshot must always exist;
+        # the negation flips at the per-port predicate
+        # (``screenwords`` excludes the words rather than the
+        # whole match).
+        port_query = Q("exists", field="ports.screenshot")
+        if port is not None:
+            port_query &= Q("match", ports__port=port)
+            port_query &= Q("match", ports__protocol=protocol)
+        if service is not None:
+            port_query &= Q("match", ports__service_name=service)
+        if words is not None:
+            words_q = cls._screenshot_words_predicate(words, neg=neg)
+            port_query &= words_q
+        elif neg:
+            # ``words=None`` with a port / service constraint:
+            # invert the per-port screenshot existence.
+            port_query = ~Q("exists", field="ports.screenshot")
+            if port is not None:
+                port_query &= Q("match", ports__port=port)
+                port_query &= Q("match", ports__protocol=protocol)
+            if service is not None:
+                port_query &= Q("match", ports__service_name=service)
+        return Q("nested", path="ports", query=port_query)
+
+    @classmethod
+    def _screenshot_words_predicate(cls, words, neg=False):
+        """Build the ``ports.screenwords`` predicate for
+        :meth:`searchscreenshot`.  Matches the four input
+        shapes Mongo's helper supports: ``bool`` (existence),
+        ``list`` (every word must be present), regex (any
+        element matches the pattern), or scalar string (any
+        element equals the value).  ``neg=True`` flips the
+        polarity at the predicate level (Mongo's ``$ne`` /
+        ``$not``); ``words=False`` short-circuits to the
+        no-word existence check regardless of ``neg``.
+        """
+        if isinstance(words, bool):
+            res = Q("exists", field="ports.screenwords")
+            if not words:
+                return ~res
+            return res
+        if isinstance(words, list):
+            lowered = [w.lower() for w in words]
+            res = cls.flt_and(*(Q("match", ports__screenwords=w) for w in lowered))
+            if neg:
+                return ~res
+            return res
+        if isinstance(words, utils.REGEXP_T):
+            pattern = re.compile(words.pattern.lower(), flags=words.flags)
+            res = Q("regexp", **{"ports.screenwords": cls._get_pattern(pattern)})
+            if neg:
+                return ~res
+            return res
+        # scalar string -- lower-cased to match the
+        # pre-stored shape.
+        res = Q("match", ports__screenwords=words.lower())
+        if neg:
+            return ~res
+        return res
+
+    # -- searchsmbshares -- direct ``ports.scripts.smb-enum-shares``
+    # query; ``ElasticDBActive.searchscript`` cannot translate
+    # the nested ``$elemMatch`` / ``$or`` / ``$nin`` shape the
+    # Mongo helper builds, so we go via a hand-rolled
+    # ``Nested(ports, Nested(ports.scripts, Bool(...)))`` query.
+    @classmethod
+    def searchsmbshares(cls, access="", hidden=None):
+        """Filter SMB shares with the given ``access`` (default:
+        either read or write, accepted values 'r', 'w', 'rw').
+
+        ``hidden=True`` selects hidden shares only,
+        ``hidden=False`` non-hidden only, ``None`` (the default)
+        accepts either.
+
+        Mirrors :meth:`MongoDB.searchsmbshares`.  The Mongo
+        helper builds a ``$elemMatch`` / ``$or`` / ``$nin``
+        block under ``searchscript(values=...)``;
+        :meth:`ElasticDBActive.searchscript` does not translate
+        that shape, so the predicate is built directly here.
+        """
+        access_pattern = {
+            "": re.compile("^(READ|WRITE)"),
+            "r": re.compile("^READ(/|$)"),
+            "w": re.compile("(^|/)WRITE$"),
+            "rw": "READ/WRITE",
+            "wr": "READ/WRITE",
+        }[access.lower()]
+        excluded_share_types = (
+            "STYPE_IPC_HIDDEN",
+            "Not a file share",
+            "STYPE_IPC",
+            "STYPE_PRINTQ",
+        )
+
+        def _access_match(field):
+            if isinstance(access_pattern, utils.REGEXP_T):
+                return Q(
+                    "regexp",
+                    **{field: cls._get_pattern(access_pattern)},
+                )
+            return Q("match", **{field: access_pattern})
+
+        access_q = _access_match(
+            "ports.scripts.smb-enum-shares.shares.Anonymous access"
+        ) | _access_match("ports.scripts.smb-enum-shares.shares.Current user access")
+        if hidden is None:
+            type_q = ~Q(
+                "terms",
+                **{
+                    "ports.scripts.smb-enum-shares.shares.Type": list(
+                        excluded_share_types
+                    )
+                },
+            )
+        elif hidden:
+            type_q = Q(
+                "match",
+                **{
+                    "ports.scripts.smb-enum-shares.shares.Type": (
+                        "STYPE_DISKTREE_HIDDEN"
+                    )
+                },
+            )
+        else:
+            type_q = Q(
+                "match",
+                **{"ports.scripts.smb-enum-shares.shares.Type": "STYPE_DISKTREE"},
+            )
+        share_q = ~Q(
+            "match",
+            **{"ports.scripts.smb-enum-shares.shares.Share": "IPC$"},
+        )
+        return Q(
+            "nested",
+            path="ports",
+            query=Q(
+                "nested",
+                path="ports.scripts",
+                query=Q("match", **{"ports.scripts.id": "smb-enum-shares"})
+                & access_q
+                & type_q
+                & share_q,
+            ),
+        )
+
     @staticmethod
     def searchopenport(neg=False):
         "Filters records with at least one open port."

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1672,6 +1672,277 @@ class ElasticDBSearchTier1Tests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# ElasticDBSearchTier2Tests -- pin the wire shape of the
+# Tier-2 ``search*`` parity helpers added on
+# ``ElasticDBActive``: ``searchsmbshares`` /
+# ``searchscreenshot`` / ``searchhttptitle`` /
+# ``searchldapanon`` / ``searchvsftpdbackdoor`` /
+# ``searchwebmin`` / ``searchhop`` / ``searchhopname`` /
+# ``searchhopdomain``.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_ELASTICSEARCH_DSL,
+    "elasticsearch_dsl is required (install with the ``elasticsearch`` extras)",
+)
+class ElasticDBSearchTier2Tests(unittest.TestCase):
+    """Behaviour-pin for Tier-2 ``ElasticDBActive.search*``
+    parity helpers.  All nine helpers were missing on Elastic
+    before this PR and route through bespoke
+    ``Q("nested", path="ports", ...)`` /
+    ``Q("nested", path="ports.scripts", ...)`` builders rather
+    than :meth:`ElasticDBActive.searchscript` (which cannot
+    translate the nested ``$elemMatch`` / ``$or`` / ``$nin``
+    shape Mongo's ``searchsmbshares`` produces).
+    """
+
+    @staticmethod
+    def _ED():
+        from ivre.db.elastic import ElasticDBView
+
+        return ElasticDBView
+
+    # -- traces.hops --------------------------------------------------
+
+    def test_searchhop_scalar(self):
+        body = self._ED().searchhop("1.2.3.4").to_dict()
+        self.assertEqual(body, {"match": {"traces.hops.ipaddr": "1.2.3.4"}})
+
+    def test_searchhop_with_ttl(self):
+        body = self._ED().searchhop("1.2.3.4", ttl=5).to_dict()
+        self.assertEqual(
+            body,
+            {
+                "bool": {
+                    "must": [
+                        {"match": {"traces.hops.ipaddr": "1.2.3.4"}},
+                        {"match": {"traces.hops.ttl": 5}},
+                    ]
+                }
+            },
+        )
+
+    def test_searchhop_neg(self):
+        body = self._ED().searchhop("1.2.3.4", neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"match": {"traces.hops.ipaddr": "1.2.3.4"}}]}},
+        )
+
+    def test_searchhopdomain_scalar(self):
+        body = self._ED().searchhopdomain("example.com").to_dict()
+        self.assertEqual(body, {"match": {"traces.hops.domains": "example.com"}})
+
+    def test_searchhopname_combines_domain_and_host(self):
+        body = self._ED().searchhopname("foo.example.com").to_dict()
+        # Same indexed-domain + non-indexed-name shape
+        # ``searchhostname`` ships in M4.5.1.
+        self.assertEqual(
+            body,
+            {
+                "bool": {
+                    "must": [
+                        {"match": {"traces.hops.domains": "foo.example.com"}},
+                        {"match": {"traces.hops.host": "foo.example.com"}},
+                    ]
+                }
+            },
+        )
+
+    def test_searchhopname_neg_skips_indexed_lookup(self):
+        body = self._ED().searchhopname("foo", neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"match": {"traces.hops.host": "foo"}}]}},
+        )
+
+    # -- per-port fingerprints ---------------------------------------
+
+    def test_searchldapanon_matches_anonymous_bind_ok(self):
+        body = self._ED().searchldapanon().to_dict()
+        self.assertEqual(
+            body,
+            {"match": {"ports.service_extrainfo": "Anonymous bind OK"}},
+        )
+
+    def test_searchvsftpdbackdoor_pins_full_fingerprint(self):
+        body = self._ED().searchvsftpdbackdoor().to_dict()
+        self.assertIn("nested", body)
+        self.assertEqual(body["nested"]["path"], "ports")
+        must = body["nested"]["query"]["bool"]["must"]
+        self.assertIn({"match": {"ports.protocol": "tcp"}}, must)
+        self.assertIn({"match": {"ports.state_state": "open"}}, must)
+        self.assertIn({"match": {"ports.service_product": "vsftpd"}}, must)
+        self.assertIn({"match": {"ports.service_version": "2.3.4"}}, must)
+
+    def test_searchwebmin_excludes_apache_hosting_webmin(self):
+        body = self._ED().searchwebmin().to_dict()
+        self.assertIn("nested", body)
+        bool_q = body["nested"]["query"]["bool"]
+        self.assertIn({"match": {"ports.service_name": "http"}}, bool_q["must"])
+        self.assertIn({"match": {"ports.service_product": "MiniServ"}}, bool_q["must"])
+        # ``service_extrainfo`` must *not* be ``"Webmin httpd"``
+        # (that's the regular Apache / nginx hosting the
+        # admin UI rather than the standalone Webmin).
+        self.assertIn(
+            {"match": {"ports.service_extrainfo": "Webmin httpd"}},
+            bool_q["must_not"],
+        )
+
+    def test_searchhttptitle_delegates_to_searchscript(self):
+        body = self._ED().searchhttptitle("Welcome").to_dict()
+        self.assertIn("nested", body)
+        self.assertEqual(body["nested"]["path"], "ports")
+        inner = body["nested"]["query"]["nested"]
+        self.assertEqual(inner["path"], "ports.scripts")
+        must = inner["query"]["bool"]["must"]
+        # ``searchscript`` with a list of names emits
+        # ``terms``; pin that.
+        self.assertIn(
+            {"terms": {"ports.scripts.id": ["http-title", "html-title"]}},
+            must,
+        )
+        self.assertIn({"match": {"ports.scripts.output": "Welcome"}}, must)
+
+    # -- screenshot / screenwords ------------------------------------
+
+    def test_searchscreenshot_no_args_existence_check(self):
+        body = self._ED().searchscreenshot().to_dict()
+        self.assertEqual(
+            body,
+            {
+                "nested": {
+                    "path": "ports",
+                    "query": {"exists": {"field": "ports.screenshot"}},
+                }
+            },
+        )
+
+    def test_searchscreenshot_neg_inverts_at_host_level(self):
+        # Mirrors Mongo's ``$exists: false`` semantics: *no*
+        # port has a screenshot, not "there's a port without
+        # a screenshot".  Pin the ``must_not`` wrap at the
+        # outermost ``Nested`` level rather than the inner
+        # predicate.
+        body = self._ED().searchscreenshot(neg=True).to_dict()
+        self.assertIn("must_not", body["bool"])
+        self.assertEqual(body["bool"]["must_not"][0]["nested"]["path"], "ports")
+
+    def test_searchscreenshot_with_port_constrains_inner_predicate(self):
+        body = self._ED().searchscreenshot(port=80).to_dict()
+        must = body["nested"]["query"]["bool"]["must"]
+        self.assertIn({"exists": {"field": "ports.screenshot"}}, must)
+        self.assertIn({"match": {"ports.port": 80}}, must)
+        self.assertIn({"match": {"ports.protocol": "tcp"}}, must)
+
+    def test_searchscreenshot_words_string_lower_cases(self):
+        body = self._ED().searchscreenshot(words="WELCOME").to_dict()
+        must = body["nested"]["query"]["bool"]["must"]
+        # Word value is lower-cased to match the pre-stored
+        # shape.
+        self.assertIn({"match": {"ports.screenwords": "welcome"}}, must)
+
+    def test_searchscreenshot_words_list_requires_all(self):
+        body = self._ED().searchscreenshot(words=["foo", "bar"]).to_dict()
+        must = body["nested"]["query"]["bool"]["must"]
+        # Each element becomes its own ``match`` -- the list
+        # form is "all of these words must be present".
+        self.assertIn({"match": {"ports.screenwords": "foo"}}, must)
+        self.assertIn({"match": {"ports.screenwords": "bar"}}, must)
+
+    def test_searchscreenshot_words_regex(self):
+        import re
+
+        body = self._ED().searchscreenshot(words=re.compile("LOGIN")).to_dict()
+        must = body["nested"]["query"]["bool"]["must"]
+        # Pattern is lower-cased before being passed to
+        # ``_get_pattern``.
+        self.assertIn({"regexp": {"ports.screenwords": ".*login.*"}}, must)
+
+    def test_searchscreenshot_words_neg_inverts_at_predicate(self):
+        # ``words=...`` with ``neg=True`` keeps the
+        # screenshot existence check positive (Mongo semantic:
+        # "has a screenshot **without** these words").
+        body = self._ED().searchscreenshot(words="foo", neg=True).to_dict()
+        bool_q = body["nested"]["query"]["bool"]
+        self.assertIn({"exists": {"field": "ports.screenshot"}}, bool_q["must"])
+        self.assertIn({"match": {"ports.screenwords": "foo"}}, bool_q["must_not"])
+
+    # -- searchsmbshares ---------------------------------------------
+
+    def test_searchsmbshares_default_uses_access_regex(self):
+        body = self._ED().searchsmbshares().to_dict()
+        self.assertIn("nested", body)
+        self.assertEqual(body["nested"]["path"], "ports")
+        inner = body["nested"]["query"]["nested"]
+        self.assertEqual(inner["path"], "ports.scripts")
+        bool_q = inner["query"]["bool"]
+        # ``access=""`` defaults to a regex matching either
+        # READ or WRITE at the start of the access field.
+        self.assertIn(
+            {
+                "regexp": {
+                    "ports.scripts.smb-enum-shares.shares.Anonymous access": "(READ|WRITE).*"
+                }
+            },
+            bool_q["should"],
+        )
+        # IPC$ is excluded by name.
+        self.assertIn(
+            {"match": {"ports.scripts.smb-enum-shares.shares.Share": "IPC$"}},
+            bool_q["must_not"],
+        )
+
+    def test_searchsmbshares_rw_uses_literal_match(self):
+        body = self._ED().searchsmbshares(access="rw").to_dict()
+        bool_q = body["nested"]["query"]["nested"]["query"]["bool"]
+        # ``access="rw"`` is a literal "READ/WRITE" string
+        # (not a regex).
+        self.assertIn(
+            {
+                "match": {
+                    "ports.scripts.smb-enum-shares.shares.Anonymous access": "READ/WRITE"
+                }
+            },
+            bool_q["should"],
+        )
+
+    def test_searchsmbshares_hidden_true_pins_hidden_share_type(self):
+        body = self._ED().searchsmbshares(hidden=True).to_dict()
+        bool_q = body["nested"]["query"]["nested"]["query"]["bool"]
+        self.assertIn(
+            {
+                "match": {
+                    "ports.scripts.smb-enum-shares.shares.Type": "STYPE_DISKTREE_HIDDEN"
+                }
+            },
+            bool_q["must"],
+        )
+
+    def test_searchsmbshares_hidden_none_excludes_sentinel_types(self):
+        body = self._ED().searchsmbshares().to_dict()
+        bool_q = body["nested"]["query"]["nested"]["query"]["bool"]
+        # ``hidden=None`` is the default: ``Type`` must not
+        # be one of the four sentinel values.
+        excluded = {
+            "STYPE_IPC_HIDDEN",
+            "Not a file share",
+            "STYPE_IPC",
+            "STYPE_PRINTQ",
+        }
+        # The ``must_not`` carries a ``terms`` query whose
+        # value list matches the sentinel set.
+        terms_clauses = [
+            clause["terms"]["ports.scripts.smb-enum-shares.shares.Type"]
+            for clause in bool_q.get("must_not", [])
+            if "terms" in clause
+        ]
+        self.assertTrue(terms_clauses)
+        self.assertEqual(set(terms_clauses[0]), excluded)
+
+
+# ---------------------------------------------------------------------
 # PostgresExplainTests -- defence-in-depth check that values
 # inlined into the ``EXPLAIN`` statement go through SQLAlchemy's
 # per-type literal binding, not Python ``repr``.


### PR DESCRIPTION
Close the M4.5 Tier-2 ``search*`` parity gap on Elasticsearch view: add the nine helpers Mongo ships under
:meth:`MongoDB.search*` but ``ElasticDBActive`` had so far left unimplemented (every one of them was missing -- not ``NotImplementedError``-stub, just absent).

New helpers (``ElasticDBActive``):

* ``searchhop(hop, ttl=None, neg=False)`` -- match ``traces.hops.ipaddr`` (and optional ``traces.hops.ttl``).  ``traces.hops.ipaddr`` is mapped as Elasticsearch's native ``ip`` type so the helper takes a printable IP string directly without the ``ip2internal`` split the Mongo helper applies.
* ``searchhopdomain(hop, neg=False)`` -- ``match`` against the indexed ``traces.hops.domains`` field.
* ``searchhopname(hop, neg=False)`` -- mirrors the Tier-1 :meth:`searchhostname` shape: positive matches AND the indexed-domain lookup with the non-indexed ``traces.hops.host`` match; negation only excludes ``traces.hops.host`` so the indexed filter does not silently drop legitimate non-matches.
* ``searchldapanon()`` -- ``match`` against ``ports.service_extrainfo`` for nmap's ``"Anonymous bind OK"`` string.
* ``searchvsftpdbackdoor()`` -- nested ``ports`` match on the canonical product / version / state fingerprint Metasploit's ``ftp/vsftpd_234_backdoor`` module checks (CVE-2011-2523).
* ``searchwebmin()`` -- nested ``ports`` match on ``service_name == "http"`` AND ``service_product == "MiniServ"`` AND ``service_extrainfo != "Webmin httpd"`` (the latter is the regular Apache / nginx hosting the admin UI rather than the standalone Webmin service).
* ``searchhttptitle(title)`` -- delegates to :meth:`searchscript` with ``name=["http-title", "html-title"]`` so both the modern http-title and the legacy html-title NSE script outputs are matched.
* ``searchscreenshot(port, protocol, service, words, neg)`` -- mirrors the Mongo-shape semantics in full: ``words=None`` with no port / service constraint flips at the host level on ``neg=True`` (i.e. *no* port has a screenshot) while a port / service constraint inverts the inner predicate so other ports on the same host can keep their screenshots; ``words`` accepts ``bool`` (existence), ``str`` (lower-cased exact match), regex (lower-cased pattern via ``_get_pattern``), or ``list`` (every word must be present). ``words=...`` with ``neg=True`` means "has a screenshot *without* these words" -- the screenshot existence stays positive.
* ``searchsmbshares(access, hidden)`` -- direct ``Nested(ports, Nested(ports.scripts, Bool(...)))`` query rather than going through :meth:`searchscript`; the Mongo helper builds a nested ``$elemMatch`` / ``$or`` / ``$nin`` block under ``searchscript(values=...)`` and Elastic's ``searchscript`` does not translate that shape. The same access-regex / hidden-share-type / IPC$-exclusion semantics as the SQL implementation (M4.3.2).

Tests (``ElasticDBSearchTier2Tests`` in ``tests/tests_no_backend.py``):

21 pin tests covering each helper -- per-helper field / operator / nesting shape, the Mongo-shape ``words`` dispatch on ``searchscreenshot`` (bool / str / list / regex / neg), the access-regex defaults / literal-match special cases / hidden-share-type / sentinel-exclusion shapes on
``searchsmbshares``, the indexed-domain + non-indexed-name positive / negation-skips-indexed shapes on
``searchhopname``, and the script-delegation shape on ``searchhttptitle``.