### PR TITLE
feat(db/elastic): add Tier-3 search* helpers

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -1746,6 +1746,244 @@ return result;
         return res
 
     @classmethod
+    def searchports(cls, ports, protocol="tcp", state="open", neg=False, any_=False):
+        """Filter records that have all (or any, with
+        ``any_=True``) of the listed ports in the given state.
+
+        Mirrors :meth:`MongoDB.searchports`: defaults to
+        AND-ing ``searchport(p)`` for every element (so every
+        port must be open); ``any_=True`` returns the OR
+        instead; ``neg=True`` AND-NOTs each match.
+
+        ``any_`` and ``neg`` are mutually exclusive on Mongo;
+        the same restriction applies here.
+        """
+        if any_ and neg:
+            raise ValueError("searchports: cannot set both neg and any_")
+        if any_:
+            return cls.flt_or(
+                *(cls.searchport(p, protocol=protocol, state=state) for p in ports)
+            )
+        return cls.flt_and(
+            *(cls.searchport(p, protocol=protocol, state=state, neg=neg) for p in ports)
+        )
+
+    @classmethod
+    def searchportsother(cls, ports, protocol="tcp", state="open"):
+        """Filter records carrying at least one port (with the
+        given ``state`` / ``protocol``) **other** than those
+        listed.
+
+        Mirrors :meth:`MongoDB.searchportsother`: a nested
+        ``ports`` query with the same protocol / state
+        constraints and ``ports.port NOT IN (...)``.  The
+        Mongo helper uses ``$elemMatch + $nin`` on the openports
+        map for ``state=open``; the Elastic implementation
+        uses the same nested-ports path for both ``state=open``
+        and other states so the predicate is uniform.
+        """
+        return Q(
+            "nested",
+            path="ports",
+            query=(
+                ~Q("terms", ports__port=ports)
+                & Q("match", ports__protocol=protocol)
+                & Q("match", ports__state_state=state)
+            ),
+        )
+
+    @classmethod
+    def searchcountopenports(cls, minn=None, maxn=None, neg=False):
+        """Filter records whose ``openports.count`` falls in
+        the ``[minn, maxn]`` range.
+
+        Mirrors :meth:`MongoDB.searchcountopenports`: equal
+        bounds collapse to a ``match`` (or ``must_not`` on
+        ``neg=True``); a single bound emits ``range`` with
+        ``gte`` / ``lte``; both bounds combine into a single
+        ``range`` query (or, on ``neg=True``, an OR of the
+        two individual range exclusions, mirroring Mongo's
+        ``$or`` of ``$lt`` / ``$gt``).
+        """
+        if minn is None and maxn is None:
+            raise AssertionError(
+                "searchcountopenports: at least one of minn or maxn must be set"
+            )
+        if minn == maxn:
+            res = Q("match", **{"openports.count": minn})
+            if neg:
+                return ~res
+            return res
+        if neg:
+            # Mirror Mongo's ``$or`` of ``$lt`` / ``$gt``: the
+            # row passes when ``count`` falls outside *either*
+            # bound, so a host with very few open ports still
+            # matches even if it has more than ``maxn``.
+            clauses = []
+            if minn is not None:
+                clauses.append(Q("range", **{"openports.count": {"lt": minn}}))
+            if maxn is not None:
+                clauses.append(Q("range", **{"openports.count": {"gt": maxn}}))
+            if len(clauses) == 1:
+                return clauses[0]
+            return cls.flt_or(*clauses)
+        bounds: dict[str, int] = {}
+        if minn is not None:
+            bounds["gte"] = minn
+        if maxn is not None:
+            bounds["lte"] = maxn
+        return Q("range", **{"openports.count": bounds})
+
+    @classmethod
+    def searchfile(cls, fname=None, scripts=None):
+        """Filter records exposing a shared file by name (NSE
+        ``ls`` module).
+
+        Mirrors :meth:`MongoDB.searchfile`.  ``scripts``
+        narrows the script-id space (string, list, or ``None``
+        = any of the ``ls``-emitting scripts).
+        """
+        ls_path = "ports.scripts.ls.volumes.files.filename"
+        if fname is None:
+            file_q = Q("exists", field=ls_path)
+        elif isinstance(fname, list):
+            file_q = Q("terms", **{ls_path: fname})
+        elif isinstance(fname, utils.REGEXP_T):
+            file_q = Q("regexp", **{ls_path: cls._get_pattern(fname)})
+        else:
+            file_q = Q("match", **{ls_path: fname})
+        if scripts is None:
+            return Q(
+                "nested",
+                path="ports",
+                query=Q("nested", path="ports.scripts", query=file_q),
+            )
+        if isinstance(scripts, str):
+            scripts = [scripts]
+        if len(scripts) == 1:
+            id_q = Q("match", **{"ports.scripts.id": scripts[0]})
+        else:
+            id_q = Q("terms", **{"ports.scripts.id": scripts})
+        return Q(
+            "nested",
+            path="ports",
+            query=Q(
+                "nested",
+                path="ports.scripts",
+                query=id_q & file_q,
+            ),
+        )
+
+    @classmethod
+    def searchvuln(cls, vulnid=None, state=None):
+        """Filter records exposing a vulnerability matching
+        ``vulnid`` and / or ``state``.
+
+        Mirrors :meth:`MongoDB.searchvuln`: with neither
+        argument the predicate matches any host with at least
+        one ``ports.scripts.vulns.id`` field; with one or
+        both, it constrains the matching field on the
+        unwound vuln entry.
+        """
+        if state is None and vulnid is None:
+            inner = Q("exists", field="ports.scripts.vulns.id")
+        elif state is None:
+            if isinstance(vulnid, utils.REGEXP_T):
+                inner = Q(
+                    "regexp",
+                    **{"ports.scripts.vulns.id": cls._get_pattern(vulnid)},
+                )
+            else:
+                inner = Q("match", **{"ports.scripts.vulns.id": vulnid})
+        elif vulnid is None:
+            inner = Q("match", **{"ports.scripts.vulns.state": state})
+        else:
+            inner = Q("match", **{"ports.scripts.vulns.id": vulnid}) & Q(
+                "match", **{"ports.scripts.vulns.status": state}
+            )
+        return Q(
+            "nested",
+            path="ports",
+            query=Q("nested", path="ports.scripts", query=inner),
+        )
+
+    @staticmethod
+    def searchvulnintersil():
+        """Filter records exposing the Intersil HTTPd password
+        reset vulnerability (Boa HTTPd, MSF
+        ``admin/http/intersil_pass_reset``).
+
+        Mirrors :meth:`MongoDB.searchvulnintersil`: a nested
+        ``ports`` match on the canonical product / version
+        regex the MSF module checks.
+        """
+        return Q(
+            "nested",
+            path="ports",
+            query=(
+                Q("match", ports__protocol="tcp")
+                & Q("match", ports__state_state="open")
+                & Q("match", ports__service_product="Boa HTTPd")
+                & Q(
+                    "regexp",
+                    ports__service_version=(
+                        # Intersil firmware versions matching
+                        # the MSF probe.
+                        "0\\.9(3([^0-9]|).*"
+                        "|4\\.([0-9]|0[0-9]|1[0-1])([^0-9]|).*)"
+                    ),
+                )
+            ),
+        )
+
+    @classmethod
+    def searchcpe(cls, cpe_type=None, vendor=None, product=None, version=None):
+        """Filter records by CPE.  No argument matches any host
+        with at least one CPE; otherwise the named fields are
+        AND-ed against the same CPE entry (``cpes`` is a flat
+        array of objects on the Elasticsearch schema -- not
+        declared in :attr:`nested_fields` -- so a host with
+        ``cpes = [{vendor: A, product: P}, {vendor: B, product:
+        Q}]`` would match ``searchcpe(vendor="A", product="Q")``
+        even though no single entry has both; this matches the
+        existing schema's flat-array semantics for
+        ``hostnames.*`` and the rest of the non-nested arrays).
+
+        Mirrors :meth:`MongoDB.searchcpe`.
+        """
+        fields = [
+            ("type", cpe_type),
+            ("vendor", vendor),
+            ("product", product),
+            ("version", version),
+        ]
+        flt = [(name, value) for name, value in fields if value is not None]
+        if not flt:
+            return Q("exists", field="cpes")
+        clauses = []
+        for name, value in flt:
+            if isinstance(value, utils.REGEXP_T):
+                clauses.append(Q("regexp", **{f"cpes.{name}": cls._get_pattern(value)}))
+            else:
+                clauses.append(Q("match", **{f"cpes.{name}": value}))
+        return cls.flt_and(*clauses)
+
+    @classmethod
+    def searchos(cls, txt):
+        """Filter records by OS detection.  ``txt`` is matched
+        against any of ``os.osclass.{vendor, osfamily, osgen,
+        type}`` -- the same four sub-keys :meth:`MongoDB.searchos`
+        ORs.
+        """
+        keys = ("vendor", "osfamily", "osgen", "type")
+        if isinstance(txt, utils.REGEXP_T):
+            pattern = cls._get_pattern(txt)
+            return cls.flt_or(
+                *(Q("regexp", **{f"os.osclass.{key}": pattern}) for key in keys)
+            )
+        return cls.flt_or(*(Q("match", **{f"os.osclass.{key}": txt}) for key in keys))
+
+    @classmethod
     def searchscript(cls, name=None, output=None, values=None, neg=False):
         """Search a particular content in the scripts results."""
         req = []
@@ -2161,6 +2399,15 @@ class ElasticDBView(ElasticDBActive, DBView):
         return cls._search_field(
             "infos.country_code", utils.country_unalias(country), neg=neg
         )
+
+    @classmethod
+    def searchcity(cls, city, neg=False):
+        """Filter records by GeoIP city.  Mirrors
+        :meth:`MongoDB.searchcity` (a ``match`` on
+        ``infos.city`` with the regex / list / scalar dispatch
+        :meth:`_search_field` provides).
+        """
+        return cls._search_field("infos.city", city, neg=neg)
 
     @classmethod
     def searchasnum(cls, asnum, neg=False):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1943,6 +1943,223 @@ class ElasticDBSearchTier2Tests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# ElasticDBSearchTier3Tests -- pin the wire shape of the
+# Tier-3 ``search*`` parity helpers added on
+# ``ElasticDBActive`` / ``ElasticDBView``:
+# ``searchcountopenports`` / ``searchports`` / ``searchportsother``
+# / ``searchcity`` / ``searchfile`` / ``searchvuln`` /
+# ``searchvulnintersil`` / ``searchcpe`` / ``searchos``.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_ELASTICSEARCH_DSL,
+    "elasticsearch_dsl is required (install with the ``elasticsearch`` extras)",
+)
+class ElasticDBSearchTier3Tests(unittest.TestCase):
+    """Behaviour-pin for Tier-3 ``ElasticDBActive.search*``
+    parity helpers.  ``searchfile`` previously raised
+    ``NotImplementedError``; the rest were missing entirely.
+    """
+
+    @staticmethod
+    def _ED():
+        from ivre.db.elastic import ElasticDBView
+
+        return ElasticDBView
+
+    # -- searchcountopenports ----------------------------------------
+
+    def test_searchcountopenports_equal_bounds_collapses_to_match(self):
+        body = self._ED().searchcountopenports(minn=5, maxn=5).to_dict()
+        self.assertEqual(body, {"match": {"openports.count": 5}})
+
+    def test_searchcountopenports_emits_range(self):
+        body = self._ED().searchcountopenports(minn=5, maxn=100).to_dict()
+        self.assertEqual(body, {"range": {"openports.count": {"gte": 5, "lte": 100}}})
+
+    def test_searchcountopenports_neg_with_both_bounds_uses_or(self):
+        # Mirrors Mongo's ``$or`` of ``$lt`` / ``$gt``: the
+        # row passes when count falls outside *either*
+        # bound.
+        body = self._ED().searchcountopenports(minn=5, maxn=100, neg=True).to_dict()
+        should = body["bool"]["should"]
+        self.assertEqual(len(should), 2)
+        self.assertEqual(should[0], {"range": {"openports.count": {"lt": 5}}})
+        self.assertEqual(should[1], {"range": {"openports.count": {"gt": 100}}})
+
+    def test_searchcountopenports_requires_at_least_one_bound(self):
+        with self.assertRaises(AssertionError):
+            self._ED().searchcountopenports()
+
+    # -- searchports / searchportsother ------------------------------
+
+    def test_searchports_default_ands_per_port_matches(self):
+        body = self._ED().searchports([22, 80]).to_dict()
+        # Each port becomes its own ``match`` against
+        # ``openports.tcp.ports``; the helper AND-s them.
+        must = body["bool"]["must"]
+        self.assertEqual(len(must), 2)
+        self.assertIn({"match": {"openports.tcp.ports": 22}}, must)
+        self.assertIn({"match": {"openports.tcp.ports": 80}}, must)
+
+    def test_searchports_any_uses_or(self):
+        body = self._ED().searchports([22, 80], any_=True).to_dict()
+        should = body["bool"]["should"]
+        self.assertEqual(len(should), 2)
+        self.assertIn({"match": {"openports.tcp.ports": 22}}, should)
+        self.assertIn({"match": {"openports.tcp.ports": 80}}, should)
+
+    def test_searchports_neg_and_any_is_an_error(self):
+        with self.assertRaises(ValueError):
+            self._ED().searchports([22], neg=True, any_=True)
+
+    def test_searchportsother_emits_terms_must_not(self):
+        body = self._ED().searchportsother([22, 80]).to_dict()
+        # Nested ports query with ``ports.port NOT IN (22, 80)``.
+        self.assertEqual(body["nested"]["path"], "ports")
+        bool_q = body["nested"]["query"]["bool"]
+        self.assertIn({"terms": {"ports.port": [22, 80]}}, bool_q["must_not"])
+        self.assertIn({"match": {"ports.protocol": "tcp"}}, bool_q["must"])
+        self.assertIn({"match": {"ports.state_state": "open"}}, bool_q["must"])
+
+    # -- searchcity ---------------------------------------------------
+
+    def test_searchcity_scalar(self):
+        body = self._ED().searchcity("Paris").to_dict()
+        self.assertEqual(body, {"match": {"infos.city": "Paris"}})
+
+    def test_searchcity_neg(self):
+        body = self._ED().searchcity("Paris", neg=True).to_dict()
+        self.assertEqual(
+            body, {"bool": {"must_not": [{"match": {"infos.city": "Paris"}}]}}
+        )
+
+    # -- searchfile ---------------------------------------------------
+
+    def test_searchfile_no_args_existence_check(self):
+        body = self._ED().searchfile().to_dict()
+        # Goes through ``Nested(ports, Nested(ports.scripts,
+        # exists))`` so the predicate is evaluated against
+        # the inner ``files`` array per script.
+        self.assertEqual(body["nested"]["path"], "ports")
+        inner = body["nested"]["query"]["nested"]
+        self.assertEqual(inner["path"], "ports.scripts")
+        self.assertEqual(
+            inner["query"],
+            {"exists": {"field": "ports.scripts.ls.volumes.files.filename"}},
+        )
+
+    def test_searchfile_with_filename(self):
+        body = self._ED().searchfile("README").to_dict()
+        inner = body["nested"]["query"]["nested"]["query"]
+        self.assertEqual(
+            inner,
+            {"match": {"ports.scripts.ls.volumes.files.filename": "README"}},
+        )
+
+    def test_searchfile_with_scripts_filter(self):
+        body = self._ED().searchfile(scripts=["nfs-ls", "smb-ls"]).to_dict()
+        inner = body["nested"]["query"]["nested"]["query"]["bool"]["must"]
+        self.assertIn({"terms": {"ports.scripts.id": ["nfs-ls", "smb-ls"]}}, inner)
+        self.assertIn(
+            {"exists": {"field": "ports.scripts.ls.volumes.files.filename"}},
+            inner,
+        )
+
+    def test_searchfile_with_single_script_uses_match(self):
+        body = self._ED().searchfile(scripts="nfs-ls").to_dict()
+        inner = body["nested"]["query"]["nested"]["query"]["bool"]["must"]
+        # Single-element scripts list collapses to ``match``
+        # (vs ``terms`` for multi-element).
+        self.assertIn({"match": {"ports.scripts.id": "nfs-ls"}}, inner)
+
+    # -- searchvuln / searchvulnintersil -----------------------------
+
+    def test_searchvuln_no_args_emits_existence(self):
+        body = self._ED().searchvuln().to_dict()
+        self.assertEqual(body["nested"]["path"], "ports")
+        inner = body["nested"]["query"]["nested"]
+        self.assertEqual(inner["path"], "ports.scripts")
+        self.assertEqual(
+            inner["query"], {"exists": {"field": "ports.scripts.vulns.id"}}
+        )
+
+    def test_searchvuln_with_id_only(self):
+        body = self._ED().searchvuln("CVE-2021-44228").to_dict()
+        inner = body["nested"]["query"]["nested"]["query"]
+        self.assertEqual(inner, {"match": {"ports.scripts.vulns.id": "CVE-2021-44228"}})
+
+    def test_searchvuln_with_state_only(self):
+        body = self._ED().searchvuln(state="VULNERABLE").to_dict()
+        inner = body["nested"]["query"]["nested"]["query"]
+        self.assertEqual(inner, {"match": {"ports.scripts.vulns.state": "VULNERABLE"}})
+
+    def test_searchvuln_with_id_and_state_uses_status_field(self):
+        # Mirrors the Mongo helper's ``$elemMatch`` shape:
+        # the *status* field (not ``state``) is used when
+        # both args are supplied.
+        body = self._ED().searchvuln("CVE-2021-44228", "VULNERABLE").to_dict()
+        must = body["nested"]["query"]["nested"]["query"]["bool"]["must"]
+        self.assertIn({"match": {"ports.scripts.vulns.id": "CVE-2021-44228"}}, must)
+        self.assertIn({"match": {"ports.scripts.vulns.status": "VULNERABLE"}}, must)
+
+    def test_searchvulnintersil_pins_full_fingerprint(self):
+        body = self._ED().searchvulnintersil().to_dict()
+        self.assertEqual(body["nested"]["path"], "ports")
+        must = body["nested"]["query"]["bool"]["must"]
+        self.assertIn({"match": {"ports.protocol": "tcp"}}, must)
+        self.assertIn({"match": {"ports.state_state": "open"}}, must)
+        self.assertIn({"match": {"ports.service_product": "Boa HTTPd"}}, must)
+        # The version regex matches Intersil firmware
+        # versions vulnerable to MSF's
+        # ``admin/http/intersil_pass_reset`` module.
+        regexp_clauses = [c for c in must if "regexp" in c]
+        self.assertEqual(len(regexp_clauses), 1)
+        self.assertIn("ports.service_version", regexp_clauses[0]["regexp"])
+
+    # -- searchcpe ----------------------------------------------------
+
+    def test_searchcpe_no_args_existence_check(self):
+        body = self._ED().searchcpe().to_dict()
+        self.assertEqual(body, {"exists": {"field": "cpes"}})
+
+    def test_searchcpe_single_field_uses_match(self):
+        body = self._ED().searchcpe(vendor="apache").to_dict()
+        self.assertEqual(body, {"match": {"cpes.vendor": "apache"}})
+
+    def test_searchcpe_multiple_fields_AND(self):
+        body = self._ED().searchcpe(vendor="apache", product="httpd").to_dict()
+        must = body["bool"]["must"]
+        self.assertIn({"match": {"cpes.vendor": "apache"}}, must)
+        self.assertIn({"match": {"cpes.product": "httpd"}}, must)
+
+    def test_searchcpe_regex_emits_regexp_query(self):
+        import re
+
+        body = self._ED().searchcpe(vendor=re.compile("^apache")).to_dict()
+        self.assertEqual(body, {"regexp": {"cpes.vendor": "apache.*"}})
+
+    # -- searchos -----------------------------------------------------
+
+    def test_searchos_scalar_ors_four_subkeys(self):
+        body = self._ED().searchos("Linux").to_dict()
+        should = body["bool"]["should"]
+        self.assertEqual(len(should), 4)
+        for key in ("vendor", "osfamily", "osgen", "type"):
+            self.assertIn({"match": {f"os.osclass.{key}": "Linux"}}, should)
+
+    def test_searchos_regex_uses_regexp_query(self):
+        import re
+
+        body = self._ED().searchos(re.compile("Linux")).to_dict()
+        should = body["bool"]["should"]
+        self.assertEqual(len(should), 4)
+        for key in ("vendor", "osfamily", "osgen", "type"):
+            self.assertIn({"regexp": {f"os.osclass.{key}": ".*Linux.*"}}, should)
+
+
+# ---------------------------------------------------------------------
 # PostgresExplainTests -- defence-in-depth check that values
 # inlined into the ``EXPLAIN`` statement go through SQLAlchemy's
 # per-type literal binding, not Python ``repr``.


### PR DESCRIPTION
Close the M4.5 Tier-3 ``search*`` parity gap on
Elasticsearch view: nine helpers Mongo ships under :meth:`MongoDB.search*` but ``ElasticDBActive`` /
``ElasticDBView`` had so far left missing or stubbed at ``raise NotImplementedError``.

New helpers (``ElasticDBActive``):

* ``searchcountopenports(minn, maxn, neg)`` -- ``range`` query on ``openports.count`` with the Mongo-shape branches (equal bounds collapse to ``match``; negated two-bound case ORs the two range exclusions).
* ``searchports(ports, protocol, state, neg, any_)`` -- AND-of-``searchport`` over the list (or OR with ``any_=True``).  Same ``neg``/``any_`` mutual-exclusion the Mongo helper enforces.
* ``searchportsother(ports, protocol, state)`` -- nested ``ports`` query with ``ports.port NOT IN (...)`` plus the protocol / state constraints.  Mongo's ``$elemMatch + $nin`` translates one-to-one.
* ``searchfile(fname, scripts)`` -- nested ``Nested(ports, Nested(ports.scripts, ...))`` query on ``ports.scripts.ls.volumes.files.filename``; ``scripts`` narrows the script-id space (string / list / ``None``). ``fname`` accepts the same regex / list / scalar shapes the Mongo helper does.
* ``searchvuln(vulnid, state)`` -- nested-ports + nested-scripts query on ``ports.scripts.vulns.{id, state, status}``.  Both-args case uses ``status`` (not ``state``) to match Mongo's ``$elemMatch`` shape.
* ``searchvulnintersil()`` -- nested ``ports`` match on Boa HTTPd + the Intersil firmware-version regex MSF's ``admin/http/intersil_pass_reset`` module checks.
* ``searchcpe(cpe_type, vendor, product, version)`` -- flat ``cpes.<key>`` matches AND-ed across supplied fields; ``cpes`` is *not* declared in :attr:`nested_fields` so a single ``match`` covers every CPE entry on the host (matching the existing flat-array semantics for ``hostnames.*`` and the rest of the schema).
* ``searchos(txt)`` -- OR over ``os.osclass.{vendor, osfamily, osgen, type}`` -- the same four sub-keys Mongo's ``searchos`` ORs, with the regex / scalar dispatch ``_get_pattern`` already provides.

New helper (``ElasticDBView``):

* ``searchcity(city, neg)`` -- ``_search_field`` against ``infos.city`` (mirrors the existing ``searchcountry`` / ``searchasnum`` pattern, scoped to the view since GeoIP enrichment lands on the merged record).

Tests (``ElasticDBSearchTier3Tests`` in
``tests/tests_no_backend.py``):

25 pin tests covering each helper -- per-helper field / operator / nesting shape, the Mongo-shape branch
dispatch (equal-bounds / single-bound / negated-or for ``searchcountopenports``; default-AND / ``any_``-OR / ``neg``-and-``any_``-conflict for ``searchports``; no-args-existence / id-only / state-only /
both-args-status for ``searchvuln``; flat-array
no-args-existence / single-field-match / multi-field-AND / regex for ``searchcpe``; four-subkey OR for
``searchos``).