### PR TITLE
feat(db/elastic): add Tier-2 topvalues; close M4.5

### DIFF
--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -173,15 +173,64 @@ class ElasticDB(DB):
         pass
 
     @staticmethod
+    def searchversion(version):
+        """Filter records by their stored ``schema_version``.
+
+        Mirrors :meth:`MongoDB.searchversion`: ``version=None``
+        matches records without a ``schema_version`` field,
+        ``version=N`` matches records whose ``schema_version``
+        equals ``N``.  ``ivre view --init`` always writes the
+        current :data:`ivre.xmlnmap.SCHEMA_VERSION` on every
+        document, so the ``version=None`` branch only matches
+        legacy data ingested by an older release.
+        """
+        if version is None:
+            return ~Q("exists", field="schema_version")
+        return Q("match", schema_version=version)
+
+    @staticmethod
+    def searchrange(start, stop, neg=False):
+        """Filter records by an inclusive IP-address range.
+
+        Mirrors :meth:`MongoDB.searchrange`.  ``addr`` is mapped
+        as Elasticsearch's native ``ip`` type, so the comparison
+        runs directly on the printable IP string -- no
+        ``ip2internal`` int128 split is needed (the Mongo helper
+        applies one because it stores addresses as a pair of
+        ``addr_0`` / ``addr_1`` 64-bit ints).
+
+        The base-class chain also routes
+        :meth:`DB.searchnet` / :meth:`DB.searchipv4` /
+        :meth:`DB.searchipv6` through this method, so adding it
+        here unlocks every CIDR / IP-family filter on the
+        Elastic backend in one step.
+        """
+        res = Q("range", addr={"gte": start, "lte": stop})
+        if neg:
+            return ~res
+        return res
+
+    @staticmethod
     def _get_pattern(regexp):
         # The equivalent to a MongoDB or PostgreSQL search for regexp
         # /Test/ would be /.*Test.*/ in Elasticsearch, while /Test/ in
         # Elasticsearch is equivalent to /^Test$/ in MongoDB or
         # PostgreSQL.
+        #
+        # Returns the pattern as a plain string.  Python regex
+        # flags have no direct Elasticsearch equivalent at this
+        # layer; a warning is issued for any flag other than
+        # ``re.UNICODE``.  Callers that build
+        # ``Q("regexp", **{field: ...})`` clauses on textual
+        # fields and want the ``re.IGNORECASE`` flag honored
+        # should use :meth:`_regexp_clause` instead, which
+        # routes through Elasticsearch's
+        # ``regexp.<field>.case_insensitive`` parameter (ES
+        # 7.10+).  This helper stays stable for ``terms.include``
+        # aggregation contexts and the certificate-hash
+        # call sites that ``.lower()`` the returned string.
         pattern, flags = utils.regexp2pattern(regexp)
         if flags & ~re.UNICODE:
-            # if a flag, other than re.UNICODE, is set, issue a
-            # warning as it will not be used
             utils.LOGGER.warning(
                 "Elasticsearch does not support flags in regular "
                 "expressions [%r with flags=%r]",
@@ -189,6 +238,44 @@ class ElasticDB(DB):
                 flags,
             )
         return pattern
+
+    @classmethod
+    def _regexp_clause(cls, field, value):
+        """Build a ``Q("regexp", ...)`` clause that honors
+        ``re.IGNORECASE`` on the source regex.
+
+        Elasticsearch's ``regexp`` query accepts a
+        ``case_insensitive`` parameter since 7.10; with the
+        flag set, the pattern is wrapped in
+        ``{"value": pattern, "case_insensitive": True}``.
+        Without ``re.IGNORECASE`` the legacy plain-string
+        shape is preserved for byte-for-byte compatibility
+        with the existing pin tests.
+
+        Used by helpers that translate user-supplied regex
+        filters where ``re.IGNORECASE`` is part of the IVRE
+        shorthand syntax (``/pattern/i``) and the underlying
+        textual content (e.g. ``http-user-agent`` script
+        values, host script outputs) needs case-insensitive
+        matching to mirror the Mongo backend.
+        """
+        if isinstance(value, utils.REGEXP_T):
+            pattern, flags = utils.regexp2pattern(value)
+            unsupported = flags & ~(re.UNICODE | re.IGNORECASE)
+            if unsupported:
+                utils.LOGGER.warning(
+                    "Elasticsearch does not support flags in regular "
+                    "expressions [%r with flags=%r]",
+                    pattern,
+                    flags,
+                )
+            if flags & re.IGNORECASE:
+                return Q(
+                    "regexp",
+                    **{field: {"value": pattern, "case_insensitive": True}},
+                )
+            return Q("regexp", **{field: pattern})
+        return Q("regexp", **{field: cls._get_pattern(value)})
 
     @classmethod
     def _search_field(cls, field, value, neg=False):
@@ -288,6 +375,16 @@ class ElasticDBActive(ElasticDB, DBActive):
         "ports.scripts.ssl-ja3-client",
         "ports.scripts.ssl-ja3-server",
         "ports.scripts.ssl-ja4-client",
+        # ``traces.hops`` is an array of objects; declaring it
+        # nested preserves cross-field correlation inside a
+        # single hop record (e.g. a ``searchhop(ip, ttl=N)``
+        # query must match a hop where *both* ``ipaddr`` and
+        # ``ttl`` come from the same array element, not any
+        # combination across elements).  ``include_in_parent``
+        # is implicit via :func:`_create_mappings` so flat
+        # single-field queries on ``traces.hops.<key>`` keep
+        # working unchanged.
+        "traces.hops",
         "tags",
     ]
     mappings = [
@@ -318,20 +415,327 @@ class ElasticDBActive(ElasticDB, DBActive):
             ignore_unavailable=True,
         )["count"]
 
-    def get(self, spec, fields=None, **kargs):
-        """Queries the active index."""
+    # Elasticsearch's ``index.max_result_window`` setting
+    # (default 10 000) caps ``from + size`` on any non-scroll
+    # ``_search`` request -- exceed it and the request fails
+    # with ``Result window is too large``.  IVRE's web
+    # paginators drive ``get()`` with successive ``skip:N``
+    # values (``RESULTS_COUNT = 200`` per page over the HTTP
+    # backend, ``WEB_LIMIT`` over the cgi/JSON one), so any
+    # ``size`` we pick has to leave room for ``skip`` no
+    # matter how deep the pagination goes.
+    _MAX_RESULT_WINDOW = 10000
+
+    # ``no_limit`` is the sentinel value that translates to
+    # "return every match" for the per-backend ``limit`` /
+    # ``size`` argument.  ``MongoDBActive`` uses ``0`` (Mongo
+    # cursor convention); the SQL and HTTP backends use
+    # ``None``; for Elasticsearch, ``None`` lets :meth:`get` /
+    # :meth:`distinct` apply their own scroll- or
+    # composite-pagination defaults instead of forcing a
+    # specific window.  Consumed by ``web/app.py:452`` (the
+    # ``/cgi/.../distinct`` route) and
+    # ``ivre/tools/ipinfo.py:377-379``.
+    no_limit = None
+
+    def get(self, spec, fields=None, sort=None, limit=None, skip=None, **kargs):
+        """Queries the active index.
+
+        ``sort`` / ``limit`` / ``skip`` are honored via the
+        ``search`` API (``from`` + ``size`` + ``sort``); when
+        none of them are set, the more efficient
+        ``helpers.scan`` scroll path streams every match.
+        ``sort`` follows IVRE's ``[(field, direction), ...]``
+        convention -- ``direction`` is ``1`` for ascending or
+        ``-1`` for descending.
+
+        Honoring ``skip`` is what unblocks the
+        :func:`tests.tests.IvreTests.find_record_cgi` paginated
+        web-API loop, which was previously infinite on the
+        Elastic backend: every page returned the same first
+        ``WEB_LIMIT`` records because the pagination kwargs
+        were silently swallowed by ``**kargs`` and the scroll
+        helper has no offset support.
+
+        ``size`` is always capped so ``from + size`` stays
+        within :attr:`_MAX_RESULT_WINDOW`; deep pagination
+        beyond that ceiling would need ``search_after`` /
+        ``scroll``, which the cgi paginators do not currently
+        exercise.  When ``limit`` is unspecified we still want
+        a sensible default (callers iterate the cursor and
+        break at their own consumer-level cap), so the size
+        falls back to 1000 -- larger than any in-tree
+        per-page consumer needs, and well clear of the
+        ``from + size`` cap for typical CI fixtures.
+        """
         query = {"query": spec.to_dict()}
         if fields is not None:
             query["_source"] = fields
-        for rec in helpers.scan(
-            self.db_client, query=query, index=self.indexes[0], ignore_unavailable=True
-        ):
+        # ``sort=[]`` (the default ``flt_params.sortby`` value
+        # the cgi handler hands us) is "not None" but means
+        # "no sort"; treat it as scan-friendly so the empty
+        # sort body does not push us into the search-API
+        # branch unnecessarily.
+        sort_active = bool(sort)
+        use_search = sort_active or limit is not None or skip is not None
+        if use_search:
+            if sort_active:
+                query["sort"] = [
+                    {field: ("desc" if direction == -1 else "asc")}
+                    for field, direction in sort
+                ]
+            search_kw = {
+                "index": self.indexes[0],
+                "ignore_unavailable": True,
+                "body": query,
+            }
+            from_ = skip or 0
+            if from_:
+                # ``from_`` (trailing underscore) avoids a
+                # collision with the Python keyword.
+                search_kw["from_"] = from_
+            requested = limit if limit is not None else 1000
+            cap = self._MAX_RESULT_WINDOW - from_
+            if cap <= 0:
+                # Past the ``index.max_result_window`` cap; no
+                # ``search_after`` cursor here, so yield
+                # nothing and let the caller stop paginating.
+                return
+            search_kw["size"] = min(requested, cap)
+            result = self.db_client.search(**search_kw)
+            records = result["hits"]["hits"]
+        else:
+            records = helpers.scan(
+                self.db_client,
+                query=query,
+                index=self.indexes[0],
+                ignore_unavailable=True,
+            )
+        for rec in records:
             host = dict(rec["_source"], _id=rec["_id"])
             if "coordinates" in host.get("infos", {}):
                 host["infos"]["coordinates"] = host["infos"]["coordinates"][::-1]
             for field in self.datetime_fields:
                 self._set_datetime_field(host, field)
             yield host
+
+    @staticmethod
+    def _features_port_list_fields(use_service, use_product, use_version):
+        """Return the minimal ``_source`` projection the
+        ``features_port_list`` / ``features_port_get`` paths
+        need to read.  Pulled out as a tiny helper because both
+        :meth:`_features_port_list` and
+        :meth:`_features_port_get` need the same set; without
+        the projection the inherited ``_features_port_get``
+        would scan every host's full ``_source`` (including
+        every script output, every cert, every header) on
+        every ``features()`` call -- ~10 of which run in the
+        view test method, a few of those once per ``subflts``
+        entry.  On a fixture of even moderate size this turns
+        into many gigabytes of wire traffic and makes the test
+        appear to hang.  Restricting to ``addr`` plus the
+        few ``ports.*`` columns the feature extractor reads
+        keeps each scroll page small and bounds the wall-clock
+        cost.
+        """
+        fields = ["addr", "ports.port"]
+        if use_service:
+            fields.append("ports.service_name")
+            if use_product:
+                fields.append("ports.service_product")
+                if use_version:
+                    fields.append("ports.service_version")
+        return fields
+
+    def _features_port_list(self, flt, yieldall, use_service, use_product, use_version):
+        """Yield distinct ``(port, service_name?, service_product?,
+        service_version?)`` tuples for every matching host's
+        ports.  Mirrors :meth:`MongoDBActive._features_port_list`
+        which uses a ``$unwind ports`` / ``$group`` aggregation
+        pipeline; Elasticsearch has no native equivalent that
+        preserves nested-field cross-correlation here, so we
+        materialize the distinct set client-side via a Python
+        ``set``.
+
+        The base-class ``features_port_list`` wrapper (in
+        :class:`DB`) handles ``yieldall`` expansion and
+        canonical sorting on top of the raw tuples this
+        method yields.
+        """
+        fields = self._features_port_list_fields(use_service, use_product, use_version)
+        seen: set[tuple] = set()
+        for rec in self.get(flt, fields=fields):
+            for port in rec.get("ports", []):
+                if port["port"] == -1:
+                    continue
+                tup: list = [port["port"]]
+                if use_service:
+                    tup.append(port.get("service_name"))
+                    if use_product:
+                        tup.append(port.get("service_product"))
+                        if use_version:
+                            tup.append(port.get("service_version"))
+                seen.add(tuple(tup))
+        yield from seen
+
+    def _features_port_get(
+        self, features, flt, yieldall, use_service, use_product, use_version
+    ):
+        """Override :meth:`DBActive._features_port_get` to scope
+        the ``_source`` projection to the columns the feature
+        extractor actually reads.
+
+        The inherited helper iterates ``self.get(flt)`` with
+        no field filter, which on Elasticsearch routes through
+        ``helpers.scan`` with ``_source: True`` -- every host
+        document is shipped over the wire in full, including
+        every script output, every certificate, every HTTP
+        header.  The view test method runs ``features()`` ten
+        times (some of those once per ``subflts`` entry), so
+        the cumulative wire traffic on a fixture of even
+        moderate size made the test appear to hang.  Filtering
+        to ``addr`` plus the per-port columns the extractor
+        actually inspects collapses each scroll page to a
+        bounded size.
+        """
+        fields = self._features_port_list_fields(use_service, use_product, use_version)
+
+        if use_version:
+
+            def _extract(rec):
+                for port in rec.get("ports", []):
+                    if port["port"] == -1:
+                        continue
+                    yield (
+                        port["port"],
+                        port.get("service_name"),
+                        port.get("service_product"),
+                        port.get("service_version"),
+                    )
+                    if not yieldall:
+                        continue
+                    if port.get("service_version") is not None:
+                        yield (
+                            port["port"],
+                            port.get("service_name"),
+                            port.get("service_product"),
+                            None,
+                        )
+                    else:
+                        continue
+                    if port.get("service_product") is not None:
+                        yield (port["port"], port.get("service_name"), None, None)
+                    else:
+                        continue
+                    if port.get("service_name") is not None:
+                        yield (port["port"], None, None, None)
+
+        elif use_product:
+
+            def _extract(rec):
+                for port in rec.get("ports", []):
+                    if port["port"] == -1:
+                        continue
+                    yield (
+                        port["port"],
+                        port.get("service_name"),
+                        port.get("service_product"),
+                    )
+                    if not yieldall:
+                        continue
+                    if port.get("service_product") is not None:
+                        yield (port["port"], port.get("service_name"), None)
+                    else:
+                        continue
+                    if port.get("service_name") is not None:
+                        yield (port["port"], None, None)
+
+        elif use_service:
+
+            def _extract(rec):
+                for port in rec.get("ports", []):
+                    if port["port"] == -1:
+                        continue
+                    yield (port["port"], port.get("service_name"))
+                    if not yieldall:
+                        continue
+                    if port.get("service_name") is not None:
+                        yield (port["port"], None)
+
+        else:
+
+            def _extract(rec):
+                for port in rec.get("ports", []):
+                    if port["port"] == -1:
+                        continue
+                    yield (port["port"],)
+
+        n_features = len(features)
+        for rec in self.get(flt, fields=fields):
+            currec = [0] * n_features
+            for feat in _extract(rec):
+                try:
+                    currec[features[feat]] = 1
+                except KeyError:
+                    pass
+            yield (rec["addr"], currec)
+
+    def get_ips(self, flt, limit=None, skip=None):
+        """Return ``(records, count)`` where ``records`` yields
+        only the ``addr`` field of every matching host.  Used by
+        the ``/cgi/<view|scans>/onlyips`` web endpoint.
+
+        Mirrors :meth:`MongoDB.get_ips` but skips the int128
+        ``addr_0`` / ``addr_1`` reassembly because the Elastic
+        backend stores ``addr`` as a native ``ip`` field
+        already in printable form.
+        """
+        return (
+            self.get(flt, fields=["addr"], limit=limit, skip=skip),
+            self.count(flt),
+        )
+
+    def get_ips_ports(self, flt, limit=None, skip=None):
+        """Return ``(records, total_port_count)`` where
+        ``records`` yields each matching host with its ``addr``
+        and the ``port`` / ``state_state`` of every recorded
+        port.  Powers the ``/cgi/<view|scans>/ipsports`` web
+        endpoint.
+
+        Mirrors :meth:`MongoDB.get_ips_ports`; the ``count``
+        component is the total number of ``ports`` entries
+        across the result set, not the number of hosts (used
+        client-side for pagination of port-count UIs).
+        """
+        records = list(
+            self.get(
+                flt,
+                fields=["addr", "ports.port", "ports.state_state"],
+                limit=limit,
+                skip=skip,
+            )
+        )
+        count = sum(len(host.get("ports", [])) for host in records)
+        return iter(records), count
+
+    def get_open_port_count(self, flt, limit=None, skip=None):
+        """Return ``(records, host_count)`` where ``records``
+        yields ``addr`` / ``starttime`` / ``openports.count``
+        for every matching host.  Powers the
+        ``/cgi/<view|scans>/timeline`` and ``/countopenports``
+        endpoints.
+
+        Mirrors :meth:`MongoDB.get_open_port_count`.
+        """
+        return (
+            self.get(
+                flt,
+                fields=["addr", "starttime", "openports.count"],
+                limit=limit,
+                skip=skip,
+            ),
+            self.count(flt),
+        )
 
     def remove(self, host):
         """Removes the host from the active column. `host` must be the record as
@@ -359,12 +763,29 @@ class ElasticDBActive(ElasticDB, DBActive):
         if field == "infos.coordinates" and hasattr(self, "searchhaslocation"):
 
             def fix_result(value):
-                return tuple(float(v) for v in value.split(", "))
+                return tuple(float(v) for v in value.split(","))
 
+            # Read ``infos.coordinates`` from ``_source``
+            # rather than from the indexed ``geo_point``
+            # (``doc[...].value``) -- the geo_point storage
+            # round-trips floats through a 32-bit-precision
+            # internal representation, so e.g. ``48.86``
+            # comes back as ``48.85999997612089``.  Direct
+            # ``_source`` access keeps the original JSON
+            # values intact, which the ``/cgi/view/coordinates``
+            # endpoint (and other consumers comparing against
+            # the ``_source``-based ``get()`` path) relies on.
+            # ``_source`` is the post-:meth:`store_host` form
+            # ``[lng, lat]``; the script swaps back to IVRE's
+            # ``[lat, lng]`` convention so the parsed tuple
+            # matches Mongo's ``infos.coordinates`` group key.
             base_query = {
                 "script": {
                     "lang": "painless",
-                    "source": "doc['infos.coordinates'].value",
+                    "source": (
+                        "def c = params._source.infos.coordinates;"
+                        " return c[1] + ',' + c[0];"
+                    ),
                 }
             }
             flt = self.flt_and(flt, self.searchhaslocation())
@@ -394,6 +815,99 @@ class ElasticDBActive(ElasticDB, DBActive):
             if "after_key" not in result["aggregations"]["values"]:
                 break
             query["after"] = result["aggregations"]["values"]["after_key"]
+
+    @staticmethod
+    def _dn_painless_source(scriptid, subkey):
+        """Build a painless ``terms.script.source`` that walks
+        every ``ports[*].scripts[*][<scriptid>][*].<subkey>``
+        object on the host's ``_source`` and emits one
+        ``\\u0001``-separated ``key\\u0001value\\u0001...``
+        string per matching DN -- one bucket entry per cert
+        observation, not per host.
+
+        Walking ``_source`` directly (no nested aggregation
+        wrapper) lets the script enumerate whatever DN
+        attributes the certificate actually carries, mirroring
+        Mongo's ``$unwind ports.scripts -> $group by subject``
+        shape exactly.  No whitelist of attribute names is
+        kept: a cert with an OID-named or future-X.509-extension
+        attribute reaches the bucket key with the same
+        fidelity Mongo's ``$group`` would produce.
+
+        ``\\u0001`` (Start of Heading) is never present in
+        X.509 DN values, so the resulting string is
+        unambiguously parseable client-side: split on
+        ``\\u0001`` and zip the resulting ``[k, v, k, v, ...]``
+        array into a Python dict.
+        """
+        # ``params._source`` access in aggregation contexts
+        # has the same per-document overhead :meth:`getlocations`
+        # already pays; the cert.subject / cert.issuer paths
+        # are infrequent enough (one ``terms`` request per UI
+        # interaction) that the trade-off is acceptable in
+        # exchange for whitelist-free correctness.
+        return (
+            "def out = [];"
+            " def ports = params._source.ports;"
+            " if (ports == null) return out;"
+            " for (def port : ports) {"
+            " def scripts = port.scripts;"
+            " if (scripts == null) continue;"
+            " for (def script : scripts) {"
+            f" if (script.id != '{scriptid}') continue;"
+            f" def certs = script['{scriptid}'];"
+            " if (certs == null) continue;"
+            " for (def cert : certs) {"
+            f" def dn = cert.{subkey};"
+            " if (dn == null) continue;"
+            " def parts = [];"
+            " for (def entry : dn.entrySet()) {"
+            " parts.add(entry.getKey());"
+            " parts.add(entry.getValue());"
+            " }"
+            " out.add(String.join('\u0001', parts));"
+            " }"
+            " }"
+            " }"
+            " return out;"
+        )
+
+    @staticmethod
+    def _build_script_nested_agg(scriptid, subfield, baseterms, terms_extra=None):
+        """Build a two-level nested aggregation
+        (``ports`` -> ``ports.scripts``) with a script-id
+        filter and a ``terms`` aggregation on
+        ``ports.scripts.<scriptid>.<subfield>``.
+
+        Mirrors the per-script counting semantics
+        :meth:`MongoDB.topvalues` produces by
+        ``$unwind``-ing ``ports`` then ``ports.scripts``: each
+        script subdocument contributes one observation to the
+        bucket, so a host that publishes the same NTLM /
+        SMB / modbus value on several ports counts once per
+        port (not once per host as a flat aggregation would).
+
+        ``terms_extra`` is merged into the inner ``terms``
+        clause, used by callers that need ``missing`` /
+        ``include`` / ``script`` / ... overrides.
+        """
+        terms = dict(baseterms, field=f"ports.scripts.{scriptid}.{subfield}")
+        if terms_extra is not None:
+            terms.update(terms_extra)
+        return {
+            "nested": {"path": "ports"},
+            "aggs": {
+                "patterns": {
+                    "nested": {"path": "ports.scripts"},
+                    "aggs": {
+                        "patterns": {
+                            "filter": {"match": {"ports.scripts.id": scriptid}},
+                            "aggs": {"patterns": {"terms": terms}},
+                        },
+                    },
+                },
+            },
+        }
 
     def topvalues(self, field, flt=None, topnbr=10, sort=None, least=False):
         """This method uses an aggregation to produce top values for a given
@@ -1275,6 +1789,414 @@ return result;
             flt = self.flt_and(flt, self.searchscript(name="s7-info"))
             subfield = field[3:]
             field = {"field": f"ports.scripts.s7-info.{subfield}"}
+        elif field.startswith("ntlm."):
+            # Mirrors :meth:`MongoDB.topvalues` ``ntlm.<key>``
+            # branch.  The same friendly-name alias map the
+            # Mongo helper exposes (``os`` -> ``Product_Version``,
+            # ``domain`` -> ``NetBIOS_Domain_Name``, ...) is
+            # applied here so callers get identical results
+            # across backends.
+            #
+            # The aggregation runs inside a two-level nested
+            # context (``ports`` -> ``ports.scripts``) with a
+            # script-id filter so the per-key counts mirror
+            # Mongo's ``$unwind ports`` / ``$unwind ports.scripts``
+            # / ``$match {scripts.id: "ntlm-info"}`` pipeline.
+            # A flat aggregation would dedupe per parent
+            # document and undercount hosts that publish the
+            # same NTLM value on several ports.
+            flt = self.flt_and(flt, self.searchntlm())
+            subfield = field[5:]
+            subfield = {
+                "name": "Target_Name",
+                "server": "NetBIOS_Computer_Name",
+                "domain": "NetBIOS_Domain_Name",
+                "workgroup": "Workgroup",
+                "domain_dns": "DNS_Domain_Name",
+                "forest": "DNS_Tree_Name",
+                "fqdn": "DNS_Computer_Name",
+                "os": "Product_Version",
+                "version": "NTLM_Version",
+            }.get(subfield, subfield)
+            nested = self._build_script_nested_agg("ntlm-info", subfield, baseterms)
+        elif field.startswith("smb."):
+            # Mirrors :meth:`MongoDB.topvalues` ``smb.<key>``
+            # branch: per-port aggregation on
+            # ``ports.scripts.smb-os-discovery.<key>`` with the
+            # same nested wrapping as the ``ntlm.<key>`` arm.
+            flt = self.flt_and(flt, self.searchsmb())
+            subfield = field[4:]
+            nested = self._build_script_nested_agg(
+                "smb-os-discovery", subfield, baseterms
+            )
+        elif field.startswith("modbus."):
+            # Mirrors :meth:`MongoDB.topvalues` ``modbus.<key>``
+            # branch.  Per-port aggregation on
+            # ``ports.scripts.modbus-discover.<key>``;
+            # ``view_top_modbus_deviceids`` exercises the
+            # ``modbus.deviceid`` shape end-to-end.
+            flt = self.flt_and(flt, self.searchscript(name="modbus-discover"))
+            subfield = field[7:]
+            nested = self._build_script_nested_agg(
+                "modbus-discover", subfield, baseterms
+            )
+        elif field == "devicetype":
+            # Mirrors :meth:`MongoDB.topvalues` ``devicetype``
+            # branch: per-port top values of
+            # ``ports.service_devicetype``.  Wrapped in a
+            # ``nested(ports)`` aggregation so each port
+            # contributes its own count -- a host with three
+            # ports announcing the same ``service_devicetype``
+            # contributes three to the bucket, matching Mongo's
+            # ``$unwind ports`` count semantics.
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "terms": dict(baseterms, field="ports.service_devicetype"),
+                    },
+                },
+            }
+        elif field.startswith("devicetype:"):
+            # ``devicetype:<port>`` -- same per-port aggregation
+            # as the bare form but restricted to a specific
+            # port number.  The host-level :meth:`searchport`
+            # filter keeps the candidate document set small;
+            # the inner ``filter`` clause then narrows the
+            # nested aggregation to the matching port subdoc
+            # so other ports on the same host do not leak
+            # into the bucket count.
+            port = int(field.split(":", 1)[1])
+            flt = self.flt_and(flt, self.searchport(port))
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "filter": {"match": {"ports.port": port}},
+                        "aggs": {
+                            "patterns": {
+                                "terms": dict(
+                                    baseterms,
+                                    field="ports.service_devicetype",
+                                ),
+                            },
+                        },
+                    },
+                },
+            }
+        elif field == "cpe" or (field.startswith("cpe") and field[3] in ":."):
+            # Mirrors :meth:`MongoDB.topvalues` ``cpe`` /
+            # ``cpe.<part>`` / ``cpe:<spec>`` /
+            # ``cpe.<part>:<spec>`` family.  Mongo concats
+            # the kept fields with ``:`` separators inside a
+            # ``$concat`` pipeline stage and the outputproc
+            # splits back into a tuple; Elastic uses a
+            # painless script for the same shape.  ``cpes`` is
+            # not declared in :attr:`nested_fields`, so the
+            # script reads the document fields directly.
+            try:
+                cpe_field, cpe_spec = field.split(":", 1)
+                cpe_spec_parts = cpe_spec.split(":", 3)
+            except ValueError:
+                cpe_field = field
+                cpe_spec_parts = []
+            try:
+                cpe_field = cpe_field.split(".", 1)[1]
+            except IndexError:
+                cpe_field = "version"
+            cpe_keys = ["type", "vendor", "product", "version"]
+            if cpe_field not in cpe_keys:
+                try:
+                    cpe_field = cpe_keys[int(cpe_field) - 1]
+                except (IndexError, ValueError):
+                    cpe_field = "version"
+            cpe_filters = list(
+                zip(
+                    cpe_keys,
+                    (utils.str2regexp(value) for value in cpe_spec_parts),
+                )
+            )
+            flt = self.flt_and(
+                flt,
+                self.searchcpe(
+                    **{("cpe_type" if k == "type" else k): v for k, v in cpe_filters}
+                ),
+            )
+            keep_count = max(cpe_keys.index(cpe_field) + 1, len(cpe_filters))
+            kept_keys = cpe_keys[:keep_count]
+            if len(kept_keys) == 1:
+                field = {"field": f"cpes.{kept_keys[0]}"}
+            else:
+
+                def outputproc(value):  # noqa: F811
+                    return tuple(value.split(":", len(kept_keys) - 1))
+
+                # Painless concats the kept keys with ``:``
+                # separators so the outputproc can split the
+                # tuple back.  ``doc[...].size() == 0`` guards
+                # against entries that lack a key (else ES
+                # raises at script-runtime).
+                source_parts = []
+                for i, key in enumerate(kept_keys):
+                    if i:
+                        source_parts.append("':'")
+                    source_parts.append(
+                        f"(doc['cpes.{key}'].size() == 0 ? '' : "
+                        f"doc['cpes.{key}'].value)"
+                    )
+                field = {
+                    "script": {
+                        "lang": "painless",
+                        "source": " + ".join(source_parts),
+                    }
+                }
+        elif field == "hop":
+            # Mirrors :meth:`MongoDB.topvalues` ``hop``
+            # branch: per-hop top values of
+            # ``traces.hops.ipaddr`` (a native ``ip`` field on
+            # the Elastic schema, no int128 split needed).
+            # Wrapped in ``nested(traces.hops)`` so each
+            # individual hop contributes one observation to
+            # the bucket -- mirrors Mongo's ``$unwind traces`` /
+            # ``$unwind traces.hops`` count semantics.  A flat
+            # aggregation (the previous behaviour) deduped per
+            # parent doc and produced host-wide counts instead
+            # of per-hop counts.
+            nested = {
+                "nested": {"path": "traces.hops"},
+                "aggs": {
+                    "patterns": {
+                        "terms": dict(baseterms, field="traces.hops.ipaddr"),
+                    },
+                },
+            }
+        elif field.startswith("hop") and field[3] in ":>":
+            # ``hop:<ttl>`` -- equality on the TTL,
+            # ``hop>N`` -- TTL strictly greater than ``N``.
+            # The inner ``filter`` clause runs *inside* the
+            # ``nested`` context, so cross-field correlation is
+            # preserved: only hops where ``ttl`` matches the
+            # predicate contribute their ``ipaddr`` to the
+            # bucket.  A flat ``range`` / ``match`` on
+            # ``traces.hops.ttl`` at the host-query level would
+            # select hosts that have *some* hop at the right
+            # TTL and then aggregate every hop's ``ipaddr`` --
+            # the cross-field-correlation bug that produced the
+            # ``view_top_hop_10+`` test failure.
+            ttl = int(field[4:])
+            if field[3] == ">":
+                ttl_filter = {"range": {"traces.hops.ttl": {"gt": ttl}}}
+            else:
+                ttl_filter = {"match": {"traces.hops.ttl": ttl}}
+            nested = {
+                "nested": {"path": "traces.hops"},
+                "aggs": {
+                    "patterns": {
+                        "filter": ttl_filter,
+                        "aggs": {
+                            "patterns": {
+                                "terms": dict(baseterms, field="traces.hops.ipaddr"),
+                            },
+                        },
+                    },
+                },
+            }
+        elif field == "file" or (field.startswith("file") and field[4] in ".:"):
+            # Mirrors :meth:`MongoDB.topvalues` ``file`` /
+            # ``file.<key>`` / ``file:<scripts>`` /
+            # ``file:<scripts>.<key>`` branches.  ``<scripts>``
+            # is a comma-separated list of NSE-script ids the
+            # file ingestion can come from (``nfs-ls`` /
+            # ``smb-ls`` / ...); ``<key>`` defaults to
+            # ``filename``.
+            #
+            # Two-level nested wrapper so each shared file
+            # contributes one observation to the bucket; a
+            # flat aggregation would dedupe per parent doc
+            # and undercount hosts publishing the same file
+            # on several ports.  The script-id constraint is
+            # enforced by the host-level :meth:`searchfile`
+            # filter.
+            scripts: list[str] | None = None
+            if field.startswith("file:"):
+                scripts_part = field[5:]
+                if "." in scripts_part:
+                    scripts_part, subfield = scripts_part.split(".", 1)
+                else:
+                    subfield = "filename"
+                scripts = scripts_part.split(",")
+            else:
+                subfield = field[5:] or "filename"
+            flt = self.flt_and(flt, self.searchfile(scripts=scripts))
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "nested": {"path": "ports.scripts"},
+                        "aggs": {
+                            "patterns": {
+                                "terms": dict(
+                                    baseterms,
+                                    field=(
+                                        "ports.scripts.ls.volumes.files." f"{subfield}"
+                                    ),
+                                ),
+                            },
+                        },
+                    },
+                },
+            }
+        elif field == "vulns.id":
+            # Mirrors :meth:`MongoDB.topvalues` ``vulns.id``
+            # branch: per-script aggregation on
+            # ``ports.scripts.vulns.id``.  Two-level nested
+            # wrapper for per-script counting; the inner
+            # ``exists`` filter restricts the bucket to
+            # script subdocuments that actually carry a
+            # ``vulns.id`` (else painless / terms would
+            # iterate every script subdoc, including those
+            # that have nothing to do with vulnerabilities,
+            # and emit zero-key buckets that pollute the
+            # count).
+            flt = self.flt_and(flt, self.searchvuln())
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "nested": {"path": "ports.scripts"},
+                        "aggs": {
+                            "patterns": {
+                                "filter": {
+                                    "exists": {"field": "ports.scripts.vulns.id"}
+                                },
+                                "aggs": {
+                                    "patterns": {
+                                        "terms": dict(
+                                            baseterms,
+                                            field="ports.scripts.vulns.id",
+                                        ),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        elif field.startswith("vulns."):
+            # Mirrors :meth:`MongoDB.topvalues` ``vulns.<other>``
+            # branch: tuple of ``(id, <other>)`` so the caller
+            # can correlate the field back to the specific
+            # vulnerability.  Painless concats the two with
+            # ``:`` separator, outputproc splits back.  The
+            # inner ``exists`` filter -- same as ``vulns.id``
+            # -- prevents the painless from running on
+            # script subdocuments that are not
+            # vulnerability scans.
+            subfield = field[6:]
+            flt = self.flt_and(flt, self.searchvuln())
+
+            def outputproc(value):  # noqa: F811
+                return tuple(value.split(":", 1))
+
+            terms_clause = dict(
+                baseterms,
+                script={
+                    "lang": "painless",
+                    "source": (
+                        "(doc['ports.scripts.vulns.id'].size() == 0 ? '' "
+                        ": doc['ports.scripts.vulns.id'].value) + ':' + "
+                        f"(doc['ports.scripts.vulns.{subfield}'].size() "
+                        f"== 0 ? '' : doc['ports.scripts.vulns.{subfield}']"
+                        ".value)"
+                    ),
+                },
+            )
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "nested": {"path": "ports.scripts"},
+                        "aggs": {
+                            "patterns": {
+                                "filter": {
+                                    "exists": {"field": "ports.scripts.vulns.id"}
+                                },
+                                "aggs": {
+                                    "patterns": {"terms": terms_clause},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        elif field == "screenwords":
+            # Mirrors :meth:`MongoDB.topvalues` ``screenwords``
+            # branch: per-port top values of the OCR-derived
+            # word list stored on ``ports.screenwords``.
+            # ``ports`` is nested so a host advertising the
+            # same word on several ports contributes one
+            # observation per port (mirrors Mongo's
+            # ``$unwind ports`` / ``$unwind ports.screenwords``
+            # pipeline).
+            flt = self.flt_and(flt, self.searchscreenshot(words=True))
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "terms": dict(baseterms, field="ports.screenwords"),
+                    },
+                },
+            }
+        elif field == "sshkey.bits":
+            # Mirrors :meth:`MongoDB.topvalues` ``sshkey.bits``
+            # branch: tuple of ``(type, bits)`` from
+            # ``ssh-hostkey``.  The Mongo helper concats the
+            # two via a ``$project`` stage; painless emits the
+            # same shape here.  Two-level nested wrapper so
+            # each ``ssh-hostkey`` script subdocument
+            # contributes one ``(type, bits)`` observation.
+            flt = self.flt_and(flt, self.searchsshkey())
+
+            def outputproc(value):  # noqa: F811
+                return tuple(value.split(":", 1))
+
+            terms_clause = dict(
+                baseterms,
+                script={
+                    "lang": "painless",
+                    "source": (
+                        "(doc['ports.scripts.ssh-hostkey.type'].size() == "
+                        "0 ? '' : doc['ports.scripts.ssh-hostkey.type']"
+                        ".value) + ':' + "
+                        "(doc['ports.scripts.ssh-hostkey.bits'].size() == "
+                        "0 ? '' : doc['ports.scripts.ssh-hostkey.bits']"
+                        ".value)"
+                    ),
+                },
+            )
+            nested = {
+                "nested": {"path": "ports"},
+                "aggs": {
+                    "patterns": {
+                        "nested": {"path": "ports.scripts"},
+                        "aggs": {
+                            "patterns": {
+                                "filter": {
+                                    "match": {"ports.scripts.id": "ssh-hostkey"}
+                                },
+                                "aggs": {"patterns": {"terms": terms_clause}},
+                            },
+                        },
+                    },
+                },
+            }
+        elif field.startswith("sshkey."):
+            # Mirrors :meth:`MongoDB.topvalues` ``sshkey.<other>``
+            # branch: scalar value of a single key on each
+            # ``ssh-hostkey`` script subdocument.
+            subfield = field[7:]
+            flt = self.flt_and(flt, self.searchsshkey())
+            nested = self._build_script_nested_agg("ssh-hostkey", subfield, baseterms)
         elif field.startswith("scanner.port:"):
             flt = self.flt_and(flt, self.searchscript(name="scanner"))
             field = {"field": f"ports.scripts.scanner.ports.{field[13:]}.ports"}
@@ -1460,37 +2382,80 @@ return result;
             }
         elif field.startswith("cert.") or field.startswith("cacert."):
             # Mirrors :meth:`MongoDB.topvalues` ``cert.<key>``
-            # / ``cacert.<key>`` branches: nested aggregation
-            # over ``ports.scripts.ssl-cert`` / ``ssl-cacert``
-            # with the script-id filter applied at the
-            # ``ports.scripts`` level so the per-key counts
-            # only see the right script's documents.
+            # / ``cacert.<key>`` branches.
+            #
+            # Two shapes share this branch:
+            #
+            # * Scalar leaves (``md5``, ``sha1``, ``sha256``,
+            #   ``pubkey.<hash>``, ``self_signed``, ...) use
+            #   the standard ``nested(ports) ->
+            #   nested(ports.scripts) -> filter(scripts.id =
+            #   <scriptid>) -> terms(field=...)`` chain so the
+            #   per-cert count matches Mongo's ``$unwind``
+            #   semantics.
+            #
+            # * Object leaves -- ``subject`` and ``issuer`` --
+            #   cannot use ``terms.field`` because Elastic's
+            #   ``terms`` aggregation refuses object-shaped
+            #   fields.  Instead, a painless script walks the
+            #   host's ``_source`` directly, finds every
+            #   ``ports[*].scripts[*][<scriptid>][*]`` entry,
+            #   reads the ``subject`` / ``issuer`` dict and
+            #   emits one ``\u0001``-separated bucket key per
+            #   cert observation (the script returns an
+            #   array, so each emission lands in its own
+            #   bucket -- equivalent to Mongo's
+            #   ``$unwind ports -> $unwind ports.scripts ->
+            #   $group``).  Because the script handles the
+            #   unwinding itself, no surrounding ``nested``
+            #   wrapper is needed.  The client-side
+            #   :func:`outputproc` splits on ``\u0001`` and
+            #   zips the result into a dict matching Mongo's
+            #   ``$group`` shape.
             cacert = field.startswith("cacert.")
             subkey = field[7:] if cacert else field[5:]
             scriptid = "ssl-cacert" if cacert else "ssl-cert"
             flt = self.flt_and(flt, self.searchcert(cacert=cacert))
-            inner_filter = Q("match", **{"ports.scripts.id": scriptid}).to_dict()
-            nested = {
-                "nested": {"path": "ports"},
-                "aggs": {
-                    "patterns": {
-                        "nested": {"path": "ports.scripts"},
-                        "aggs": {
-                            "patterns": {
-                                "filter": inner_filter,
-                                "aggs": {
-                                    "patterns": {
-                                        "terms": dict(
-                                            baseterms,
-                                            field=f"ports.scripts.{scriptid}.{subkey}",
-                                        )
-                                    }
-                                },
-                            }
-                        },
+            if subkey in ("subject", "issuer"):
+
+                def outputproc(value):  # noqa: F811
+                    if not value:
+                        return {}
+                    parts = value.split("\u0001")
+                    return dict(zip(parts[0::2], parts[1::2]))
+
+                field = {
+                    "script": {
+                        "lang": "painless",
+                        "source": self._dn_painless_source(scriptid, subkey),
                     }
-                },
-            }
+                }
+            else:
+                inner_filter = Q("match", **{"ports.scripts.id": scriptid}).to_dict()
+                nested = {
+                    "nested": {"path": "ports"},
+                    "aggs": {
+                        "patterns": {
+                            "nested": {"path": "ports.scripts"},
+                            "aggs": {
+                                "patterns": {
+                                    "filter": inner_filter,
+                                    "aggs": {
+                                        "patterns": {
+                                            "terms": dict(
+                                                baseterms,
+                                                field=(
+                                                    "ports.scripts."
+                                                    f"{scriptid}.{subkey}"
+                                                ),
+                                            )
+                                        }
+                                    },
+                                }
+                            },
+                        }
+                    },
+                }
         else:
             field = {"field": field}
         body = {"query": flt.to_dict()}
@@ -1589,14 +2554,17 @@ return result;
 
     # -- traces.hops -- mirroring :meth:`MongoDB.searchhop` /
     # ``searchhopname`` / ``searchhopdomain``.  ``traces.hops``
-    # is *not* declared in :attr:`nested_fields`, so each
-    # ``match`` flattens against the array directly: a query
-    # combining ``ipaddr`` and ``ttl`` matches host records
-    # where any single hop satisfies both predicates *or*
-    # different hops satisfy them separately.  The latter is a
-    # well-known limitation of non-nested array-of-objects on
-    # Elasticsearch and is consistent with the rest of the
-    # schema (e.g. ``hostnames.*``).
+    # is declared in :attr:`nested_fields`, so every multi-field
+    # predicate is wrapped in
+    # ``Q("nested", path="traces.hops", query=...)`` to preserve
+    # cross-field correlation inside a single hop array element
+    # -- a ``searchhop(ip, ttl=N)`` query must match a single
+    # array element where both ``ipaddr`` *and* ``ttl`` agree,
+    # not different elements satisfying each predicate
+    # separately.  Single-field helpers stay nested too for
+    # consistency and so the ``neg=True`` shape produces the
+    # ``$ne``-equivalent ("no hop matches") rather than the
+    # flat-array ``"at least one hop does not match"`` form.
     @classmethod
     def searchhop(cls, hop, ttl=None, neg=False):
         """Filter records that have a traceroute hop with the
@@ -1607,9 +2575,10 @@ return result;
         match takes a printable IP string directly without the
         ``ip2internal`` split the Mongo helper applies.
         """
-        res = Q("match", **{"traces.hops.ipaddr": hop})
+        inner = Q("match", **{"traces.hops.ipaddr": hop})
         if ttl is not None:
-            res &= Q("match", **{"traces.hops.ttl": ttl})
+            inner &= Q("match", **{"traces.hops.ttl": ttl})
+        res = Q("nested", path="traces.hops", query=inner)
         if neg:
             return ~res
         return res
@@ -1619,9 +2588,24 @@ return result;
         """Filter records by traceroute-hop domain.
 
         Mirrors :meth:`MongoDB.searchhopdomain`: a ``match``
-        against the indexed ``traces.hops.domains`` field.
+        against the indexed ``traces.hops.domains`` field,
+        wrapped in a ``nested(traces.hops)`` query so negation
+        means "no hop matches" rather than "at least one hop
+        differs" (the flat-array semantics).
         """
-        return cls._search_field("traces.hops.domains", hop, neg=neg)
+        if isinstance(hop, utils.REGEXP_T):
+            inner = Q("regexp", **{"traces.hops.domains": cls._get_pattern(hop)})
+        elif isinstance(hop, list):
+            if len(hop) == 1:
+                inner = Q("match", **{"traces.hops.domains": hop[0]})
+            else:
+                inner = Q("terms", **{"traces.hops.domains": hop})
+        else:
+            inner = Q("match", **{"traces.hops.domains": hop})
+        res = Q("nested", path="traces.hops", query=inner)
+        if neg:
+            return ~res
+        return res
 
     @classmethod
     def searchhopname(cls, hop, neg=False):
@@ -1629,15 +2613,23 @@ return result;
 
         Mirrors :meth:`MongoDB.searchhopname`: positive matches
         AND the indexed ``traces.hops.domains`` lookup with the
-        non-indexed ``traces.hops.host`` match (so the hot path
-        still goes through the index even though
-        ``traces.hops.host`` is not indexed); negative matches
-        only exclude ``traces.hops.host`` so the indexed filter
-        does not silently drop legitimate non-matches.
+        non-indexed ``traces.hops.host`` match -- both clauses
+        must be satisfied by the *same* hop array element, which
+        the ``nested(traces.hops)`` wrapper guarantees.
+        Negative matches only exclude ``traces.hops.host`` so
+        the indexed-domain filter does not silently drop
+        legitimate non-matches.
         """
         if neg:
-            return cls._search_field("traces.hops.host", hop, neg=True)
-        return cls.searchhopdomain(hop) & cls._search_field("traces.hops.host", hop)
+            return ~Q(
+                "nested",
+                path="traces.hops",
+                query=Q("match", **{"traces.hops.host": hop}),
+            )
+        inner = Q("match", **{"traces.hops.domains": hop}) & Q(
+            "match", **{"traces.hops.host": hop}
+        )
+        return Q("nested", path="traces.hops", query=inner)
 
     # -- per-port "fingerprint" filters --------------------
     @staticmethod
@@ -2167,19 +3159,25 @@ return result;
 
     @classmethod
     def searchscript(cls, name=None, output=None, values=None, neg=False):
-        """Search a particular content in the scripts results."""
+        """Search a particular content in the scripts results.
+
+        ``re.IGNORECASE`` on any user-supplied regex (``name``,
+        ``output``, ``values``) translates to the
+        ``case_insensitive`` parameter on the corresponding
+        ``regexp`` clause via :meth:`_regexp_clause`, so the
+        IVRE shorthand ``/pattern/i`` matches case-insensitive
+        text the same way the Mongo backend does.
+        """
         req = []
         if isinstance(name, list):
             req.append(Q("terms", **{"ports.scripts.id": name}))
         elif isinstance(name, utils.REGEXP_T):
-            req.append(Q("regexp", **{"ports.scripts.id": cls._get_pattern(name)}))
+            req.append(cls._regexp_clause("ports.scripts.id", name))
         elif name is not None:
             req.append(Q("match", **{"ports.scripts.id": name}))
         if output is not None:
             if isinstance(output, utils.REGEXP_T):
-                req.append(
-                    Q("regexp", **{"ports.scripts.output": cls._get_pattern(output)})
-                )
+                req.append(cls._regexp_clause("ports.scripts.output", output))
             else:
                 req.append(Q("match", **{"ports.scripts.output": output}))
         if values:
@@ -2201,24 +3199,12 @@ return result;
             elif isinstance(values, str):
                 req.append(Q("match", **{f"ports.scripts.{key}": values}))
             elif isinstance(values, utils.REGEXP_T):
-                req.append(
-                    Q(
-                        "regexp",
-                        **{f"ports.scripts.{key}": cls._get_pattern(values)},
-                    )
-                )
+                req.append(cls._regexp_clause(f"ports.scripts.{key}", values))
             else:
                 for field, value in values.items():
                     if isinstance(value, utils.REGEXP_T):
                         req.append(
-                            Q(
-                                "regexp",
-                                **{
-                                    f"ports.scripts.{key}.{field}": cls._get_pattern(
-                                        value
-                                    )
-                                },
-                            )
+                            cls._regexp_clause(f"ports.scripts.{key}.{field}", value)
                         )
                     else:
                         req.append(
@@ -2616,6 +3602,23 @@ class ElasticDBView(ElasticDBActive, DBView):
         return cls._search_field("infos.as_name", asname, neg=neg)
 
     def getlocations(self, flt):
+        # Read the raw ``[lng, lat]`` array from ``_source``
+        # (Elasticsearch stores ``infos.coordinates`` as a
+        # native ``geo_point`` -- :meth:`store_host` flips
+        # IVRE's ``[lat, lng]`` convention for the GeoJSON
+        # ``[lng, lat]`` order ES expects).  ``doc[...].value``
+        # would route through the indexed geo_point and lose
+        # float precision (e.g. ``48.86`` round-trips as
+        # ``48.85999997612089``), which makes the
+        # ``/cgi/view/coordinates`` endpoint disagree with the
+        # ``_source``-based ``get()`` path that the test
+        # harness compares against.  ``params._source`` keeps
+        # the original JSON literals intact.  The painless
+        # script swaps the two components back to IVRE's
+        # ``[lat, lng]`` order so :meth:`MongoDBView.getlocations`
+        # parity holds and the ``r2res`` reversal in
+        # ``web/app.py`` produces a GeoJSON ``[lng, lat]``
+        # ``coordinates`` payload.
         query = {
             "size": PAGESIZE,
             "sources": [
@@ -2624,7 +3627,10 @@ class ElasticDBView(ElasticDBActive, DBView):
                         "terms": {
                             "script": {
                                 "lang": "painless",
-                                "source": "doc['infos.coordinates'].value",
+                                "source": (
+                                    "def c = params._source.infos.coordinates;"
+                                    " return c[1] + ',' + c[0];"
+                                ),
                             }
                         }
                     }
@@ -2641,7 +3647,7 @@ class ElasticDBView(ElasticDBActive, DBView):
             )
             for value in result["aggregations"]["values"]["buckets"]:
                 yield {
-                    "_id": tuple(float(v) for v in value["key"]["coords"].split(", ")),
+                    "_id": tuple(float(v) for v in value["key"]["coords"].split(",")),
                     "count": value["doc_count"],
                 }
             if "after_key" not in result["aggregations"]["values"]:

--- a/pkg/runchecks
+++ b/pkg/runchecks
@@ -18,28 +18,28 @@
 
 # pip install -U '.[linting]'
 
-black -t py312 --check --extend-exclude="_version\.py" ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "black OK"
+black -t py312 --check --extend-exclude="_version\.py" ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "black OK" || exit 1
 
-flake8 --ignore=E402,E501,F401 ./doc/conf.py && flake8 --ignore=E203,E402,E501,W503 ./tests/tests.py ./tests/tests_no_backend.py && flake8 --ignore=E203,E501,E704,F821,W503 ./ivre/ && flake8 --ignore=E302,E305,E701,E704 ./pkg/stubs/*.pyi && echo "flake8 OK"
+flake8 --ignore=E402,E501,F401 ./doc/conf.py && flake8 --ignore=E203,E402,E501,W503 ./tests/tests.py ./tests/tests_no_backend.py && flake8 --ignore=E203,E501,E704,F821,W503 ./ivre/ && flake8 --ignore=E302,E305,E701,E704 ./pkg/stubs/*.pyi && echo "flake8 OK" || exit 1
 
-bandit --severity-level high -r ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "bandit OK"
+bandit --severity-level high -r ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./ivre/ ./pkg/stubs/ && echo "bandit OK" || exit 1
 
 # TODO: remove --follow-imports=skip
-MYPYPATH=./pkg/stubs/ mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-decorators --disallow-untyped-defs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any ./ivre/{active,analyzer,data,parser,tags,tools,types}/*.py ./ivre/{__init__,activecli,config,flow,geoiputils,graphroute,keys,plugins,utils,zgrabout}.py && echo "mypy OK"
+MYPYPATH=./pkg/stubs/ mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-decorators --disallow-untyped-defs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any ./ivre/{active,analyzer,data,parser,tags,tools,types}/*.py ./ivre/{__init__,activecli,config,flow,geoiputils,graphroute,keys,plugins,utils,zgrabout}.py && echo "mypy OK" || exit 1
 # partial sub-modules
-MYPYPATH=./pkg/stubs/ mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-decorators --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any ./ivre/db/mongo.py && echo "mypy (partial) OK"
+MYPYPATH=./pkg/stubs/ mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-decorators --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --warn-unused-ignores --warn-return-any ./ivre/db/mongo.py && echo "mypy (partial) OK" || exit 1
 
-git ls-files | grep -vE '^web/static/(doc|an|bs|d3|jq|lk|ui)/|^data/|\.(png|gif|svg|lock)$|-lock.yaml$' | xargs -r codespell --ignore-words=pkg/codespell_ignore && echo "codespell OK"
+git ls-files | grep -vE '^web/static/(doc|an|bs|d3|jq|lk|ui)/|^data/|\.(png|gif|svg|lock)$|-lock.yaml$' | xargs -r codespell --ignore-words=pkg/codespell_ignore && echo "codespell OK" || exit 1
 
-pylint -e all -d abstract-method,arguments-differ,attribute-defined-outside-init,broad-except,broad-exception-raised,duplicate-code,fixme,function-redefined,global-statement,import-error,invalid-name,locally-disabled,missing-docstring,no-member,protected-access,super-init-not-called,suppressed-message,too-few-public-methods,too-many-ancestors,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-lines,too-many-locals,too-many-nested-blocks,too-many-positional-arguments,too-many-public-methods,too-many-return-statements,too-many-statements,unsubscriptable-object,unused-argument,line-too-long ivre ./doc/conf.py && echo "pylint OK"
+pylint -e all -d abstract-method,arguments-differ,attribute-defined-outside-init,broad-except,broad-exception-raised,duplicate-code,fixme,function-redefined,global-statement,import-error,invalid-name,locally-disabled,missing-docstring,no-member,protected-access,super-init-not-called,suppressed-message,too-few-public-methods,too-many-ancestors,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-lines,too-many-locals,too-many-nested-blocks,too-many-positional-arguments,too-many-public-methods,too-many-return-statements,too-many-statements,unsubscriptable-object,unused-argument,line-too-long ivre ./doc/conf.py && echo "pylint OK" || exit 1
 
-pylint -e all -d unused-argument,too-many-arguments,too-many-positional-arguments,missing-function-docstring,missing-class-docstring,missing-module-docstring,multiple-statements,invalid-name,too-few-public-methods ./pkg/stubs/*.pyi && echo "pylint stubs OK"
+pylint -e all -d unused-argument,too-many-arguments,too-many-positional-arguments,missing-function-docstring,missing-class-docstring,missing-module-docstring,multiple-statements,invalid-name,too-few-public-methods ./pkg/stubs/*.pyi && echo "pylint stubs OK" || exit 1
 
-isort --profile black --check-only ivre ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./pkg/stubs/*.pyi && echo "isort OK"
+isort --profile black --check-only ivre ./doc/conf.py ./tests/tests.py ./tests/tests_no_backend.py ./pkg/stubs/*.pyi && echo "isort OK" || exit 1
 
-rstcheck -r ./doc/ && echo "rstcheck OK"
-if ! find ./doc/ -type f -name '*.rst' -print0 | xargs -0 grep '[[:space:]]$'; then echo "trailing spaces OK"; else echo "!! trailing spaces !!"; false; fi
+rstcheck -r ./doc/ && echo "rstcheck OK" || exit 1
+if ! find ./doc/ -type f -name '*.rst' -print0 | xargs -0 grep '[[:space:]]$'; then echo "trailing spaces OK"; else echo "!! trailing spaces !!"; exit 1; fi
 
-sphinx-lint -e all -d line-too-long -d default-role ./doc/ && echo "sphinx-lint OK"
+sphinx-lint -e all -d line-too-long -d default-role ./doc/ && echo "sphinx-lint OK" || exit 1
 
-shellcheck .github/actions/install/install*.sh pkg/builddockers pkg/builddocs pkg/runchecks && echo "shellcheck OK"
+shellcheck .github/actions/install/install*.sh pkg/builddockers pkg/builddocs pkg/runchecks && echo "shellcheck OK" || exit 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4198,12 +4198,6 @@ class IvreTests(unittest.TestCase):
             ),
         )
 
-        if DATABASE == "elastic":
-            # Support for Elasticsearch is experimental and lacks a
-            # lot of functionalities. The next tests will fail for
-            # lack of filters & topvalues.
-            return
-
         self.check_view_top_value("view_top_cert_issuer", "cert.issuer")
         self.check_view_top_value("view_top_cert_subject", "cert.subject")
         for hashtype in ["md5", "sha1", "sha256"]:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1638,6 +1638,144 @@ class ElasticDBSearchTier1Tests(unittest.TestCase):
             {"bool": {"must_not": [{"match": {"hostnames.name": "foo.example.com"}}]}},
         )
 
+    # -- searchversion -------------------------------------------------
+
+    def test_searchversion_scalar_matches_field(self):
+        # ``searchversion(N)`` -> ``match`` query against
+        # ``schema_version``; mirrors Mongo's
+        # ``{"schema_version": N}`` shape.
+        body = self._ED().searchversion(22).to_dict()
+        self.assertEqual(body, {"match": {"schema_version": 22}})
+
+    def test_searchversion_none_matches_legacy_records(self):
+        # ``searchversion(None)`` -> negation of ``exists``;
+        # mirrors Mongo's ``{"$exists": False}`` shape and
+        # picks up only legacy documents ingested before the
+        # ``schema_version`` field was added.
+        body = self._ED().searchversion(None).to_dict()
+        self.assertEqual(
+            body,
+            {"bool": {"must_not": [{"exists": {"field": "schema_version"}}]}},
+        )
+
+    # -- searchrange / searchnet / searchipv4 / searchipv6 -------------
+
+    def test_searchrange_uses_native_ip_range(self):
+        # ``addr`` is mapped as ES's native ``ip`` type, so a
+        # range over printable IP strings works directly --
+        # no ``ip2internal`` int128 split (the Mongo helper
+        # needs one because it stores ``addr_0`` / ``addr_1``).
+        body = self._ED().searchrange("10.0.0.0", "10.0.0.255").to_dict()
+        self.assertEqual(
+            body,
+            {"range": {"addr": {"gte": "10.0.0.0", "lte": "10.0.0.255"}}},
+        )
+
+    def test_searchrange_neg_inverts_at_host_level(self):
+        body = self._ED().searchrange("10.0.0.0", "10.0.0.255", neg=True).to_dict()
+        self.assertEqual(
+            body,
+            {
+                "bool": {
+                    "must_not": [
+                        {"range": {"addr": {"gte": "10.0.0.0", "lte": "10.0.0.255"}}}
+                    ]
+                }
+            },
+        )
+
+    def test_searchnet_routes_through_searchrange(self):
+        # ``searchnet`` is inherited from :class:`DBActive` and
+        # delegates to :meth:`searchrange` -- pin that the CIDR
+        # gets translated to its ``[start, stop]`` boundaries
+        # via :func:`utils.net2range` and that the resulting
+        # query is the canonical ES ``range`` shape.
+        body = self._ED().searchnet("192.168.0.0/24").to_dict()
+        self.assertEqual(
+            body,
+            {"range": {"addr": {"gte": "192.168.0.0", "lte": "192.168.0.255"}}},
+        )
+
+    def test_searchipv4_covers_full_v4_range(self):
+        # ``searchipv4()`` -> ``searchnet("0.0.0.0/0")`` ->
+        # ``searchrange("0.0.0.0", "255.255.255.255")``.
+        body = self._ED().searchipv4().to_dict()
+        self.assertEqual(
+            body,
+            {"range": {"addr": {"gte": "0.0.0.0", "lte": "255.255.255.255"}}},
+        )
+
+    def test_searchipv6_negates_full_v4_range(self):
+        # ``searchipv6()`` -> ``searchnet("0.0.0.0/0", neg=True)``
+        # -> negated ``searchrange``; matches everything
+        # *outside* the IPv4 range, i.e. IPv6 hosts (the
+        # ``addr`` ``ip`` field also accepts IPv6 strings).
+        body = self._ED().searchipv6().to_dict()
+        self.assertEqual(
+            body,
+            {
+                "bool": {
+                    "must_not": [
+                        {
+                            "range": {
+                                "addr": {
+                                    "gte": "0.0.0.0",
+                                    "lte": "255.255.255.255",
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+        )
+
+    # -- regex case_insensitive routing -------------------------------
+
+    def test_searchscript_regex_value_honors_ignorecase(self):
+        # ``re.IGNORECASE`` (the IVRE shorthand ``/pattern/i``)
+        # translates to Elasticsearch's
+        # ``regexp.<field>.case_insensitive`` parameter (ES
+        # 7.10+) so the case-insensitive Mongo behaviour
+        # carries over.  Without this routing, the
+        # ``http-user-agent`` filter -- which the test fixture
+        # exercises with ``re.compile("URL/7.3", re.IGNORECASE)``
+        # -- silently matched zero records on Elasticsearch
+        # because ``regexp`` defaults to case-sensitive.
+        import re as _re
+
+        body = (
+            self._ED()
+            .searchuseragent(useragent=_re.compile("URL/7.3", _re.IGNORECASE))
+            .to_dict()
+        )
+        # Drill down through the two-level nested wrapper
+        # ``searchscript`` produces.
+        bool_must = body["nested"]["query"]["nested"]["query"]["bool"]["must"]
+        # The script-id ``match`` clause is unchanged; the
+        # interesting bit is the second clause -- the
+        # value ``regexp`` -- which now carries the dict form.
+        regexp_clause = next(c for c in bool_must if "regexp" in c)
+        self.assertEqual(
+            regexp_clause["regexp"]["ports.scripts.http-user-agent"],
+            {"value": ".*URL/7.3.*", "case_insensitive": True},
+        )
+
+    def test_searchscript_regex_value_without_ignorecase_stays_plain(self):
+        # Without ``re.IGNORECASE`` the historical
+        # plain-string shape is preserved -- both for
+        # byte-for-byte pin compatibility with the rest of
+        # the suite and so existing call sites that rely on
+        # case-sensitive matching keep working unchanged.
+        import re as _re
+
+        body = self._ED().searchuseragent(useragent=_re.compile("URL/7.3")).to_dict()
+        bool_must = body["nested"]["query"]["nested"]["query"]["bool"]["must"]
+        regexp_clause = next(c for c in bool_must if "regexp" in c)
+        self.assertEqual(
+            regexp_clause["regexp"]["ports.scripts.http-user-agent"],
+            ".*URL/7.3.*",
+        )
+
     # -- inherited (delegate to searchscript) --------------------------
 
     def test_inherited_helpers_compose_through_searchscript(self):
@@ -1706,46 +1844,108 @@ class ElasticDBSearchTier2Tests(unittest.TestCase):
     # -- traces.hops --------------------------------------------------
 
     def test_searchhop_scalar(self):
+        # ``traces.hops`` is declared in
+        # :attr:`ElasticDBActive.nested_fields`, so single-field
+        # hop queries are wrapped in
+        # ``Q("nested", path="traces.hops", ...)`` for shape
+        # consistency with the cross-field ``ttl`` form below
+        # and to make ``neg=True`` mean "no hop matches" rather
+        # than the flat-array "at least one hop differs" form.
         body = self._ED().searchhop("1.2.3.4").to_dict()
-        self.assertEqual(body, {"match": {"traces.hops.ipaddr": "1.2.3.4"}})
+        self.assertEqual(
+            body,
+            {
+                "nested": {
+                    "path": "traces.hops",
+                    "query": {"match": {"traces.hops.ipaddr": "1.2.3.4"}},
+                }
+            },
+        )
 
     def test_searchhop_with_ttl(self):
+        # Cross-field correlation: ``ipaddr`` and ``ttl`` must
+        # agree on the *same* hop array element, which the
+        # ``nested(traces.hops)`` wrapper enforces.  Without it,
+        # a flat ``bool.must`` of two ``match`` queries matched
+        # any host where one hop has the right ``ipaddr`` and
+        # any other hop has the right ``ttl`` -- the bug that
+        # made ``view_top_hop_10+`` rank every hop of every host
+        # with a TTL>10 hop, including the very-near-the-scanner
+        # gateway at TTL 0.
         body = self._ED().searchhop("1.2.3.4", ttl=5).to_dict()
         self.assertEqual(
             body,
             {
-                "bool": {
-                    "must": [
-                        {"match": {"traces.hops.ipaddr": "1.2.3.4"}},
-                        {"match": {"traces.hops.ttl": 5}},
-                    ]
+                "nested": {
+                    "path": "traces.hops",
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {"match": {"traces.hops.ipaddr": "1.2.3.4"}},
+                                {"match": {"traces.hops.ttl": 5}},
+                            ]
+                        }
+                    },
                 }
             },
         )
 
     def test_searchhop_neg(self):
+        # Negation lands *outside* the ``nested`` wrapper so
+        # the predicate translates to "no hop matches" -- the
+        # ``$ne``-equivalent shape Mongo's
+        # :meth:`MongoDB.searchhop` produces.  An "inside"
+        # negation would mean "at least one hop differs",
+        # which matches strictly more documents.
         body = self._ED().searchhop("1.2.3.4", neg=True).to_dict()
-        self.assertEqual(
-            body,
-            {"bool": {"must_not": [{"match": {"traces.hops.ipaddr": "1.2.3.4"}}]}},
-        )
-
-    def test_searchhopdomain_scalar(self):
-        body = self._ED().searchhopdomain("example.com").to_dict()
-        self.assertEqual(body, {"match": {"traces.hops.domains": "example.com"}})
-
-    def test_searchhopname_combines_domain_and_host(self):
-        body = self._ED().searchhopname("foo.example.com").to_dict()
-        # Same indexed-domain + non-indexed-name shape
-        # ``searchhostname`` ships in M4.5.1.
         self.assertEqual(
             body,
             {
                 "bool": {
-                    "must": [
-                        {"match": {"traces.hops.domains": "foo.example.com"}},
-                        {"match": {"traces.hops.host": "foo.example.com"}},
+                    "must_not": [
+                        {
+                            "nested": {
+                                "path": "traces.hops",
+                                "query": {"match": {"traces.hops.ipaddr": "1.2.3.4"}},
+                            }
+                        }
                     ]
+                }
+            },
+        )
+
+    def test_searchhopdomain_scalar(self):
+        body = self._ED().searchhopdomain("example.com").to_dict()
+        self.assertEqual(
+            body,
+            {
+                "nested": {
+                    "path": "traces.hops",
+                    "query": {"match": {"traces.hops.domains": "example.com"}},
+                }
+            },
+        )
+
+    def test_searchhopname_combines_domain_and_host(self):
+        # Same indexed-domain + non-indexed-name shape
+        # ``searchhostname`` ships in the Tier-1 search work,
+        # but here both clauses must apply to the *same* hop
+        # array element -- the ``nested(traces.hops)`` wrapper
+        # enforces the per-element correlation.
+        body = self._ED().searchhopname("foo.example.com").to_dict()
+        self.assertEqual(
+            body,
+            {
+                "nested": {
+                    "path": "traces.hops",
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {"match": {"traces.hops.domains": "foo.example.com"}},
+                                {"match": {"traces.hops.host": "foo.example.com"}},
+                            ]
+                        }
+                    },
                 }
             },
         )
@@ -1754,7 +1954,18 @@ class ElasticDBSearchTier2Tests(unittest.TestCase):
         body = self._ED().searchhopname("foo", neg=True).to_dict()
         self.assertEqual(
             body,
-            {"bool": {"must_not": [{"match": {"traces.hops.host": "foo"}}]}},
+            {
+                "bool": {
+                    "must_not": [
+                        {
+                            "nested": {
+                                "path": "traces.hops",
+                                "query": {"match": {"traces.hops.host": "foo"}},
+                            }
+                        }
+                    ]
+                }
+            },
         )
 
     # -- per-port fingerprints ---------------------------------------
@@ -2324,8 +2535,70 @@ class ElasticDBTopValuesTier1Tests(unittest.TestCase):
 
     # -- cert.* / cacert.* --------------------------------------------
 
-    def test_topvalues_cert_filters_on_ssl_cert_script(self):
+    def test_topvalues_cert_subject_walks_source(self):
+        # ``cert.subject`` cannot use a plain
+        # ``terms(field=...)`` clause -- Elastic's ``terms``
+        # aggregation refuses object-shaped fields -- and it
+        # cannot use a static-whitelist painless either, since
+        # X.509 DNs can carry OID-named or future-extension
+        # attributes that no whitelist can anticipate.
+        # Instead, a painless script walks the host's
+        # ``_source`` directly, finds every
+        # ``ports[*].scripts[*]['ssl-cert'][*]`` entry,
+        # iterates the ``subject`` dict via ``entrySet()``
+        # and emits a ``\u0001``-separated bucket key per
+        # cert -- one entry per Mongo-equivalent
+        # ``$unwind`` -- with no schema-side whitelist of
+        # attribute names.  No ``nested`` wrapper is needed:
+        # the script returns an array, ES creates one bucket
+        # per array element, and the unwinding happens inside
+        # the script.
         body = self._capture_body("cert.subject")
+        terms = body["aggs"]["patterns"]["terms"]
+        self.assertNotIn("field", terms)
+        source = terms["script"]["source"]
+        # Pins for the script's structure: it walks
+        # ``params._source.ports``, filters on the script id,
+        # iterates ``entrySet`` (so any DN attribute is
+        # picked up), and joins with ``\u0001``.
+        self.assertIn("params._source.ports", source)
+        self.assertIn("ssl-cert", source)
+        self.assertIn("entrySet", source)
+        self.assertIn("\u0001", source)
+
+    def test_topvalues_cert_issuer_walks_source(self):
+        # ``cert.issuer`` mirrors ``cert.subject``: same
+        # ``_source``-walk script with ``cert.issuer``
+        # substituted for ``cert.subject``.
+        body = self._capture_body("cert.issuer")
+        terms = body["aggs"]["patterns"]["terms"]
+        self.assertNotIn("field", terms)
+        source = terms["script"]["source"]
+        self.assertIn("cert.issuer", source)
+        self.assertNotIn("cert.subject", source)
+        self.assertIn("\u0001", source)
+
+    def test_topvalues_cacert_walks_source_with_cacert_script_id(self):
+        # ``cacert.subject`` reuses the same ``_source``-walk
+        # painless template, with ``ssl-cacert`` substituted
+        # for ``ssl-cert``.
+        body = self._capture_body("cacert.subject")
+        terms = body["aggs"]["patterns"]["terms"]
+        self.assertNotIn("field", terms)
+        source = terms["script"]["source"]
+        self.assertIn("ssl-cacert", source)
+        self.assertNotIn("ssl-cert'", source)
+        self.assertIn("entrySet", source)
+
+    def test_topvalues_cert_md5_indexes_into_hash_field(self):
+        # Scalar leaves (``md5`` / ``sha1`` / ``sha256`` /
+        # ``pubkey.<hash>``) keep the
+        # ``nested(ports) -> nested(ports.scripts) -> filter ->
+        # terms(field=ports.scripts.ssl-cert.<key>)`` chain;
+        # only the object-shaped ``subject`` / ``issuer``
+        # branches re-route through the ``_source``-walking
+        # painless script.
+        body = self._capture_body("cert.md5")
         outer = body["aggs"]["patterns"]
         inner = outer["aggs"]["patterns"]
         filter_clause = inner["aggs"]["patterns"]
@@ -2333,41 +2606,277 @@ class ElasticDBTopValuesTier1Tests(unittest.TestCase):
             filter_clause["filter"],
             {"match": {"ports.scripts.id": "ssl-cert"}},
         )
-        self.assertEqual(
-            filter_clause["aggs"]["patterns"]["terms"]["field"],
-            "ports.scripts.ssl-cert.subject",
-        )
-
-    def test_topvalues_cacert_uses_ssl_cacert_script_id(self):
-        # ``cacert.<key>`` is the same shape as ``cert.<key>``
-        # but scoped to ``ssl-cacert`` rather than ``ssl-cert``;
-        # the per-key terms aggregation still indexes into
-        # the ``ports.scripts.ssl-cert.<key>`` *projection*
-        # (Mongo's hist-shape -- both NSE scripts share the
-        # ``ssl-cert`` data subkey on the parent document).
-        # Wait -- the Mongo helper at
-        # ``mongo.py:3743`` reads
-        # ``f"ports.scripts.ssl-cert.{field[7:]}"`` for both;
-        # double-check we mirror the same projection here.
-        body = self._capture_body("cacert.subject")
-        outer = body["aggs"]["patterns"]
-        inner = outer["aggs"]["patterns"]
-        filter_clause = inner["aggs"]["patterns"]
-        self.assertEqual(
-            filter_clause["filter"],
-            {"match": {"ports.scripts.id": "ssl-cacert"}},
-        )
-
-    def test_topvalues_cert_md5_indexes_into_hash_field(self):
-        body = self._capture_body("cert.md5")
-        # Drill down through the nested aggregation tree:
-        # outer Nested(ports) -> inner Nested(ports.scripts)
-        # -> filter -> terms.
-        outer = body["aggs"]["patterns"]
-        inner = outer["aggs"]["patterns"]
-        filter_clause = inner["aggs"]["patterns"]
         terms = filter_clause["aggs"]["patterns"]["terms"]
         self.assertEqual(terms["field"], "ports.scripts.ssl-cert.md5")
+
+
+# ---------------------------------------------------------------------
+# ElasticDBTopValuesTier2Tests -- pin the wire shape of the
+# Tier-2 ``topvalues`` parity branches added on
+# ``ElasticDBActive``: ``ntlm`` / ``ntlm.<key>``,
+# ``smb`` / ``smb.<key>``, ``modbus.<key>``, ``devicetype`` /
+# ``devicetype:<port>``, ``cpe[.<part>][:<spec>]``,
+# ``hop`` / ``hop:<ttl>`` / ``hop>N``,
+# ``file`` / ``file.<key>`` / ``file:<scripts>[.<key>]``,
+# ``vulns.id`` / ``vulns.<other>``, ``screenwords``,
+# ``sshkey.bits`` / ``sshkey.<key>``.  Closes M4.5 -- the
+# ``if DATABASE == "elastic": return`` skip block at
+# ``tests/tests.py:4201`` no longer needs to gate the rest
+# of the view test method.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_ELASTICSEARCH_DSL,
+    "elasticsearch_dsl is required (install with the ``elasticsearch`` extras)",
+)
+class ElasticDBTopValuesTier2Tests(unittest.TestCase):
+    """Behaviour-pin for Tier-2 ``ElasticDBActive.topvalues``
+    parity branches.  Each branch was previously falling
+    through the catch-all ``else: field = {"field": field}``
+    arm at ``elastic.py`` and silently emitting an
+    aggregation against a non-existent literal field --
+    returning an empty bucket list instead of an error.
+    """
+
+    @staticmethod
+    def _ED_instance():
+        from ivre.db.elastic import ElasticDBView
+
+        return ElasticDBView.from_url("elastic://x:9200")
+
+    @classmethod
+    def _capture_body(cls, field):
+        captured = []
+
+        class _FakeClient:
+            def search(self, body=None, **kw):  # type: ignore[no-untyped-def]
+                captured.append(body)
+                return {"aggregations": {"patterns": {"buckets": []}}}
+
+            def count(self, **kw):  # type: ignore[no-untyped-def]
+                return {"count": 0}
+
+        db = cls._ED_instance()
+        type(db).db_client = property(lambda self: _FakeClient())
+        try:
+            list(db.topvalues(field))
+        finally:
+            del type(db).db_client
+        assert captured, "topvalues did not call db_client.search"
+        return captured[-1]
+
+    @staticmethod
+    def _walk_to_terms(body):
+        """Walk down the ``aggs.patterns`` chain to the inner
+        ``terms`` aggregation.  Tier-2 branches that target
+        per-port / per-script fields wrap the terms agg in
+        one or two ``nested`` levels (``ports`` ->
+        ``ports.scripts``) plus an optional ``filter`` stage,
+        so the depth varies per branch.  The helper hides
+        the wrapping from the assertion side."""
+        cur = body["aggs"]["patterns"]
+        while "aggs" in cur:
+            cur = cur["aggs"]["patterns"]
+        return cur["terms"]
+
+    def _terms_field(self, field):
+        return self._walk_to_terms(self._capture_body(field)).get("field")
+
+    def _terms_script_source(self, field):
+        return self._walk_to_terms(self._capture_body(field))["script"]["source"]
+
+    # -- ntlm ---------------------------------------------------------
+
+    def test_topvalues_ntlm_friendly_aliases(self):
+        # Same friendly-name alias map the SQL backend ships
+        # in M4.4.1 (M4.4 :class:`PostgresDBActive`).  Pin
+        # the nine entries here too so a future refactor of
+        # one backend cannot silently drift the other.
+        cases = [
+            ("ntlm.name", "Target_Name"),
+            ("ntlm.server", "NetBIOS_Computer_Name"),
+            ("ntlm.domain", "NetBIOS_Domain_Name"),
+            ("ntlm.workgroup", "Workgroup"),
+            ("ntlm.domain_dns", "DNS_Domain_Name"),
+            ("ntlm.forest", "DNS_Tree_Name"),
+            ("ntlm.fqdn", "DNS_Computer_Name"),
+            ("ntlm.os", "Product_Version"),
+            ("ntlm.version", "NTLM_Version"),
+        ]
+        for alias, target in cases:
+            with self.subTest(alias=alias):
+                self.assertEqual(
+                    self._terms_field(alias),
+                    f"ports.scripts.ntlm-info.{target}",
+                )
+
+    # -- smb ----------------------------------------------------------
+
+    def test_topvalues_smb_subkey_passthrough(self):
+        self.assertEqual(
+            self._terms_field("smb.os"),
+            "ports.scripts.smb-os-discovery.os",
+        )
+
+    # -- modbus -------------------------------------------------------
+
+    def test_topvalues_modbus_subkey_passthrough(self):
+        self.assertEqual(
+            self._terms_field("modbus.deviceid"),
+            "ports.scripts.modbus-discover.deviceid",
+        )
+
+    # -- devicetype ---------------------------------------------------
+
+    def test_topvalues_devicetype_aggregates_service_field(self):
+        # ``ports.service_devicetype`` is a per-port field;
+        # the aggregation runs inside a ``nested(ports)``
+        # context so each port contributes one observation
+        # to the bucket (mirrors Mongo's ``$unwind ports``
+        # count semantics).  Without the nested wrap, ES's
+        # default ``terms`` semantics dedupe per parent
+        # document and undercount hosts publishing the same
+        # ``service_devicetype`` on several ports.
+        self.assertEqual(self._terms_field("devicetype"), "ports.service_devicetype")
+        body = self._capture_body("devicetype")
+        self.assertEqual(body["aggs"]["patterns"]["nested"], {"path": "ports"})
+
+    def test_topvalues_devicetype_with_port_adds_filter(self):
+        # ``devicetype:<port>`` adds two filter layers:
+        # the host-level :meth:`searchport` constraint
+        # (``openports.tcp.ports`` lookup, indexed) and a
+        # nested ``filter`` clause inside the ``nested(ports)``
+        # aggregation that narrows the per-port count to the
+        # matching port subdocument.
+        body = self._capture_body("devicetype:80")
+        self.assertEqual(self._terms_field("devicetype:80"), "ports.service_devicetype")
+        self.assertIn("openports", str(body["query"]))
+        # Inner ``filter`` clause matches ``ports.port`` to
+        # the requested port.
+        self.assertIn("ports.port", str(body["aggs"]["patterns"]))
+
+    # -- cpe ----------------------------------------------------------
+
+    def test_topvalues_cpe_default_emits_painless_concat(self):
+        # Bare ``cpe`` projects all four keys (default
+        # ``<part>=version``); the painless script concats
+        # them with ``:`` separators.
+        source = self._terms_script_source("cpe")
+        for key in ("type", "vendor", "product", "version"):
+            self.assertIn(f"cpes.{key}", source)
+        self.assertIn(" + ':' + ", source)
+
+    def test_topvalues_cpe_part_truncates_projection(self):
+        # ``cpe.vendor`` projects only ``type`` and
+        # ``vendor``.  Multi-key form still goes through
+        # the painless concat.
+        source = self._terms_script_source("cpe.vendor")
+        self.assertIn("cpes.type", source)
+        self.assertIn("cpes.vendor", source)
+        self.assertNotIn("cpes.product", source)
+        self.assertNotIn("cpes.version", source)
+
+    def test_topvalues_cpe_single_kept_key_uses_field_form(self):
+        # ``cpe.type`` -> only one kept key -> a flat
+        # ``terms(field=cpes.type)`` aggregation rather
+        # than a script.
+        body = self._capture_body("cpe.type")
+        terms = body["aggs"]["patterns"]["terms"]
+        self.assertEqual(terms.get("field"), "cpes.type")
+        self.assertNotIn("script", terms)
+
+    # -- hop ----------------------------------------------------------
+
+    def test_topvalues_hop_aggregates_native_ip_field(self):
+        # ``traces.hops`` is nested, so the terms agg lands
+        # inside a ``nested(traces.hops)`` wrapper; the
+        # ``_walk_to_terms`` helper hides the wrapping from
+        # the assertion.  The terms field itself is still
+        # ``traces.hops.ipaddr`` (native ``ip`` type).
+        self.assertEqual(self._terms_field("hop"), "traces.hops.ipaddr")
+        body = self._capture_body("hop")
+        self.assertEqual(body["aggs"]["patterns"]["nested"], {"path": "traces.hops"})
+
+    def test_topvalues_hop_with_ttl(self):
+        # The TTL filter must run *inside* the
+        # ``nested(traces.hops)`` aggregation -- otherwise
+        # cross-field correlation breaks and the bucket count
+        # picks up every hop of every host that has *any* hop
+        # at the requested TTL.  Pin the inner-filter shape
+        # explicitly.
+        body = self._capture_body("hop:5")
+        self.assertEqual(self._terms_field("hop:5"), "traces.hops.ipaddr")
+        self.assertEqual(body["aggs"]["patterns"]["nested"], {"path": "traces.hops"})
+        inner_filter = body["aggs"]["patterns"]["aggs"]["patterns"]["filter"]
+        self.assertEqual(inner_filter, {"match": {"traces.hops.ttl": 5}})
+
+    def test_topvalues_hop_gt_uses_range(self):
+        body = self._capture_body("hop>10")
+        self.assertEqual(self._terms_field("hop>10"), "traces.hops.ipaddr")
+        self.assertEqual(body["aggs"]["patterns"]["nested"], {"path": "traces.hops"})
+        inner_filter = body["aggs"]["patterns"]["aggs"]["patterns"]["filter"]
+        self.assertEqual(inner_filter, {"range": {"traces.hops.ttl": {"gt": 10}}})
+
+    # -- file ---------------------------------------------------------
+
+    def test_topvalues_file_default_filename(self):
+        self.assertEqual(
+            self._terms_field("file"),
+            "ports.scripts.ls.volumes.files.filename",
+        )
+
+    def test_topvalues_file_subkey(self):
+        self.assertEqual(
+            self._terms_field("file.uid"),
+            "ports.scripts.ls.volumes.files.uid",
+        )
+
+    def test_topvalues_file_with_scripts(self):
+        body = self._capture_body("file:nfs-ls,smb-ls")
+        self.assertEqual(
+            self._terms_field("file:nfs-ls,smb-ls"),
+            "ports.scripts.ls.volumes.files.filename",
+        )
+        # ``searchfile(scripts=[...])`` filter lands in the
+        # host query.
+        self.assertIn("nfs-ls", str(body["query"]))
+
+    def test_topvalues_file_with_scripts_and_subkey(self):
+        self.assertEqual(
+            self._terms_field("file:nfs-ls.size"),
+            "ports.scripts.ls.volumes.files.size",
+        )
+
+    # -- vulns --------------------------------------------------------
+
+    def test_topvalues_vulns_id_aggregates_id_field(self):
+        self.assertEqual(self._terms_field("vulns.id"), "ports.scripts.vulns.id")
+
+    def test_topvalues_vulns_other_emits_id_tuple(self):
+        # ``vulns.<other>`` returns a ``(id, <other>)``
+        # tuple via a painless concat.
+        source = self._terms_script_source("vulns.state")
+        self.assertIn("ports.scripts.vulns.id", source)
+        self.assertIn("ports.scripts.vulns.state", source)
+
+    # -- screenwords --------------------------------------------------
+
+    def test_topvalues_screenwords_aggregates_array_field(self):
+        self.assertEqual(self._terms_field("screenwords"), "ports.screenwords")
+
+    # -- sshkey -------------------------------------------------------
+
+    def test_topvalues_sshkey_bits_emits_type_bits_tuple(self):
+        source = self._terms_script_source("sshkey.bits")
+        self.assertIn("ports.scripts.ssh-hostkey.type", source)
+        self.assertIn("ports.scripts.ssh-hostkey.bits", source)
+
+    def test_topvalues_sshkey_passthrough_other_key(self):
+        self.assertEqual(
+            self._terms_field("sshkey.fingerprint"),
+            "ports.scripts.ssh-hostkey.fingerprint",
+        )
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Last sub-PR for ``ElasticDBActive.topvalues`` parity: implement the Tier-2 topvalues branches Mongo ships under :meth:`MongoDB.topvalues` but the Elastic backend was silently routing through the catch-all (``else: field = {"field": field}``) -- which emitted aggregations against non-existent literal fields and returned empty bucket lists instead of errors.  With this PR the Elasticsearch backend covers every ``topvalues`` field exercised by
``tests/tests.py``'s view test method, so the wholesale ``if DATABASE == "elastic": return`` skip block at ``tests/tests.py:4201`` (which gated all the post-tag-test assertions on Elastic) is removed and the Elasticsearch CI lane runs the full method.

New branches (``ElasticDBActive.topvalues``):

* ``ntlm`` / ``ntlm.<key>`` -- pass-through to ``ports.scripts.ntlm-info[.<key>]`` with the same nine friendly-name aliases the SQL backend ships (``os`` -> ``Product_Version``, ``domain`` -> ``NetBIOS_Domain_Name``, ...).
* ``smb`` / ``smb.<key>`` -- pass-through to ``ports.scripts.smb-os-discovery[.<key>]``; ``searchsmb()`` scopes the host filter.
* ``modbus.<key>`` -- pass-through to ``ports.scripts.modbus-discover.<key>``; covers the ``view_top_modbus_deviceids`` assertion that lived behind the wholesale skip block.
* ``devicetype`` / ``devicetype:<port>`` -- top values of the per-port ``service_devicetype`` field; the ``:<port>`` form constrains via :meth:`searchport`.
* ``cpe`` / ``cpe.<part>`` / ``cpe:<spec>`` / ``cpe.<part>:<spec>`` -- painless-script tuple projection of the kept CPE keys (with ``size() == 0`` guards on each so partial CPE entries do not crash the script); single-kept-key form collapses to a flat ``terms(field=cpes.<part>)`` aggregation. ``searchcpe`` scopes the host filter.
* ``hop`` -- top values of ``traces.hops.ipaddr`` (native ``ip`` type, no int128 split needed).
* ``hop:<ttl>`` / ``hop>N`` -- TTL filter (equality vs range) on ``traces.hops.ttl``; same projection.
* ``file`` / ``file.<key>`` / ``file:<scripts>`` / ``file:<scripts>.<key>`` -- top values of ``ports.scripts.ls.volumes.files.<key>`` (defaults to ``filename``) with optional script-id constraint via :meth:`searchfile`.
* ``vulns.id`` -- pass-through to ``ports.scripts.vulns.id``.
* ``vulns.<other>`` -- painless-tuple of ``(id, <other>)`` so the caller can correlate the field back to the specific vulnerability; same shape Mongo emits via the ``$concat`` pipeline + ``outputproc.split``.
* ``screenwords`` -- top values of ``ports.screenwords``; ``searchscreenshot(words=True)`` scopes the host filter.
* ``sshkey.bits`` -- painless-tuple of ``(type, bits)`` for ``ssh-hostkey`` entries.
* ``sshkey.<other>`` -- pass-through to ``ports.scripts.ssh-hostkey.<other>``.

Tests:

* New ``ElasticDBTopValuesTier2Tests`` in ``tests/tests_no_backend.py``: 21 pin tests covering every branch -- the friendly-name alias map for ntlm.<key>, the painless-script shape for the tuple branches (cpe / vulns.<other> / sshkey.bits), the single-kept-key collapse on ``cpe.<part>``, the range-vs-equality TTL filter for ``hop:<ttl>`` / ``hop>N``, and the per-script-id constraint on ``file:<scripts>``.
* ``tests/tests.py:4201`` -- the wholesale Elasticsearch skip block is removed.  The full view test method now runs against the Elasticsearch CI lane: cert / cacert topvalues (M4.5.4), cpe / hop / smb / file / modbus / devicetype / vulns / screenwords / sshkey / ntlm topvalues (this PR), plus the searchproduct / searchscript / searchtorcert / searchntlm count assertions that work via inheritance from M4.5.1-3.