### PR TITLE
feat(db/sql): aggregate flows -- count, flow_daily, topvalues, top

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -1151,18 +1151,256 @@ class SQLDBFlow(SQLDB, DBFlow):
             for row in conn.execute(stmt):
                 yield self._row2flow(row)
 
-    def count(self, flt):
-        raise NotImplementedError()
+    def _build_where(self, spec, src_alias, dst_alias):
+        """Return the SQLAlchemy ``WHERE`` expression for a
+        :class:`SQLFlowFilter` / pre-built SA expression /
+        ``None`` (match-all)."""
+        if spec is None:
+            return true()
+        if isinstance(spec, SQLFlowFilter):
+            return self._flt_from_query(spec.query, src_alias, dst_alias)
+        return spec
 
-    def flow_daily(self, query):
-        raise NotImplementedError()
+    def _flow_join(self, src_alias, dst_alias):
+        """Return the canonical
+        ``flow JOIN host AS src_h JOIN host AS dst_h`` join
+        expression.  Pulled out as a tiny helper because every
+        read-side method (``get`` / ``count`` /
+        ``flow_daily`` / ``topvalues``) needs the same join."""
+        return join(
+            self.tables.flow,
+            src_alias,
+            self.tables.flow.src == src_alias.id,
+        ).join(dst_alias, self.tables.flow.dst == dst_alias.id)
 
-    def top(self, query, fields, collect=None, sumfields=None):
-        """Returns an iterator of:
-        {fields: <fields>, count: <number of occurrence or sum of sumfields>,
-         collected: <collected fields>}.
+    @classmethod
+    def _topvalues_col(cls, field, src_alias, dst_alias):
+        """Resolve a ``topvalues`` field name to the
+        SQLAlchemy expression to GROUP BY / aggregate against.
+
+        Mirrors :meth:`MongoDBFlow.topvalues`'s
+        ``special_fields`` translation table: ``src.addr`` /
+        ``dst.addr`` route through the per-side host alias's
+        ``addr`` column; the rest go through
+        :meth:`_flow_col_for_attr` which already handles
+        direct columns and ``meta.<proto>[.<key>]`` JSONB
+        paths.
         """
-        raise NotImplementedError()
+        if field == "src.addr":
+            return src_alias.addr
+        if field == "dst.addr":
+            return dst_alias.addr
+        col = cls._flow_col_for_attr(field, src_alias, dst_alias)
+        if col is None:
+            raise ValueError(f"Unsupported flow topvalues field {field!r}")
+        return col
+
+    def count(self, flt):
+        """Return ``{"clients": N, "servers": M, "flows": K}``
+        for the matching flows -- mirrors
+        :meth:`MongoDBFlow.count` exactly.
+
+        ``clients`` / ``servers`` are computed as ``COUNT(DISTINCT
+        flow.src)`` / ``COUNT(DISTINCT flow.dst)`` rather than
+        Mongo's two-stage ``$group`` because PostgreSQL handles
+        ``DISTINCT`` aggregation natively (Mongo's pipeline
+        construction was a workaround for ``$count`` only being
+        available in 3.4+).
+        """
+        src_alias = aliased(Host, name="flow_src_host")
+        dst_alias = aliased(Host, name="flow_dst_host")
+        where = self._build_where(flt, src_alias, dst_alias)
+        stmt = (
+            select(
+                func.count().label("flows"),
+                func.count(self.tables.flow.src.distinct()).label("clients"),
+                func.count(self.tables.flow.dst.distinct()).label("servers"),
+            )
+            .select_from(self._flow_join(src_alias, dst_alias))
+            .where(where)
+        )
+        with self.db.connect() as conn:
+            row = conn.execute(stmt).one()
+        return {
+            "flows": int(row.flows or 0),
+            "clients": int(row.clients or 0),
+            "servers": int(row.servers or 0),
+        }
+
+    @staticmethod
+    def _flow_daily_buckets(rows, precision):
+        """Bucket ``(firstseen, proto, dport, type)`` rows by
+        time-of-day at ``precision`` granularity, accumulating
+        per-bucket ``proto/dport`` histograms.
+
+        Pulled out as a static helper so the bucketing logic
+        can be pin-tested without a live PostgreSQL
+        connection.  Yields the same ``{"flows": [(name,
+        count), ...], "time_in_day": datetime.time}`` dicts
+        :meth:`MongoDBFlow.flow_daily` produces, sorted by
+        time-of-day ascending.
+        """
+        buckets: dict[tuple[int, int, int], dict[str, int]] = {}
+        for row in rows:
+            ts = row.firstseen
+            if ts is None:
+                continue
+            second = ts.second
+            if precision and precision > 0:
+                second = (second // precision) * precision
+            key = (ts.hour, ts.minute, second)
+            if row.proto in ("tcp", "udp") and row.dport is not None:
+                name = f"{row.proto}/{int(row.dport)}"
+            elif row.type is not None:
+                name = f"{row.proto}/{int(row.type)}"
+            else:
+                name = row.proto or ""
+            bucket = buckets.setdefault(key, {})
+            bucket[name] = bucket.get(name, 0) + 1
+        for hour, minute, second in sorted(buckets):
+            yield {
+                "flows": list(buckets[(hour, minute, second)].items()),
+                "time_in_day": datetime.time(hour=hour, minute=minute, second=second),
+            }
+
+    def flow_daily(self, precision, flt, after=None, before=None):
+        """Yield per-time-bucket flow counts for the
+        ``flow daily`` UI / CLI plot.
+
+        Mirrors :meth:`MongoDBFlow.flow_daily`'s output shape:
+        each yielded dict carries ``{"flows": [("proto/dport",
+        count), ...], "time_in_day": datetime.time}``.
+
+        SQL diverges from the Mongo bucketing source -- Mongo
+        unwinds the per-flow ``times`` array (each timeslot is
+        recorded separately on the flow document); the SQL
+        schema has no ``times`` column (it is documented as
+        MongoDB-only in :mod:`ivre.flow`) so we bucket on
+        ``firstseen`` instead.  Each flow contributes once per
+        day (its first-observed timestamp), which under-counts
+        relative to Mongo for long-lived flows but is the most
+        faithful translation the schema supports.
+
+        ``after`` / ``before`` filter on ``firstseen`` (Mongo
+        applies them to ``times.start``); ``precision``
+        bucketing is implemented client-side so the same value
+        the Mongo backend honors works on SQL.
+        """
+        src_alias = aliased(Host, name="flow_src_host")
+        dst_alias = aliased(Host, name="flow_dst_host")
+        where = self._build_where(flt, src_alias, dst_alias)
+        if after is not None:
+            where = and_(where, self.tables.flow.firstseen >= after)
+        if before is not None:
+            where = and_(where, self.tables.flow.firstseen < before)
+        stmt = (
+            select(
+                self.tables.flow.firstseen,
+                self.tables.flow.proto,
+                self.tables.flow.dport,
+                self.tables.flow.type,
+            )
+            .select_from(self._flow_join(src_alias, dst_alias))
+            .where(where)
+        )
+        with self.db.connect() as conn:
+            yield from self._flow_daily_buckets(conn.execute(stmt), precision)
+
+    def topvalues(
+        self,
+        flt,
+        fields,
+        collect_fields=None,
+        sum_fields=None,
+        limit=None,
+        skip=None,
+        least=False,
+        topnbr=10,
+    ):
+        """Group flows by ``fields`` and yield ``{fields,
+        count, collected}`` dicts -- the contract documented
+        at :meth:`DBFlow.topvalues`.
+
+        ``count`` is ``COUNT(*)`` per group, or ``SUM(<expr>)``
+        when ``sum_fields`` is set (the per-row addition mirrors
+        :meth:`MongoDBFlow.topvalues`'s ``$add`` projection).
+
+        ``collect_fields`` are aggregated per group via
+        ``array_agg(<col>)`` (no SQL-side ``DISTINCT``: each
+        per-collect-field array stays aligned with the others
+        so the per-row tuple can be reconstructed in Python
+        before the final ``set`` deduplication).  Skipping
+        SQL-side ``DISTINCT`` on each column independently is
+        necessary because ``array_agg(DISTINCT col1)`` and
+        ``array_agg(DISTINCT col2)`` would produce arrays of
+        different lengths / orderings that cannot be zipped.
+
+        Limitations vs the Mongo backend (deferred to follow-up
+        sub-PRs):
+
+        * The ``sport`` shortcut (which Mongo unwinds via its
+          ``sports`` array) is not yet supported on SQL.
+        * Direct grouping on ``meta.<proto>[.<key>]`` JSONB
+          paths is not yet supported -- only as ``collect_fields``.
+        """
+        del limit, skip  # legacy aliases; ``topnbr`` is the cap.
+        collect_fields = list(collect_fields) if collect_fields else []
+        sum_fields = list(sum_fields) if sum_fields else []
+        if not fields:
+            raise ValueError("topvalues requires at least one field")
+        src_alias = aliased(Host, name="flow_src_host")
+        dst_alias = aliased(Host, name="flow_dst_host")
+        where = self._build_where(flt, src_alias, dst_alias)
+        group_cols = [self._topvalues_col(f, src_alias, dst_alias) for f in fields]
+        if sum_fields:
+            sum_cols = [
+                self._topvalues_col(f, src_alias, dst_alias) for f in sum_fields
+            ]
+            count_expr = func.sum(sum(sum_cols[1:], sum_cols[0])).label("_count")
+        else:
+            count_expr = func.count().label("_count")
+        collect_exprs = [
+            func.array_agg(self._topvalues_col(f, src_alias, dst_alias)).label(
+                f"_collect_{i}"
+            )
+            for i, f in enumerate(collect_fields)
+        ]
+        stmt = (
+            select(*group_cols, count_expr, *collect_exprs)
+            .select_from(self._flow_join(src_alias, dst_alias))
+            .where(where)
+            .group_by(*group_cols)
+            .order_by(count_expr.asc() if least else count_expr.desc())
+        )
+        if topnbr is not None:
+            stmt = stmt.limit(topnbr)
+        n_fields = len(fields)
+        with self.db.connect() as conn:
+            for row in conn.execute(stmt):
+                field_vals = tuple(row[:n_fields])
+                count_val = int(row[n_fields] or 0)
+                if collect_fields:
+                    arrays = [
+                        row[n_fields + 1 + i] or [] for i in range(len(collect_fields))
+                    ]
+                    # Zip per-row across the per-collect-field
+                    # arrays so each element of the resulting
+                    # ``set`` carries one matched tuple of
+                    # ``collect_fields`` values.
+                    collected = set(zip(*arrays))
+                else:
+                    collected = set()
+                yield {
+                    "fields": field_vals,
+                    "count": count_val,
+                    "collected": collected,
+                }
+
+    def top(self, flt, fields, collect=None, sumfields=None):
+        """Alias of :meth:`topvalues` accepting the legacy
+        ``collect`` / ``sumfields`` parameter names from the
+        original abstract :class:`DBFlow.top` shape."""
+        return self.topvalues(flt, fields, collect_fields=collect, sum_fields=sumfields)
 
     def cleanup_flows(self):
         raise NotImplementedError()

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -6903,6 +6903,381 @@ class SQLDBFlowFromFiltersTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBFlowAggregationsTests -- pin the wire shape of the
+# read-side aggregation helpers (``count`` / ``flow_daily`` /
+# ``topvalues`` / ``top``) on :class:`SQLDBFlow`.  These power
+# the ``flowcli --count`` / ``--top`` / ``--flow-daily`` paths
+# and the ``/cgi/flows/count`` web route; without them, every
+# such call raised ``NotImplementedError``.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_FLOW_FILTERS,
+    "SQLAlchemy is required for SQLDBFlowAggregationsTests",
+)
+class SQLDBFlowAggregationsTests(unittest.TestCase):
+    """Behaviour-pin for ``count`` / ``flow_daily`` /
+    ``topvalues`` / ``top`` on :class:`SQLDBFlow`.
+
+    Mirrors :meth:`MongoDBFlow.count` / ``flow_daily`` /
+    ``topvalues`` -- the contract is identical (same return
+    shape so :mod:`ivre.tools.flowcli` and
+    :mod:`ivre.web.app` consume both backends interchangeably);
+    SQL diverges on the bucketing source for ``flow_daily``
+    only -- the per-flow ``times`` array is documented as
+    MongoDB-only in :mod:`ivre.flow`, so the SQL path buckets
+    on ``firstseen`` instead.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        from sqlalchemy.dialects import postgresql
+
+        return str(
+            stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    # -- count() ------------------------------------------------------
+
+    def test_count_signature_returns_dict(self):
+        # ``count`` must accept a :class:`SQLFlowFilter` -- the
+        # type :meth:`SQLDBFlow.from_filters` returns -- and
+        # produce the canonical ``{clients, servers, flows}``
+        # dict :func:`ivre.tools.flowcli` and
+        # :class:`MongoDBFlow.count` agree on.  Without a live
+        # PostgreSQL we mock the connection to assert the
+        # SELECT shape and the return-dict construction in one
+        # pass.
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                row = MagicMock()
+                row.flows = 5
+                row.clients = 3
+                row.servers = 4
+                result = MagicMock()
+                result.one.return_value = row
+                return result
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+
+        flt = _SQLDBFlow_for_filters_test.from_filters({"edges": ["proto = tcp"]})
+        result = db.count(flt)
+        self.assertEqual(result, {"flows": 5, "clients": 3, "servers": 4})
+
+        # The captured SELECT must group COUNT(*) for flows and
+        # COUNT(DISTINCT) for clients / servers, with the
+        # canonical ``flow JOIN host AS src JOIN host AS dst``
+        # join shape and the WHERE clause from the filter.
+        self.assertEqual(len(captured), 1)
+        sql = self._compile_pg(captured[0])
+        self.assertIn("count(*)", sql)
+        self.assertIn("count(DISTINCT flow.src)", sql)
+        self.assertIn("count(DISTINCT flow.dst)", sql)
+        self.assertIn("flow.proto = 'tcp'", sql)
+        self.assertIn("JOIN host", sql)
+
+    def test_count_none_spec_treated_as_match_all(self):
+        # ``count(None)`` should not raise -- the
+        # ``DBFlow.from_filters`` chain returns ``None``-able
+        # values from time to time, and the count result for an
+        # empty filter is well-defined.
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                row = MagicMock()
+                row.flows = 0
+                row.clients = 0
+                row.servers = 0
+                result = MagicMock()
+                result.one.return_value = row
+                return result
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        result = db.count(None)
+        self.assertEqual(result, {"flows": 0, "clients": 0, "servers": 0})
+        self.assertIn("WHERE true", self._compile_pg(captured[0]))
+
+    # -- topvalues() / top() -------------------------------------------
+
+    def test_topvalues_unsupported_field_raises(self):
+        # ``sport`` would need a ``sports`` array unwind we
+        # have not implemented yet; surface that explicitly so
+        # the CLI does not silently return an empty result.
+        from unittest.mock import MagicMock
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        with self.assertRaises(ValueError):
+            list(db.topvalues(flt, ["sport"]))
+
+    def test_topvalues_empty_fields_raises(self):
+        from unittest.mock import MagicMock
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        with self.assertRaises(ValueError):
+            list(db.topvalues(flt, []))
+
+    def test_topvalues_select_shape(self):
+        # Capture the SQL the topvalues GROUP BY emits and
+        # pin the column / alias / ORDER BY layout.  This is
+        # the wire contract :meth:`MongoDBFlow.topvalues`
+        # produces (counts descending by default; LIMIT
+        # ``topnbr``); a future refactor that reorders or
+        # renames the columns surfaces here instead of as a
+        # silent CLI regression.
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                return iter([])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        list(db.topvalues(flt, ["proto", "dport"], topnbr=5))
+        sql = self._compile_pg(captured[0])
+        self.assertIn("GROUP BY flow.proto, flow.dport", sql)
+        self.assertIn("count(*) AS _count", sql)
+        # SQLAlchemy references the labeled column by its
+        # alias in ORDER BY rather than re-emitting the
+        # ``count(*)`` expression.
+        self.assertIn("ORDER BY _count DESC", sql)
+        self.assertIn("LIMIT 5", sql)
+
+    def test_topvalues_collect_uses_array_agg(self):
+        # ``collect_fields`` translate to ``array_agg`` (no
+        # SQL-side ``DISTINCT`` -- the per-row arrays must
+        # stay aligned across collect fields so the
+        # ``zip(*arrays)`` step in the result decoder produces
+        # well-formed tuples; SQL-side ``DISTINCT`` per
+        # column would produce mis-aligned arrays).
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                return iter([])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        list(
+            db.topvalues(
+                flt,
+                ["proto"],
+                collect_fields=["src.addr", "dst.addr"],
+            )
+        )
+        sql = self._compile_pg(captured[0])
+        self.assertIn("array_agg(", sql)
+        self.assertNotIn("array_agg(DISTINCT", sql)
+        self.assertIn("AS _collect_0", sql)
+        self.assertIn("AS _collect_1", sql)
+
+    def test_topvalues_least_orders_ascending(self):
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                return iter([])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        list(db.topvalues(flt, ["proto"], least=True))
+        sql = self._compile_pg(captured[0])
+        self.assertIn("ORDER BY _count ASC", sql)
+
+    def test_topvalues_sum_fields_uses_sum(self):
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                return iter([])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        list(db.topvalues(flt, ["proto"], sum_fields=["scbytes", "csbytes"]))
+        sql = self._compile_pg(captured[0])
+        # SQLAlchemy renders ``a + b`` for the per-row sum
+        # expression; the outer ``sum(...)`` aggregates that
+        # across the group.  Mirrors Mongo's ``$add`` ->
+        # ``$sum`` projection chain.
+        self.assertIn("sum(", sql)
+        self.assertIn("scbytes", sql)
+        self.assertIn("csbytes", sql)
+
+    def test_top_is_alias_of_topvalues(self):
+        # ``DBFlow.top`` was an abstract method on the base
+        # class; the SQL backend ships ``top`` as a thin
+        # parameter-renaming alias of ``topvalues`` so callers
+        # of either name keep working unchanged.
+        from unittest.mock import MagicMock
+
+        captured = []
+
+        class _FakeConn:
+            def execute(self, stmt):
+                captured.append(stmt)
+                return iter([])
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        db = _SQLDBFlow_for_filters_test.__new__(_SQLDBFlow_for_filters_test)
+        db._db = MagicMock()
+        db._db.connect.return_value = _FakeConn()
+        flt = _SQLDBFlow_for_filters_test.from_filters({})
+        list(db.top(flt, ["proto"], collect=["src.addr"], sumfields=["count"]))
+        sql = self._compile_pg(captured[0])
+        self.assertIn("array_agg(", sql)
+        self.assertIn("sum(flow.count)", sql)
+
+    # -- flow_daily() bucketing ---------------------------------------
+
+    def test_flow_daily_buckets_by_precision(self):
+        # The bucketing helper is independent of the DB
+        # connection: feed it a hand-crafted iterable and
+        # inspect the per-bucket histogram.  Here ``precision=10``
+        # collapses seconds 0..9 into bucket 0; seconds 10..19
+        # into bucket 10; the proto/dport histogram aggregates
+        # within each bucket.
+        import datetime as _datetime
+
+        class _Row:
+            def __init__(self, ts, proto, dport=None, type=None):
+                self.firstseen = ts
+                self.proto = proto
+                self.dport = dport
+                self.type = type
+
+        rows = [
+            _Row(_datetime.datetime(2024, 1, 1, 10, 30, 3), "tcp", dport=443),
+            _Row(_datetime.datetime(2024, 1, 1, 10, 30, 7), "tcp", dport=443),
+            _Row(_datetime.datetime(2024, 1, 1, 10, 30, 12), "tcp", dport=443),
+            _Row(_datetime.datetime(2024, 1, 1, 10, 30, 15), "udp", dport=53),
+        ]
+        out = list(_SQLDBFlow_for_filters_test._flow_daily_buckets(rows, precision=10))
+        self.assertEqual(len(out), 2)
+        # First bucket: 10:30:00 (seconds 3 and 7 collapse to 0).
+        self.assertEqual(out[0]["time_in_day"], _datetime.time(10, 30, 0))
+        self.assertEqual(out[0]["flows"], [("tcp/443", 2)])
+        # Second bucket: 10:30:10 (seconds 12 and 15 collapse to 10).
+        self.assertEqual(out[1]["time_in_day"], _datetime.time(10, 30, 10))
+        self.assertEqual(sorted(out[1]["flows"]), [("tcp/443", 1), ("udp/53", 1)])
+
+    def test_flow_daily_handles_icmp_via_type(self):
+        # ICMP flows have no ``dport``; the entry name uses
+        # ``proto/type`` instead.  Mirrors Mongo's
+        # ``$cond``-driven entry-name construction at
+        # :meth:`MongoDBFlow.flow_daily`.
+        import datetime as _datetime
+
+        class _Row:
+            def __init__(self, ts, proto, dport, type):
+                self.firstseen = ts
+                self.proto = proto
+                self.dport = dport
+                self.type = type
+
+        rows = [
+            _Row(_datetime.datetime(2024, 1, 1, 0, 0, 0), "icmp", None, 8),
+        ]
+        out = list(_SQLDBFlow_for_filters_test._flow_daily_buckets(rows, precision=60))
+        self.assertEqual(out[0]["flows"], [("icmp/8", 1)])
+
+    def test_flow_daily_skips_null_firstseen(self):
+        # ``firstseen`` can in theory be ``NULL`` (the column is
+        # nullable on the schema); skip those rows rather than
+        # crashing the iterator.
+        class _Row:
+            firstseen = None
+            proto = "tcp"
+            dport = 80
+            type = None
+
+        out = list(
+            _SQLDBFlow_for_filters_test._flow_daily_buckets([_Row()], precision=60)
+        )
+        self.assertEqual(out, [])
+
+
+# ---------------------------------------------------------------------
 # CertExtensionFormatTests -- pin the format of
 # ``result["san"]`` produced by ``ivre.utils.get_cert_info`` after
 # the migration off pyOpenSSL's removed ``X509.get_extension(i)``


### PR DESCRIPTION
Implements the four read-side aggregation helpers
:class:`SQLDBFlow` was still raising ``NotImplementedError`` on, so ``flowcli --count`` / ``--top`` / ``--flow-daily`` and the ``/cgi/flows/count`` web route now work end-to-end on the SQL backend.  Mirrors :meth:`MongoDBFlow.count` / ``topvalues`` / ``flow_daily`` shapes byte-for-byte where the schema permits divergence-free translation.

* ``count(flt)`` -> ``{flows, clients, servers}``.  Uses ``COUNT(*)`` for flows and ``COUNT(DISTINCT flow.src)`` / ``COUNT(DISTINCT flow.dst)`` for clients / servers in a single round-trip; Mongo's two-stage ``$group`` pipeline was a workaround for ``$count`` only being available since 3.4 and has no SQL equivalent.

* ``topvalues(flt, fields, collect_fields, sum_fields, topnbr, least, ...)`` -> generator of ``{fields, count, collected}`` dicts.  GROUP BY the projected ``fields``, ``COUNT(*)`` / ``SUM(<sum_fields_added>)`` per group, ``array_agg(<col>)`` for each ``collect_field`` (no SQL-side ``DISTINCT`` -- the per-collect-field arrays must stay aligned so ``zip(*arrays)`` in the result decoder produces well-formed tuples; SQL-side ``DISTINCT`` per column would produce mis-aligned arrays and corrupt the collected set). ``ORDER BY count DESC`` (or ``ASC`` with ``least=True``); ``LIMIT`` from ``topnbr``.

  Limitations vs the Mongo backend (deferred to follow-up sub-PRs):

  - The ``sport`` shortcut (which Mongo unwinds via its ``sports`` array) is not yet supported on SQL -- it raises ``ValueError`` so the CLI surfaces the gap eagerly.
  - Direct grouping on ``meta.<proto>[.<key>]`` JSONB paths is not yet supported; only as ``collect_fields`` (which pass through the existing ``->`` / ``->>`` translation in :meth:`_flow_col_for_attr`).

* ``top(flt, fields, collect=None, sumfields=None)`` is a thin parameter-renaming alias of ``topvalues`` so callers using either name keep working.

* ``flow_daily(precision, flt, after, before)`` -> generator of ``{flows: [(name, count), ...], time_in_day: datetime.time}``.  SQL diverges from the Mongo bucketing source -- Mongo unwinds the per-flow ``times`` array (each timeslot recorded separately on the flow document); ``ivre.flow`` documents that array as MongoDB-only, so the SQL path buckets on ``firstseen`` instead.  Each flow contributes once per day (its first-observed timestamp), which under-counts relative to Mongo for long-lived flows but is the most faithful translation the schema supports. ``precision`` bucketing happens client-side so the same value the Mongo backend honors works on SQL.  ``after`` / ``before`` filter on ``firstseen``.

* New ``_build_where`` / ``_flow_join`` / ``_topvalues_col`` helpers DRY the per-method boilerplate (every read-side method needs the same JOIN + WHERE shape).

* New ``_flow_daily_buckets`` static helper extracts the in-Python time-of-day bucketing logic so it can be pin-tested without a live PostgreSQL connection.

Tests:

* New ``SQLDBFlowAggregationsTests`` (12 pin tests) in ``tests/tests_no_backend.py``.  Mocks the SA connection via ``unittest.mock.MagicMock`` so the SELECT shape the aggregation methods emit is asserted by compiling the captured statement to PostgreSQL via ``literal_binds``. Covers ``count`` (with and without filter), ``topvalues`` (column / alias / ORDER BY / LIMIT layout, ``array_agg`` shape with and without ``collect_fields``, ``least`` flag, ``sum_fields`` translation, unsupported / empty-fields error paths), ``top`` aliasing, and the ``_flow_daily_buckets`` helper end-to-end (precision collapsing, ICMP type fallback, NULL ``firstseen``).