### PR TITLE
feat(db/sql): translate flow filters and project rows on SQLDBFlow

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -44,6 +44,7 @@ from sqlalchemy import (
     insert,
     join,
     not_,
+    null,
     nulls_first,
     or_,
     select,
@@ -54,6 +55,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import aliased
 
 from ivre import config, utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
@@ -721,6 +723,73 @@ class SQLDB(DB):
         return req
 
 
+class SQLFlowFilter:
+    """Wraps a parsed :class:`ivre.flow.Query` for the SQL
+    backend.
+
+    :meth:`SQLDBFlow.from_filters` returns one of these so the
+    ``flow.Query`` clauses can be deferred until query time --
+    the translation to a SQLAlchemy ``WHERE`` expression
+    happens inside :meth:`SQLDBFlow.get`, where the
+    ``src`` / ``dst`` :class:`Host` aliases are bound and can
+    be referenced by the ``addr`` / ``src.addr`` / ``dst.addr``
+    shortcuts.
+
+    The wrapper is intentionally small; richer filter-language
+    constructs (``=~`` regex, ``ANY`` / ``ALL`` / ``NONE``
+    array modes, ``LEN`` length mode) are layered on top in
+    follow-up work without changing the public ``from_filters``
+    return-type contract.
+    """
+
+    __slots__ = ("query",)
+
+    def __init__(self, query):
+        self.query = query
+
+    def __repr__(self):
+        return f"SQLFlowFilter(query={self.query!r})"
+
+
+# Translation table from IVRE's filter-language operator
+# tokens to the corresponding SQLAlchemy ``ColumnOperators``
+# magic methods.  ``:`` is the legacy "match" token Mongo
+# treats as ``$eq``; we map it the same way.
+_FLOW_FLT_OPS: dict[str, str] = {
+    ":": "__eq__",
+    "=": "__eq__",
+    "==": "__eq__",
+    "!=": "__ne__",
+    "<": "__lt__",
+    "<=": "__le__",
+    ">": "__gt__",
+    ">=": "__ge__",
+}
+
+
+# Direct column attributes on :class:`Flow` the filter
+# language can reference by their bare name (no ``meta.``
+# prefix, no ``src.`` / ``dst.`` prefix).  ``firstseen`` /
+# ``lastseen`` are split out below because the IVRE web
+# layer ships ISO-8601 strings and we coerce them to
+# :class:`datetime.datetime` before comparison.
+_FLOW_DIRECT_COLS: frozenset[str] = frozenset(
+    {
+        "proto",
+        "dport",
+        "type",
+        "count",
+        "cspkts",
+        "scpkts",
+        "csbytes",
+        "scbytes",
+        "schema_version",
+    }
+)
+
+_FLOW_DATE_COLS: frozenset[str] = frozenset({"firstseen", "lastseen"})
+
+
 class SQLDBFlow(SQLDB, DBFlow):
     # ``host`` is the per-address endpoint table referenced by
     # :attr:`Flow.src` / :attr:`Flow.dst`; SQL diverges from
@@ -782,16 +851,305 @@ class SQLDBFlow(SQLDB, DBFlow):
     def flow_details(self, flow_id):
         raise NotImplementedError()
 
+    @classmethod
     def from_filters(
-        self, filters, limit=None, skip=0, orderby="", mode=None, timeline=False
+        cls,
+        filters,
+        limit=None,
+        skip=0,
+        orderby="",
+        mode=None,
+        timeline=False,
+        after=None,
+        before=None,
+        precision=None,
     ):
-        raise NotImplementedError()
+        """Translate the web-UI / CLI filter dict into a
+        :class:`SQLFlowFilter` carrying the parsed
+        :class:`ivre.flow.Query`.
 
-    def to_graph(self, query):
-        raise NotImplementedError()
+        Mirrors :meth:`MongoDBFlow.from_filters` (which returns
+        a Mongo filter dict via ``flt_from_query``); the SQL
+        equivalent defers the per-clause SA expression building
+        to :meth:`get`, where the per-query ``Host`` aliases
+        are in scope for the ``addr`` / ``src.addr`` /
+        ``dst.addr`` shortcuts.
 
-    def to_iter(self, query):
-        raise NotImplementedError()
+        ``after`` / ``before`` / ``precision`` parameters mirror
+        the Mongo signature; they are accepted but ignored by
+        the SQL backend, which has no per-flow ``times`` array
+        (the field is documented as MongoDB-only in
+        :mod:`ivre.flow`).  ``limit`` / ``skip`` / ``orderby`` /
+        ``mode`` / ``timeline`` are accepted for the same
+        signature-compatibility reason and forwarded to the
+        base ``flow.Query`` builder, which itself ignores them.
+        """
+        query = super().from_filters(
+            filters,
+            limit=limit,
+            skip=skip,
+            orderby=orderby,
+            mode=mode,
+            timeline=timeline,
+        )
+        return SQLFlowFilter(query)
+
+    @classmethod
+    def _flow_col_for_attr(cls, attr, src_alias, dst_alias):
+        """Resolve a filter-language attribute path to the
+        SQLAlchemy column it should compare against.
+
+        ``addr`` is special-cased by the caller (it expands to
+        ``src.addr OR dst.addr`` and so cannot be a single
+        column).  ``src.addr`` / ``dst.addr`` resolve to the
+        per-side host alias's ``addr`` column.
+        ``meta.<proto>[.<key>]`` paths route through the
+        ``Flow.meta`` JSONB column via PostgreSQL's
+        ``->`` / ``->>`` accessors.  Plain column names land in
+        :data:`_FLOW_DIRECT_COLS` / :data:`_FLOW_DATE_COLS`.
+
+        Returns ``None`` when the attribute does not match any
+        known column shape; callers turn that into a
+        ``ValueError``.
+        """
+        if attr == "src.addr":
+            return src_alias.addr
+        if attr == "dst.addr":
+            return dst_alias.addr
+        if attr in _FLOW_DIRECT_COLS or attr in _FLOW_DATE_COLS:
+            return getattr(cls.tables.flow, attr)
+        if attr.startswith("meta."):
+            # ``meta.http`` -> ``meta -> 'http'``
+            # ``meta.http.method`` -> ``meta -> 'http' -> 'method'``
+            parts = attr.split(".")[1:]
+            col = cls.tables.flow.meta
+            for part in parts[:-1]:
+                col = col.op("->")(part)
+            # Last hop uses ``->>`` so the result is text and
+            # can be compared with ``=`` to the user's literal.
+            col = col.op("->>")(parts[-1])
+            return col
+        return None
+
+    @classmethod
+    def _coerce_flow_value(cls, attr, value):
+        """Coerce a filter-language literal to the Python type
+        the column expects.  ISO-8601 timestamps in the date
+        columns get parsed via :func:`utils.all2datetime`; all
+        other columns leave the value untouched (the SQLAlchemy
+        ``ColumnOperators`` handle their own coercion against
+        the column type)."""
+        if attr in _FLOW_DATE_COLS and isinstance(value, str):
+            return utils.all2datetime(value)
+        return value
+
+    @classmethod
+    def _flt_from_clause(cls, clause, src_alias, dst_alias):
+        """Translate a single :mod:`ivre.flow` clause into a
+        SQLAlchemy boolean expression.
+
+        Supported shapes:
+        * Simple comparison: ``attr op value``.
+        * Existence check: bare ``attr`` (no operator) ->
+          ``attr IS NOT NULL`` (or ``IS NULL`` under negation).
+        * ``addr op value`` -> ``(src.addr op value) OR
+          (dst.addr op value)``.
+        * Negation prefix (``!``, ``-``, ``~``) wraps the result
+          in :func:`not_`.
+
+        Deferred to follow-up sub-PRs:
+        * ``=~`` regex match.
+        * ``ANY`` / ``ALL`` / ``NONE`` / ``ONE`` array modes.
+        * ``LEN <attr> <op> <n>`` length mode.
+        """
+        if clause.get("array_mode") is not None:
+            raise NotImplementedError(
+                "array-mode filters (ANY/ALL/NONE/ONE) are not yet "
+                "supported on the SQL flow backend"
+            )
+        if clause.get("len_mode"):
+            raise NotImplementedError(
+                "LEN-mode filters are not yet supported on the SQL flow backend"
+            )
+        op_token = clause.get("operator")
+        if op_token == "=~":
+            raise NotImplementedError(
+                "regex filters (=~) are not yet supported on the SQL flow backend"
+            )
+        attr = clause["attr"]
+        neg = bool(clause.get("neg"))
+
+        # Bare attribute without an operator: existence check.
+        if op_token is None:
+            if attr == "addr":
+                expr = or_(src_alias.addr != null(), dst_alias.addr != null())
+            else:
+                col = cls._flow_col_for_attr(attr, src_alias, dst_alias)
+                if col is None:
+                    raise ValueError(f"Unknown flow filter attribute {attr!r}")
+                expr = col != null()
+            return not_(expr) if neg else expr
+
+        sa_op = _FLOW_FLT_OPS.get(op_token)
+        if sa_op is None:
+            raise ValueError(f"Unknown flow filter operator {op_token!r}")
+        value = cls._coerce_flow_value(attr, clause["value"])
+
+        if attr == "addr":
+            # ``addr`` matches either side of the flow.  ``!=``
+            # gets De Morgan'd into ``AND`` of ``!=`` so a host
+            # appearing on either side is correctly excluded.
+            src_expr = getattr(src_alias.addr, sa_op)(value)
+            dst_expr = getattr(dst_alias.addr, sa_op)(value)
+            expr = (
+                and_(src_expr, dst_expr)
+                if op_token == "!="
+                else or_(src_expr, dst_expr)
+            )
+            return not_(expr) if neg else expr
+
+        col = cls._flow_col_for_attr(attr, src_alias, dst_alias)
+        if col is None:
+            raise ValueError(f"Unknown flow filter attribute {attr!r}")
+        expr = getattr(col, sa_op)(value)
+        return not_(expr) if neg else expr
+
+    @classmethod
+    def _flt_from_query(cls, query, src_alias, dst_alias):
+        """Translate a :class:`flow.Query` (an AND of OR
+        groups) into a SQLAlchemy ``WHERE`` expression scoped
+        to the supplied per-side :class:`Host` aliases.
+
+        Returns :func:`true` when the query has no clauses so
+        the caller can plug the result straight into
+        ``select(...).where(...)``.
+        """
+        and_clauses = []
+        for or_group in query.clauses:
+            or_exprs = [cls._flt_from_clause(c, src_alias, dst_alias) for c in or_group]
+            if not or_exprs:
+                continue
+            and_clauses.append(or_exprs[0] if len(or_exprs) == 1 else or_(*or_exprs))
+        if not and_clauses:
+            return true()
+        if len(and_clauses) == 1:
+            return and_clauses[0]
+        return and_(*and_clauses)
+
+    @staticmethod
+    def _orderby_to_sa(orderby, src_alias, dst_alias):
+        """Translate IVRE's ``[(field, direction), ...]``
+        orderby convention into a list of SQLAlchemy
+        ``ColumnElement`` instances suitable for
+        ``select().order_by(*...)``.  ``direction`` is ``1``
+        for ascending or ``-1`` for descending; unknown fields
+        raise ``ValueError`` so a typo at the CLI surfaces
+        eagerly rather than silently sorting by a no-op.
+        """
+        if not orderby:
+            return []
+        out = []
+        for field, direction in orderby:
+            if field == "src.addr":
+                col = src_alias.addr
+            elif field == "dst.addr":
+                col = dst_alias.addr
+            elif field in _FLOW_DIRECT_COLS or field in _FLOW_DATE_COLS:
+                col = getattr(SQLDBFlow.tables.flow, field)
+            else:
+                raise ValueError(f"Unknown flow orderby field {field!r}")
+            out.append(desc(col) if direction == -1 else col)
+        return out
+
+    @staticmethod
+    def _row2flow(row):
+        """Project a JOINed (Flow, src_addr, dst_addr) row into
+        the dict shape :class:`MongoDBFlow.get` returns -- the
+        contract :func:`DBFlow._flow2host` /
+        :func:`DBFlow._edge2json_default` consume.
+
+        ``meta`` round-trips as a Python dict thanks to the
+        ``SQLJSONB`` column; ``sports`` / ``codes`` come out as
+        Python lists thanks to the ``SQLARRAY(Integer)`` column
+        type.
+        """
+        flow_obj, src_addr, dst_addr = row
+        return {
+            "_id": flow_obj.id,
+            "src_addr": str(src_addr) if src_addr is not None else None,
+            "dst_addr": str(dst_addr) if dst_addr is not None else None,
+            "proto": flow_obj.proto,
+            "dport": flow_obj.dport,
+            "type": flow_obj.type,
+            "firstseen": flow_obj.firstseen,
+            "lastseen": flow_obj.lastseen,
+            "cspkts": flow_obj.cspkts,
+            "scpkts": flow_obj.scpkts,
+            "csbytes": flow_obj.csbytes,
+            "scbytes": flow_obj.scbytes,
+            "count": flow_obj.count,
+            "sports": flow_obj.sports,
+            "codes": flow_obj.codes,
+            "meta": flow_obj.meta,
+            "schema_version": flow_obj.schema_version,
+        }
+
+    def get(self, spec, limit=None, skip=None, orderby=None, fields=None):
+        """Iterate flows matching ``spec`` (a :class:`SQLFlowFilter`
+        as returned by :meth:`from_filters`, or ``None`` for the
+        match-all case).  ``spec`` keeps the
+        :meth:`DB.get` parameter name so the inherited
+        :meth:`DBFlow.to_iter` / :meth:`DBFlow.to_graph`
+        helpers (which call ``self.get(flt, ...)``
+        positionally) keep working unchanged.
+
+        Each yielded row is a Mongo-shaped dict (see
+        :meth:`_row2flow`) so the inherited
+        :meth:`DBFlow.to_iter` / :meth:`DBFlow.to_graph` work
+        unchanged on top.
+
+        ``fields`` is accepted for API compatibility with
+        :meth:`DBActive.get` but ignored on the flow path: the
+        whole flow row is cheap to project (no nested array
+        unwinding), and downstream :func:`DBFlow.cursor2json_*`
+        helpers expect every column anyway.
+        """
+        del fields  # unused; signature parity with DBActive.get
+        src_alias = aliased(Host, name="flow_src_host")
+        dst_alias = aliased(Host, name="flow_dst_host")
+        if spec is None:
+            where = true()
+        elif isinstance(spec, SQLFlowFilter):
+            where = self._flt_from_query(spec.query, src_alias, dst_alias)
+        else:
+            # Allow callers to pass a pre-built SA expression
+            # (used by :meth:`host_details` / :meth:`flow_details`
+            # in follow-up sub-PRs that bypass the parser).
+            where = spec
+        stmt = (
+            select(
+                self.tables.flow,
+                src_alias.addr,
+                dst_alias.addr,
+            )
+            .select_from(
+                join(
+                    self.tables.flow,
+                    src_alias,
+                    self.tables.flow.src == src_alias.id,
+                ).join(dst_alias, self.tables.flow.dst == dst_alias.id)
+            )
+            .where(where)
+        )
+        for col in self._orderby_to_sa(orderby, src_alias, dst_alias):
+            stmt = stmt.order_by(col)
+        if skip:
+            stmt = stmt.offset(skip)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        with self.db.connect() as conn:
+            for row in conn.execute(stmt):
+                yield self._row2flow(row)
 
     def count(self, flt):
         raise NotImplementedError()

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -6574,6 +6574,335 @@ class SQLDBFlowSchemaTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBFlowFromFiltersTests -- pin the wire shape of the
+# ``from_filters`` -> ``get`` translation on ``SQLDBFlow``: the
+# parsed :class:`ivre.flow.Query` clauses must lower into the
+# expected SQLAlchemy ``WHERE`` expressions, and the JOINed
+# ``(Flow, src_addr, dst_addr)`` row must project into the
+# Mongo-shaped dict :func:`DBFlow._flow2host` /
+# :func:`DBFlow._edge2json_default` consume.  Without that
+# parity, the inherited :meth:`DBFlow.to_iter` /
+# :meth:`DBFlow.to_graph` (which feed the ``flowcli`` /
+# ``/cgi/flows`` paths) would silently return malformed graphs.
+# ---------------------------------------------------------------------
+
+
+try:
+    from ivre.db.sql import SQLDBFlow as _SQLDBFlow_for_filters_test
+    from ivre.db.sql import SQLFlowFilter as _SQLFlowFilter_for_filters_test
+    from ivre.db.sql.tables import Flow as _Flow_for_filters_test
+    from ivre.db.sql.tables import Host as _Host_for_filters_test
+
+    _HAVE_SQLDB_FLOW_FILTERS = True
+except ImportError:
+    _HAVE_SQLDB_FLOW_FILTERS = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_FLOW_FILTERS,
+    "SQLAlchemy is required for SQLDBFlowFromFiltersTests",
+)
+class SQLDBFlowFromFiltersTests(unittest.TestCase):
+    """Behaviour-pin for :meth:`SQLDBFlow.from_filters` and
+    :meth:`SQLDBFlow.get`.
+
+    Mirrors :meth:`MongoDBFlow.flt_from_query` (which produces
+    a Mongo filter dict via the same parsed
+    :class:`flow.Query`).  Every supported clause shape gets
+    its expected SQLAlchemy ``WHERE`` translation pinned to
+    the literal-binds-rendered SQL fragment, so a future
+    refactor of the translator cannot silently drift the two
+    backends apart.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        from sqlalchemy.dialects import postgresql
+
+        return str(
+            stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    @classmethod
+    def _where_sql(cls, filters):
+        """Compile ``from_filters(filters)`` -> SA ``WHERE``
+        expression -> PostgreSQL fragment for assertion."""
+        from sqlalchemy import select
+        from sqlalchemy.orm import aliased
+
+        flt = _SQLDBFlow_for_filters_test.from_filters(filters)
+        src = aliased(_Host_for_filters_test, name="src_h")
+        dst = aliased(_Host_for_filters_test, name="dst_h")
+        where = _SQLDBFlow_for_filters_test._flt_from_query(flt.query, src, dst)
+        return cls._compile_pg(select(_Flow_for_filters_test.id).where(where))
+
+    # -- return type --------------------------------------------------
+
+    def test_from_filters_returns_sqlflow_filter(self):
+        # ``from_filters`` does not eagerly translate the
+        # ``flow.Query`` clauses -- it returns a wrapper so the
+        # SA expression can be built later, when the per-query
+        # ``Host`` aliases are bound inside :meth:`get`.
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        self.assertIsInstance(flt, _SQLFlowFilter_for_filters_test)
+        # Empty filters -> empty clauses list (no AND of ORs).
+        self.assertEqual(flt.query.clauses, [])
+
+    # -- direct-column comparisons ------------------------------------
+
+    def test_proto_equality(self):
+        # Plain ``proto = tcp`` lowers to a flat
+        # ``flow.proto = 'tcp'`` predicate; no JOIN, no host
+        # alias reference -- SA prunes the unused FROM list.
+        sql = self._where_sql({"edges": ["proto = tcp"]})
+        self.assertIn("flow.proto = 'tcp'", sql)
+        self.assertNotIn("host", sql)
+
+    def test_count_gt(self):
+        sql = self._where_sql({"edges": ["count > 5"]})
+        self.assertIn("flow.count > 5", sql)
+
+    def test_negation_swaps_to_neq(self):
+        # ``!proto = tcp`` lowers to ``flow.proto != 'tcp'``;
+        # the translator wraps the comparison in ``NOT(...)``
+        # rather than swapping operators (the SQL planner
+        # inverts the comparison itself).  The flow filter
+        # parser only treats ``!`` as a negation prefix when
+        # it directly precedes the attribute (no separating
+        # whitespace), matching Mongo's
+        # :meth:`MongoDBFlow.flt_from_clause` convention.
+        sql = self._where_sql({"edges": ["!proto = tcp"]})
+        self.assertIn("flow.proto != 'tcp'", sql)
+
+    # -- AND / OR composition -----------------------------------------
+
+    def test_and_composition(self):
+        # Multiple clauses without an explicit ``OR`` are
+        # AND-ed together at the top level.
+        sql = self._where_sql({"edges": ["proto = tcp", "dport = 443"]})
+        self.assertIn("flow.proto = 'tcp'", sql)
+        self.assertIn("flow.dport = 443", sql)
+        self.assertIn(" AND ", sql)
+
+    def test_or_composition(self):
+        sql = self._where_sql({"edges": ["proto = tcp || proto = udp"]})
+        self.assertIn(" OR ", sql)
+
+    # -- addr / src.addr / dst.addr -----------------------------------
+
+    def test_addr_shortcut_expands_to_or(self):
+        # ``addr = X`` expands to ``src_h.addr = X OR
+        # dst_h.addr = X``: the JOINs to both ``Host`` aliases
+        # come from the surrounding :meth:`get` query, but the
+        # WHERE expression itself references both aliases'
+        # ``addr`` columns.
+        sql = self._where_sql({"nodes": ["addr = 1.2.3.4"]})
+        self.assertIn("src_h.addr", sql)
+        self.assertIn("dst_h.addr", sql)
+        self.assertIn(" OR ", sql)
+
+    def test_addr_neq_uses_and(self):
+        # ``addr != X`` is the De Morgan dual of ``addr = X``:
+        # exclude flows where *either* side matches, i.e.
+        # ``src_h.addr != X AND dst_h.addr != X``.  Without
+        # this special-case, ``OR`` would let through every
+        # flow where the *other* side does not match.
+        sql = self._where_sql({"nodes": ["addr != 1.2.3.4"]})
+        self.assertIn("src_h.addr !=", sql)
+        self.assertIn("dst_h.addr !=", sql)
+        self.assertIn(" AND ", sql)
+
+    def test_src_addr_only(self):
+        sql = self._where_sql({"nodes": ["src.addr = 1.2.3.4"]})
+        self.assertIn("src_h.addr = ", sql)
+        self.assertNotIn("dst_h.addr", sql)
+
+    def test_dst_addr_only(self):
+        sql = self._where_sql({"nodes": ["dst.addr = 1.2.3.4"]})
+        self.assertIn("dst_h.addr = ", sql)
+        self.assertNotIn("src_h.addr", sql)
+
+    # -- existence (no operator) --------------------------------------
+
+    def test_bare_attr_is_existence_check(self):
+        # ``proto`` (no operator) -> ``flow.proto IS NOT NULL``.
+        sql = self._where_sql({"edges": ["proto"]})
+        self.assertIn("flow.proto IS NOT NULL", sql)
+
+    def test_bare_attr_negated_is_null_check(self):
+        # SQLAlchemy folds ``NOT (col IS NOT NULL)`` straight
+        # into ``col IS NULL`` (and ditto for the addr-OR
+        # case).  Pin the simplified shape so a future
+        # rewrite of the translator that emits an explicit
+        # ``NOT`` wrapper without the simplification surfaces
+        # in this test instead of silently changing the
+        # rendered SQL.
+        sql = self._where_sql({"edges": ["!proto"]})
+        self.assertIn("flow.proto IS NULL", sql)
+
+    # -- meta.<proto>[.<key>] paths -----------------------------------
+
+    def test_meta_proto_existence(self):
+        # ``meta.http`` (bare) -> ``meta ->> 'http' IS NOT
+        # NULL``: the JSONB ``->>`` extractor returns ``NULL``
+        # when the key is absent, so the existence check
+        # composes naturally.
+        sql = self._where_sql({"edges": ["meta.http"]})
+        self.assertIn("meta", sql)
+        self.assertIn("'http'", sql)
+        self.assertIn("IS NOT NULL", sql)
+
+    def test_meta_proto_key_equality(self):
+        # ``meta.http.method = GET`` -> ``(meta -> 'http') ->>
+        # 'method' = 'GET'``.  Intermediate hops use ``->`` so
+        # they keep the JSONB shape; only the leaf hops uses
+        # ``->>`` to produce a comparable text value.
+        sql = self._where_sql({"edges": ["meta.http.method = GET"]})
+        self.assertIn("'http'", sql)
+        self.assertIn("'method'", sql)
+        self.assertIn("'GET'", sql)
+
+    # -- date columns -------------------------------------------------
+
+    def test_firstseen_iso_string_is_coerced_to_datetime(self):
+        # IVRE's web layer ships ISO-8601 timestamps; the
+        # translator routes them through
+        # :func:`utils.all2datetime` so SQLAlchemy renders them
+        # with the right ``TIMESTAMP`` literal.
+        sql = self._where_sql({"edges": ["firstseen >= 2024-01-01 00:00:00"]})
+        self.assertIn("flow.firstseen >= ", sql)
+        self.assertIn("'2024-01-01 00:00:00'", sql)
+
+    # -- error paths --------------------------------------------------
+
+    def test_unknown_attribute_raises(self):
+        # Typos / unknown columns surface eagerly rather than
+        # silently being lowered to ``NULL = ...``.
+        with self.assertRaises(ValueError):
+            self._where_sql({"edges": ["bogus_col = 5"]})
+
+    def test_array_mode_raises_not_implemented(self):
+        # ``ANY`` / ``ALL`` / ``NONE`` / ``ONE`` array modes
+        # are deferred to follow-up SQL flow work; the
+        # translator surfaces the gap explicitly so a CLI
+        # caller does not silently get an empty result set.
+        with self.assertRaises(NotImplementedError):
+            self._where_sql({"edges": ["ANY sports = 80"]})
+
+    def test_len_mode_raises_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self._where_sql({"edges": ["LEN sports > 0"]})
+
+    def test_regex_operator_raises_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self._where_sql({"edges": ["proto =~ tcp"]})
+
+    # -- _row2flow projection -----------------------------------------
+
+    def test_row2flow_returns_mongo_shaped_dict(self):
+        # The base ``DBFlow.cursor2json_iter`` consumes flow
+        # rows via ``row.get("addr")`` / ``row.get("_id")`` /
+        # ``row.get("proto")`` / etc.  Pin the per-key
+        # projection so the SA-row -> dict conversion stays
+        # compatible with the inherited helpers; without it,
+        # ``to_iter`` / ``to_graph`` would silently emit empty
+        # graph nodes.
+        class _FakeFlow:
+            id = 42
+            proto = "tcp"
+            dport = 443
+            type = None
+            firstseen = "2024-01-01"
+            lastseen = "2024-01-02"
+            scpkts = 100
+            scbytes = 4000
+            cspkts = 80
+            csbytes = 3500
+            count = 3
+            sports = [50000, 50001]
+            codes = None
+            meta = {"http": {"method": "GET"}}
+            schema_version = 1
+
+        rec = _SQLDBFlow_for_filters_test._row2flow(
+            (_FakeFlow(), "10.0.0.1", "10.0.0.2")
+        )
+        self.assertEqual(rec["_id"], 42)
+        self.assertEqual(rec["src_addr"], "10.0.0.1")
+        self.assertEqual(rec["dst_addr"], "10.0.0.2")
+        self.assertEqual(rec["proto"], "tcp")
+        self.assertEqual(rec["dport"], 443)
+        self.assertEqual(rec["sports"], [50000, 50001])
+        self.assertEqual(rec["meta"], {"http": {"method": "GET"}})
+        # Exhaustive key set so a new column added to ``Flow``
+        # shows up in the projection or fails the test.
+        self.assertEqual(
+            set(rec),
+            {
+                "_id",
+                "src_addr",
+                "dst_addr",
+                "proto",
+                "dport",
+                "type",
+                "firstseen",
+                "lastseen",
+                "scpkts",
+                "scbytes",
+                "cspkts",
+                "csbytes",
+                "count",
+                "sports",
+                "codes",
+                "meta",
+                "schema_version",
+            },
+        )
+
+    def test_row2flow_preserves_none_addresses(self):
+        # ``src_addr`` / ``dst_addr`` come from the JOIN; if a
+        # downstream consumer ever passes a NULL (e.g. a
+        # placeholder dangling pointer), ``_row2flow`` keeps
+        # that as ``None`` rather than the string ``"None"``.
+        class _FakeFlow:
+            id = 1
+            proto = None
+            dport = None
+            type = None
+            firstseen = None
+            lastseen = None
+            scpkts = None
+            scbytes = None
+            cspkts = None
+            csbytes = None
+            count = None
+            sports = None
+            codes = None
+            meta = None
+            schema_version = None
+
+        rec = _SQLDBFlow_for_filters_test._row2flow((_FakeFlow(), None, None))
+        self.assertIsNone(rec["src_addr"])
+        self.assertIsNone(rec["dst_addr"])
+
+    # -- to_iter / to_graph delegate to the base class ----------------
+
+    def test_to_iter_inherited_from_dbflow(self):
+        # The ``NotImplementedError`` stubs in ``SQLDBFlow``
+        # (``to_iter`` / ``to_graph``) were dropped so the
+        # base-class versions in :class:`DBFlow` take over;
+        # both delegate to ``self.get(...)``, which now works
+        # on the SQL backend.
+        from ivre.db import DBFlow
+
+        self.assertIs(_SQLDBFlow_for_filters_test.to_iter, DBFlow.to_iter)
+        self.assertIs(_SQLDBFlow_for_filters_test.to_graph, DBFlow.to_graph)
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Implements the read-side glue the next sub-PR (count / flow_daily / topvalues / top) and the existing inherited DBFlow.to_iter / to_graph helpers depend on.

The previous SQLDBFlow stub raised NotImplementedError on from_filters / to_iter / to_graph; the schema work that landed previously could not be exercised end-to-end.

API contract:

* ``from_filters(filters, ...)`` -> ``SQLFlowFilter``.  The wrapper carries a parsed :class:`ivre.flow.Query` so the per-clause SQLAlchemy expression can be deferred until query time, where the per-query ``Host`` aliases are in scope for the ``addr`` / ``src.addr`` / ``dst.addr`` shortcuts.  ``MongoDBFlow.from_filters`` already returns a Mongo filter dict via ``flt_from_query`` for the same reason; the SQL wrapper is the smallest analogue that keeps the public return-type contract clean.

* ``get(spec, limit, skip, orderby, fields)`` -- runs ``SELECT flow.*, src_h.addr, dst_h.addr`` with the JOINs to the per-side ``Host`` aliases, applies the WHERE expression built from the ``SQLFlowFilter``, and yields one Mongo-shaped dict per row via ``_row2flow``.  The parameter is named ``spec`` for parity with ``DB.get``; ``DBFlow.to_iter`` / ``to_graph`` call us positionally with their ``flt`` argument.

* ``to_iter`` / ``to_graph`` -- the ``raise NotImplementedError`` stubs are dropped; the base-class versions in :class:`DBFlow` (which delegate to ``self.get(...)`` and ``cursor2json_iter`` / ``cursor2json_graph``) take over unchanged.

Filter language coverage:

* Direct-column comparisons: ``proto`` / ``dport`` / ``type`` / ``count`` / ``cspkts`` / ``scpkts`` / ``csbytes`` / ``scbytes`` / ``schema_version`` / ``firstseen`` / ``lastseen`` (the date columns coerce ISO-8601 strings via :func:`utils.all2datetime`).
* ``addr op value`` -> ``(src.addr op value) OR (dst.addr op value)`` for ``=`` / ``==`` / ``:`` / ``<`` / ``<=`` / ``>`` / ``>=``; the ``!=`` shape uses ``AND`` (the De Morgan dual) so a host appearing on either side is correctly excluded.
* ``src.addr`` / ``dst.addr`` -> per-side host alias.
* ``meta.<proto>[.<key>]`` -> ``flow.meta`` JSONB path access via PostgreSQL's ``->`` / ``->>`` accessors.  Bare ``meta.<proto>`` becomes an existence check (``meta ->> '<proto>' IS NOT NULL``).
* Bare attribute (no operator) -> ``IS NOT NULL`` / ``IS NULL`` (under negation).
* Negation prefix (``!`` / ``-`` / ``~``) -> ``NOT(...)`` wrapper (SQLAlchemy folds ``NOT (col IS NOT NULL)`` into ``col IS NULL`` automatically).
* AND / OR composition through the ``flow.Query`` clause list ([[c1, c2], [c3]] -> ``(c1 OR c2) AND c3``).

Explicitly deferred (raise ``NotImplementedError`` with a specific message, so callers do not silently get an empty result set):

* ``=~`` regex filters.
* ``ANY`` / ``ALL`` / ``NONE`` / ``ONE`` array modes.
* ``LEN <attr> <op> <n>`` length mode.

Tests:

* New ``SQLDBFlowFromFiltersTests`` (22 pin tests) in ``tests/tests_no_backend.py``.  Covers every supported clause shape (compiled to PostgreSQL via ``literal_binds`` and asserted against the rendered SQL fragment), the ``_row2flow`` projection, the Mongo-shape key set, and every deferred / unknown-attribute error path.  Pins that the dropped ``to_iter`` / ``to_graph`` stubs now resolve to :class:`DBFlow`'s methods through the inheritance chain.