### PR TITLE
feat(db/sql): add Host + augmented Flow schema for SQLDBFlow

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -61,6 +61,7 @@ from ivre.db import DB, DBActive, DBFlow, DBNmap, DBPassive, DBView
 from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
     Flow,
+    Host,
     N_Association_Scan_Category,
     N_Association_Scan_Hostname,
     N_Category,
@@ -721,8 +722,14 @@ class SQLDB(DB):
 
 
 class SQLDBFlow(SQLDB, DBFlow):
-    table_layout = namedtuple("flow_layout", ["flow"])
-    tables = table_layout(Flow)
+    # ``host`` is the per-address endpoint table referenced by
+    # :attr:`Flow.src` / :attr:`Flow.dst`; SQL diverges from
+    # Mongo's inline ``src_addr_0`` / ``src_addr_1`` columns to
+    # let ``host_details`` resolve a node to its incident flows
+    # via an indexed lookup instead of a table scan.  Both
+    # tables are defined in :mod:`ivre.db.sql.tables`.
+    table_layout = namedtuple("flow_layout", ["host", "flow"])
+    tables = table_layout(Host, Flow)
 
     @staticmethod
     def query(*args, **kargs):

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -20,6 +20,7 @@
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Column,
     DateTime,
     Float,
@@ -31,6 +32,7 @@ from sqlalchemy import (
     Sequence,
     String,
     Text,
+    UniqueConstraint,
     cast,
     func,
     literal_column,
@@ -252,7 +254,65 @@ Base = declarative_base()
 
 
 # Flow
+#
+# Schema mirrors :class:`MongoDBFlow` (``ivre/db/mongo.py:6176``);
+# every flow record has the same logical columns on both
+# backends, with two structural differences:
+#
+# * Mongo stores the source / destination addresses inline on the
+#   flow record as ``src_addr_0`` / ``src_addr_1`` (int128 split).
+#   The SQL backend uses a separate :class:`Host` table with a
+#   native ``INET`` ``addr`` column and references it via
+#   ``flow.src`` / ``flow.dst`` foreign keys.  This lets the
+#   ``host_details`` / ``flow_details`` paths resolve a node to
+#   its set of incident flows with a single indexed lookup
+#   instead of scanning the flow table.
+#
+# * Mongo's ``times`` array (per-flow timeslot history, gated by
+#   ``config.FLOW_TIME``) is documented as MongoDB-only in
+#   ``ivre/flow.py:45-48`` (``FIELDS["times"] = "... (MongoDB
+#   backend only)"``).  The SQL schema does not carry it;
+#   ``flow_daily`` queries derive their per-bucket counts from
+#   ``firstseen`` / ``lastseen`` instead.
+#
+# All other Mongo flow fields (``count``, ``cspkts`` / ``scpkts`` /
+# ``csbytes`` / ``scbytes``, ``sports``, ``codes``, ``meta``,
+# ``schema_version``, ``type``) have direct counterparts here.
+# Per-flow byte / packet counters use ``BigInteger`` rather than
+# the historical ``Integer`` so long-lived flows from busy hosts
+# do not overflow at 2^31 -- the column was never populated
+# (``SQLDBFlow`` raised ``NotImplementedError`` on every write
+# path), so widening it has no migration cost.
+
+_seq_host_id = Sequence("seq_host_id")
 _seq_flow_id = Sequence("seq_flow_id")
+
+
+class Host(Base):
+    """Per-address record holding the endpoints of every
+    :class:`Flow` row.  Populated lazily by the flow ingestion
+    paths (:meth:`SQLDBFlow.any2flow` / ``conn2flow`` /
+    ``flow2flow``), which upsert one row per source / destination
+    address."""
+
+    __tablename__ = "host"
+    id = Column(
+        Integer,
+        _seq_host_id,
+        server_default=_seq_host_id.next_value(),
+        primary_key=True,
+    )
+    addr = Column(SQLINET, nullable=False)
+    firstseen = Column(DateTime)
+    lastseen = Column(DateTime)
+    __table_args__ = (
+        # ``addr`` is the natural key: every ingested flow looks
+        # up the host row by IP, so the unique index doubles as
+        # the upsert lookup index.
+        UniqueConstraint("addr", name="host_idx_addr"),
+        Index("host_idx_firstseen", "firstseen"),
+        Index("host_idx_lastseen", "lastseen"),
+    )
 
 
 class Flow(Base):
@@ -263,19 +323,72 @@ class Flow(Base):
         server_default=_seq_flow_id.next_value(),
         primary_key=True,
     )
-    proto = Column(String(32), index=True)
-    dport = Column(Integer, index=True)
+    proto = Column(String(32))
+    # Destination port for ``tcp`` / ``udp``; ICMP records leave
+    # this ``NULL`` and use :attr:`type` instead.  Mirrors Mongo's
+    # ``MongoDBFlow._get_flow_key`` dispatch
+    # (``ivre/db/mongo.py:6242``).
+    dport = Column(Integer)
+    type = Column(Integer)
     src = Column(Integer, ForeignKey("host.id", ondelete="RESTRICT"))
     dst = Column(Integer, ForeignKey("host.id", ondelete="RESTRICT"))
     firstseen = Column(DateTime)
     lastseen = Column(DateTime)
-    scpkts = Column(Integer)
-    scbytes = Column(Integer)
-    cspkts = Column(Integer)
-    csbytes = Column(Integer)
+    # Cumulative packet / byte counters incremented on every
+    # repeated ingestion of the same flow tuple (see Mongo's
+    # ``conn2flow`` / ``flow2flow`` ``$inc`` blocks at
+    # ``ivre/db/mongo.py:6311`` and ``:6340``).  ``BigInteger``
+    # avoids 2^31 overflow on long-lived flows.
+    scpkts = Column(BigInteger)
+    scbytes = Column(BigInteger)
+    cspkts = Column(BigInteger)
+    csbytes = Column(BigInteger)
+    # Number of discrete observations aggregated into this row
+    # (incremented by ``conn2flow`` / ``flow2flow``, by
+    # ``meta.<name>.count`` for ``any2flow``).
+    count = Column(BigInteger)
+    # Set-valued source ports (tcp/udp) and ICMP codes; mirror
+    # Mongo's ``$addToSet`` semantics on the same column names.
     sports = Column(SQLARRAY(Integer))
+    codes = Column(SQLARRAY(Integer))
+    # Per-protocol metadata bag -- one sub-key per Zeek log type
+    # (``http``, ``ssh``, ``dns``, ...) following
+    # :data:`ivre.flow.META_DESC`.  JSONB so the per-protocol
+    # ``keys`` / ``counters`` shape matches Mongo's ``meta.<name>``
+    # sub-document one-for-one without a migration when new Zeek
+    # log types are added.
+    meta = Column(SQLJSONB)
+    # Bound to :data:`ivre.flow.SCHEMA_VERSION`; written by every
+    # ingestion path so future ``_migrate_schema_NN_MM`` helpers
+    # can scope updates to specific generations.
+    schema_version = Column(Integer)
     __table_args__ = (
-        # Index('host_idx_tag_addr', 'tag', 'addr', unique=True),
+        # Composite index covering the upsert lookup key Mongo
+        # uses in ``MongoDBFlow._get_flow_key``: TCP/UDP rows
+        # match on (src, dst, proto, dport, schema_version), ICMP
+        # rows on (src, dst, proto, type, schema_version).  A
+        # single B-tree index over the union covers both shapes
+        # because ``dport`` / ``type`` are mutually exclusive
+        # (one is always NULL).
+        Index(
+            "flow_idx_lookup",
+            "src",
+            "dst",
+            "proto",
+            "dport",
+            "type",
+            "schema_version",
+        ),
+        Index("flow_idx_proto", "proto"),
+        Index("flow_idx_dport", "dport"),
+        Index("flow_idx_schema_version", "schema_version"),
+        Index("flow_idx_firstseen", "firstseen"),
+        Index("flow_idx_lastseen", "lastseen"),
+        Index("flow_idx_count", "count"),
+        Index("flow_idx_cspkts", "cspkts"),
+        Index("flow_idx_scpkts", "scpkts"),
+        Index("flow_idx_csbytes", "csbytes"),
+        Index("flow_idx_scbytes", "scbytes"),
     )
 
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -6374,6 +6374,206 @@ class SQLDBTopValuesResidualTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBFlowSchemaTests -- pin the SQL Flow purpose schema (host +
+# flow tables, columns, types, indexes, foreign keys).  These pin
+# the structural contract subsequent SQLDBFlow ingestion / query
+# helpers will rely on; a regression here surfaces immediately as
+# a column-name / type / index mismatch instead of a broken
+# upsert under load.
+# ---------------------------------------------------------------------
+
+
+try:
+    from ivre.db.sql import SQLDBFlow as _SQLDBFlow_for_schema_test  # noqa: F401
+    from ivre.db.sql.tables import Flow as _Flow_for_schema_test
+    from ivre.db.sql.tables import Host as _Host_for_schema_test
+
+    _HAVE_SQLDB_FLOW = True
+except ImportError:
+    _HAVE_SQLDB_FLOW = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_FLOW,
+    "SQLAlchemy is required for SQLDBFlowSchemaTests",
+)
+class SQLDBFlowSchemaTests(unittest.TestCase):
+    """Structural pin tests for the SQL Flow schema.
+
+    Mirrors :class:`MongoDBFlow` (``ivre/db/mongo.py:6176``) on the
+    columns the ingestion / query paths read.  Two intentional
+    divergences are pinned here so a future refactor cannot
+    silently revert them:
+
+    * Mongo stores source / destination addresses inline as
+      ``src_addr_0`` / ``src_addr_1``; the SQL backend uses a
+      separate :class:`Host` table referenced via ``flow.src`` /
+      ``flow.dst`` foreign keys.
+    * Mongo's ``times`` array (per-flow timeslot history) is
+      MongoDB-only per ``ivre/flow.py:45-48``; the SQL schema
+      omits it.
+    """
+
+    def test_host_table_columns(self):
+        cols = {c.name: c for c in _Host_for_schema_test.__table__.columns}
+        self.assertEqual(set(cols), {"id", "addr", "firstseen", "lastseen"})
+        self.assertTrue(cols["id"].primary_key)
+        # ``addr`` must be NOT NULL: it is the natural key the
+        # ingestion path looks up before inserting flow rows.
+        self.assertFalse(cols["addr"].nullable)
+        # ``addr`` uses the dialect-aware ``SQLINET``
+        # (``postgresql.INET`` with a DuckDB-flavoured literal
+        # processor); confirm we did not regress to plain
+        # ``String``.
+        self.assertEqual(cols["addr"].type.__class__.__name__, "INETLiteral")
+
+    def test_host_table_unique_addr(self):
+        # The ``host`` table needs a UNIQUE constraint on ``addr``
+        # so the ingestion path can ``ON CONFLICT (addr) DO
+        # UPDATE`` without an extra serialisation lock.
+        unique_constraints = [
+            c
+            for c in _Host_for_schema_test.__table__.constraints
+            if c.__class__.__name__ == "UniqueConstraint"
+        ]
+        self.assertEqual(len(unique_constraints), 1)
+        self.assertEqual([col.name for col in unique_constraints[0].columns], ["addr"])
+
+    def test_host_table_indexes(self):
+        idx_names = {i.name for i in _Host_for_schema_test.__table__.indexes}
+        self.assertIn("host_idx_firstseen", idx_names)
+        self.assertIn("host_idx_lastseen", idx_names)
+
+    def test_flow_table_columns(self):
+        cols = {c.name: c for c in _Flow_for_schema_test.__table__.columns}
+        self.assertEqual(
+            set(cols),
+            {
+                "id",
+                "proto",
+                "dport",
+                "type",
+                "src",
+                "dst",
+                "firstseen",
+                "lastseen",
+                "scpkts",
+                "scbytes",
+                "cspkts",
+                "csbytes",
+                "count",
+                "sports",
+                "codes",
+                "meta",
+                "schema_version",
+            },
+        )
+        self.assertTrue(cols["id"].primary_key)
+        # ``dport`` and ``type`` are mutually exclusive depending
+        # on the protocol; both must be nullable.
+        self.assertTrue(cols["dport"].nullable)
+        self.assertTrue(cols["type"].nullable)
+
+    def test_flow_packet_byte_counters_use_bigint(self):
+        # ``BigInteger`` (not ``Integer``): cumulative byte
+        # counters on long-lived flows can exceed 2^31 within a
+        # single retention window; widening avoids silent overflow
+        # on every PostgreSQL upsert.
+        cols = {c.name: c for c in _Flow_for_schema_test.__table__.columns}
+        for name in ("scpkts", "scbytes", "cspkts", "csbytes", "count"):
+            self.assertEqual(
+                cols[name].type.__class__.__name__,
+                "BigInteger",
+                f"{name!r} must be BigInteger to avoid 2^31 overflow",
+            )
+
+    def test_flow_meta_is_jsonb(self):
+        # ``meta`` carries the per-protocol metadata bag mirroring
+        # Mongo's ``meta.<name>`` sub-document.  ``SQLJSONB`` is a
+        # ``postgresql.JSONB().with_variant(JSON(), "duckdb")``
+        # type so the same column compiles to ``JSONB`` on
+        # PostgreSQL and ``JSON`` on DuckDB.
+        cols = {c.name: c for c in _Flow_for_schema_test.__table__.columns}
+        self.assertEqual(cols["meta"].type.__class__.__name__, "JSONB")
+
+    def test_flow_sports_codes_are_integer_arrays(self):
+        cols = {c.name: c for c in _Flow_for_schema_test.__table__.columns}
+        for name in ("sports", "codes"):
+            self.assertEqual(
+                cols[name].type.__class__.__name__,
+                "ARRAY",
+                f"{name!r} must be a SQL ARRAY",
+            )
+            self.assertEqual(cols[name].type.item_type.__class__.__name__, "Integer")
+
+    def test_flow_src_dst_are_foreign_keys_to_host(self):
+        cols = {c.name: c for c in _Flow_for_schema_test.__table__.columns}
+        for name in ("src", "dst"):
+            fks = list(cols[name].foreign_keys)
+            self.assertEqual(len(fks), 1, f"{name!r} must have a single FK")
+            fk = fks[0]
+            # FK target table is ``host``; the ondelete clause
+            # is ``RESTRICT`` so a host row cannot disappear
+            # while flows still reference it.
+            self.assertEqual(fk.column.table.name, "host")
+            self.assertEqual(fk.column.name, "id")
+            self.assertEqual(fk.ondelete, "RESTRICT")
+
+    def test_flow_lookup_index_covers_upsert_key(self):
+        # The ingestion paths upsert flows on
+        # ``(src, dst, proto, dport-or-type, schema_version)``;
+        # the composite ``flow_idx_lookup`` must cover every
+        # lookup column in that order so the planner can use
+        # the index for the ``WHERE`` clause matching the
+        # upsert spec.
+        idx_by_name = {i.name: i for i in _Flow_for_schema_test.__table__.indexes}
+        self.assertIn("flow_idx_lookup", idx_by_name)
+        self.assertEqual(
+            [c.name for c in idx_by_name["flow_idx_lookup"].columns],
+            ["src", "dst", "proto", "dport", "type", "schema_version"],
+        )
+
+    def test_flow_individual_metric_indexes(self):
+        # Mirrors the per-metric indexes on
+        # ``MongoDBFlow.indexes`` (``mongo.py:6204-6212``).  Each
+        # of these is used by the ``flow filter`` UI for
+        # ``count = N``, ``firstseen >= ...``, ``cspkts > 1000``,
+        # etc.
+        idx_names = {i.name for i in _Flow_for_schema_test.__table__.indexes}
+        for expected in (
+            "flow_idx_proto",
+            "flow_idx_dport",
+            "flow_idx_schema_version",
+            "flow_idx_firstseen",
+            "flow_idx_lastseen",
+            "flow_idx_count",
+            "flow_idx_cspkts",
+            "flow_idx_scpkts",
+            "flow_idx_csbytes",
+            "flow_idx_scbytes",
+        ):
+            self.assertIn(
+                expected,
+                idx_names,
+                f"missing per-metric index {expected!r} -- "
+                "the flow filter UI relies on indexed lookups for "
+                "single-column predicates",
+            )
+
+    def test_sqldbflow_table_layout_includes_host(self):
+        # ``SQLDBFlow.tables`` is the namedtuple subsequent helpers
+        # read; the ingestion path needs ``self.tables.host``
+        # alongside ``self.tables.flow`` to perform the host
+        # upsert before linking the flow row.
+        self.assertEqual(
+            tuple(_SQLDBFlow_for_schema_test.table_layout._fields),
+            ("host", "flow"),
+        )
+        self.assertIs(_SQLDBFlow_for_schema_test.tables.host, _Host_for_schema_test)
+        self.assertIs(_SQLDBFlow_for_schema_test.tables.flow, _Flow_for_schema_test)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Lays the structural foundation for SQLDBFlow feature parity with MongoDBFlow.  The previous Flow table at ``tables.py:258`` referenced ``ForeignKey("host.id")`` against a non-existent ``host`` table and was missing the ``count``, ``type``, ``codes``, ``meta``, and ``schema_version`` columns Mongo writes on every flow document; the 4-line ``PostgresDBFlow(PostgresDB, SQLDBFlow): pass`` shell at ``postgres.py:337`` therefore could not have produced a valid schema even if the ingestion paths had been implemented.

This sub-PR is schema only -- the per-record write paths (``start_bulk_insert`` / ``any2flow`` / ``conn2flow`` / ``flow2flow`` / ``bulk_commit``) remain ``NotImplementedError`` on ``SQLDBFlow`` until the ingestion sub-PR lands.  Splitting the schema out lets the ingestion work review against a fixed, test-pinned shape.

Schema:

* New ``Host`` table (``ivre/db/sql/tables.py``): per-address endpoint record with ``id`` PK, ``addr`` (``SQLINET``, NOT NULL, UNIQUE), ``firstseen`` / ``lastseen``.  Indexed on ``firstseen`` and ``lastseen``; the ``UNIQUE(addr)`` constraint doubles as the upsert lookup index for the ingestion path (``ON CONFLICT (addr) DO UPDATE``).

* Augmented ``Flow`` table:
  - ``proto`` / ``dport`` (TCP/UDP) / ``type`` (ICMP) -- ``dport`` and ``type`` are mutually exclusive, both nullable; mirrors ``MongoDBFlow._get_flow_key`` (``mongo.py:6242``).
  - ``src`` / ``dst`` -- foreign keys to ``host.id`` with ``ondelete=RESTRICT`` so a host row cannot disappear while flows still reference it.
  - ``firstseen`` / ``lastseen`` -- per-flow observation window.
  - ``scpkts`` / ``scbytes`` / ``cspkts`` / ``csbytes`` / ``count`` -- cumulative counters, all ``BigInteger``.  The historical ``Integer`` was unused (``SQLDBFlow`` raised on every write) and would silently overflow at 2^31 for long-lived flows on busy hosts; widening now has no migration cost.
  - ``sports`` / ``codes`` -- ``SQLARRAY(Integer)`` set-valued columns; mirror Mongo's ``$addToSet`` semantics.
  - ``meta`` -- ``SQLJSONB`` (PG ``JSONB`` / DuckDB ``JSON``) holding the per-protocol metadata bag, one sub-key per Zeek log type as defined by ``ivre.flow.META_DESC``.
  - ``schema_version`` -- bound to ``ivre.flow.SCHEMA_VERSION``; written by every ingestion path so future ``_migrate_schema_NN_MM`` helpers can scope updates.

* Indexes (``Flow``):
  - Composite ``flow_idx_lookup`` on ``(src, dst, proto, dport, type, schema_version)`` -- single B-tree covering the upsert match key for both TCP/UDP and ICMP shapes (``dport`` and ``type`` are mutually exclusive, one is always NULL).
  - Per-metric indexes mirroring ``MongoDBFlow.indexes`` (``mongo.py:6204-6212``): ``proto``, ``dport``, ``schema_version``, ``firstseen``, ``lastseen``, ``count``, ``cspkts``, ``scpkts``, ``csbytes``, ``scbytes``.  Each is used by the ``flow filter`` UI for single-column predicates (``count = N``, ``firstseen >= ...``, ``cspkts > 1000``).

* ``SQLDBFlow.tables`` (``ivre/db/sql/__init__.py``): namedtuple layout extended from ``("flow",)`` to ``("host", "flow")`` so the ingestion path can reach ``self.tables.host`` for the per-address upsert before linking the flow row.

Two intentional divergences from ``MongoDBFlow`` are pinned by the new tests:

* Mongo stores source / destination addresses inline as ``src_addr_0`` / ``src_addr_1``; SQL uses a separate ``Host`` table with native ``INET``.  This lets the ``host_details`` helper (future sub-PR) resolve a node to its incident flows via an indexed lookup instead of a full flow scan.
* Mongo's ``times`` array is documented as MongoDB-only in ``ivre/flow.py:45-48``; the SQL schema omits it.  ``flow_daily`` queries derive their per-bucket counts from ``firstseen`` / ``lastseen`` instead.

Tests:

* New ``SQLDBFlowSchemaTests`` (11 tests) in ``tests/tests_no_backend.py`` pinning the column set, types (BigInteger / JSONB / ARRAY / INETLiteral), the ``UNIQUE(addr)`` constraint, the ``RESTRICT`` ondelete on the FKs, the composite ``flow_idx_lookup`` ordering, every per-metric index, and the ``SQLDBFlow.tables`` namedtuple shape.  Skipped when SQLAlchemy is not installed (test_utils pattern).