### PR TITLE
feat(db/sql): add SQLDBRir + PostgresDBRir for whois RIR data

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -5156,6 +5156,7 @@ class DBRir(DB):
     backends = {
         "http": ("http", "HttpDBRir"),
         "mongodb": ("mongo", "MongoDBRir"),
+        "postgresql": ("sql.postgres", "PostgresDBRir"),
     }
 
     ipaddr_fields = ["start", "stop"]

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -62,7 +62,7 @@ from ivre import config
 from ivre import flow as ivre_flow
 from ivre import utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
-from ivre.db import DB, DBActive, DBFlow, DBNmap, DBPassive, DBView
+from ivre.db import DB, DBActive, DBFlow, DBNmap, DBPassive, DBRir, DBView
 from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
     Flow,
@@ -79,6 +79,7 @@ from ivre.db.sql.tables import (
     N_Trace,
     Passive,
     Point,
+    Rir,
     V_Association_Scan_Category,
     V_Association_Scan_Hostname,
     V_Category,
@@ -5819,3 +5820,493 @@ class SQLDBPassive(SQLDB, DBPassive):
         field = cls.tables.passive.firstseen if new else cls.tables.passive.lastseen
         timestamp = utils.all2datetime(timestamp)
         return PassiveFilter(main=(field <= timestamp if neg else field > timestamp))
+
+
+# ---------------------------------------------------------------------
+# SQLDBRir -- shared base for the SQL backends' RIR (Regional
+# Internet Registry whois) data category.  The schema (declared in
+# :class:`~ivre.db.sql.tables.Rir`) mirrors :class:`MongoDBRir`'s
+# wire shape: each row is one ``inetnum`` / ``inet6num`` /
+# ``aut-num`` whois block, with the IP range stored as native
+# ``INET`` columns instead of Mongo's ``(start_0, start_1)`` /
+# ``(stop_0, stop_1)`` int128 split (PostgreSQL handles range
+# comparisons on ``INET`` natively).
+#
+# The text columns (``netname`` / ``descr`` / ``remarks`` /
+# ``notify`` / ``org`` / ``as_name``) are surfaced as filterable
+# columns; everything else lands in the ``extra`` JSONB bag for
+# forward compatibility with new RIR attributes.
+# ---------------------------------------------------------------------
+
+
+# Keys the RIR parser :meth:`DBRir.gen_records` emits that map to
+# typed columns.  Anything outside this set lands in
+# :attr:`Rir.extra` (JSONB) so a new RIR field doesn't need a
+# schema migration.  The leading-key set must match
+# :data:`MongoDBRir.text_fields` plus the structural fields
+# :meth:`DBRir.import_files` synthesises (``start`` / ``stop`` /
+# ``aut-num`` / ``source_file`` / ``source_hash``).
+_RIR_TYPED_COLUMNS: dict[str, str] = {
+    "start": "start",
+    "stop": "stop",
+    "aut-num": "aut_num",
+    "as-name": "as_name",
+    "netname": "netname",
+    "descr": "descr",
+    "remarks": "remarks",
+    "notify": "notify",
+    "org": "org",
+    "country": "country",
+    "lang": "lang",
+    "source": "source",
+    "source_file": "source_file",
+    "source_hash": "source_hash",
+}
+
+# Reverse mapping for :meth:`SQLDBRir._row2rec`.
+_RIR_TYPED_COLUMNS_INVERSE: dict[str, str] = {
+    v: k for k, v in _RIR_TYPED_COLUMNS.items()
+}
+
+
+class SQLDBRir(SQLDB, DBRir):
+    """SQL-backend base for the RIR data category.
+
+    Concrete dialects subclass this together with the dialect's
+    ``SQLDB`` flavour (e.g. :class:`PostgresDB`) -- see
+    :class:`~ivre.db.sql.postgres.PostgresDBRir`.
+    """
+
+    table_layout = namedtuple("rir_layout", ["rir"])
+    tables = table_layout(Rir)
+
+    # Bound to :data:`MongoDBRir.schema_latest_versions` so a
+    # mixed PG / Mongo deployment shares the same migration
+    # generation marker.  Bumped via
+    # ``_migrate_schema_NN_MM`` on PG when the wire shape changes
+    # (the SQL backend has no records pre-dating this PR, so no
+    # historical migration is required at this point).
+    SCHEMA_VERSION = 2
+
+    @classmethod
+    def searchhost(cls, addr, neg=False):
+        """Filter rows whose IP range covers ``addr``.
+
+        Uses native ``INET`` ordering (``start <= addr <= stop``);
+        the ``rir_idx_range`` B-tree accelerates the lookup on
+        same-family ranges.  ``neg=True`` is rejected to mirror
+        :meth:`MongoDBRir.searchhost`.
+
+        ``addr`` is bound as a plain string; the
+        :class:`~ivre.db.sql.tables.INETLiteral` column type's
+        ``bind_expression`` wraps the value in ``CAST(? AS
+        INET)`` so PostgreSQL coerces the literal at execution
+        time -- no explicit cast needed at the call site.
+        """
+        if neg:
+            raise ValueError("neg == True is not supported for this purpose")
+        return and_(cls.tables.rir.start <= addr, cls.tables.rir.stop >= addr)
+
+    @classmethod
+    def searchnet(cls, net, neg=False):
+        """Filter rows whose ``(start, stop)`` range overlaps
+        with ``net``.
+
+        Mirrors :meth:`MongoDBRir.searchnet`: any kind of
+        overlap matches (record fully contains ``net``, record
+        fully contained in ``net``, partial overlap on either
+        side).  ``neg=True`` is unsupported (mirrors
+        :meth:`searchhost`).
+        """
+        if neg:
+            raise ValueError("neg == True is not supported for this purpose")
+        net_start, net_stop = utils.net2range(net)
+        return cls._searchrange_overlap(net_start, net_stop)
+
+    @classmethod
+    def searchrange(cls, start, stop, neg=False):
+        """Filter rows whose ``(start, stop)`` range overlaps
+        with the ``[start, stop]`` window.
+
+        Same overlap semantics as :meth:`searchnet`.  ``neg=True``
+        is unsupported.
+        """
+        if neg:
+            raise ValueError("neg == True is not supported for this purpose")
+        return cls._searchrange_overlap(start, stop)
+
+    @classmethod
+    def _searchrange_overlap(cls, win_start, win_stop):
+        """Return the SA expression for ``record.start <=
+        win_stop AND record.stop >= win_start``.
+
+        Mirrors :meth:`MongoDBRir._searchrange_overlap` byte-for-
+        byte; the single B-tree :data:`rir_idx_range` covers both
+        comparisons.  ``win_start`` / ``win_stop`` are bound as
+        plain strings; the column's ``INETLiteral`` bind
+        expression wraps each value in ``CAST(? AS INET)`` so
+        PostgreSQL handles the cast at execution time.
+        """
+        return and_(
+            cls.tables.rir.start <= win_stop,
+            cls.tables.rir.stop >= win_start,
+        )
+
+    @classmethod
+    def searchasnum(cls, asnum, neg=False):
+        """Filter ``aut-num`` records by integer AS number.
+
+        Accepts an int, a string (``"AS1234"`` / ``"1234"``), or
+        a list of either (mirrors
+        :meth:`MongoDBRir.searchasnum`'s shape).  Strings are
+        coerced to int via :func:`_coerce_asnum_sql`.
+        """
+        return cls._search_field(
+            cls.tables.rir.aut_num,
+            asnum,
+            neg=neg,
+            map_=_coerce_asnum_sql,
+        )
+
+    @classmethod
+    def searchasname(cls, name, neg=False):
+        """Filter ``aut-num`` records by their ``as-name`` text
+        field.  Accepts a string, a list, or a regex.
+        """
+        return cls._search_field(cls.tables.rir.as_name, name, neg=neg)
+
+    @classmethod
+    def searchcountry(cls, country, neg=False):
+        """Filter rows by two-letter country code(s)."""
+        return cls._search_field(
+            cls.tables.rir.country,
+            utils.country_unalias(country),
+            neg=neg,
+        )
+
+    @classmethod
+    def searchsourcefile(cls, src, neg=False):
+        """Filter rows by the basename of the imported RIR
+        database file (``ripe.db.inetnum.gz`` etc.).
+        """
+        return cls._search_field(cls.tables.rir.source_file, src, neg=neg)
+
+    @classmethod
+    def searchfileid(cls, fileid, neg=False):
+        """Filter rows by the SHA-256 hex digest of the imported
+        RIR database file.
+        """
+        return cls._search_field(cls.tables.rir.source_hash, fileid, neg=neg)
+
+    @staticmethod
+    def flt_and(*args):
+        """Combine filter expressions via SQL ``AND``.
+
+        ``None`` arguments are dropped so callers can chain
+        optional filters (``flt_and(searchhost(addr), spec)``
+        with ``spec`` possibly ``None`` is the common shape).
+        """
+        clauses = [a for a in args if a is not None]
+        if not clauses:
+            return None
+        if len(clauses) == 1:
+            return clauses[0]
+        return and_(*clauses)
+
+    @staticmethod
+    def flt_or(*args):
+        """Combine filter expressions via SQL ``OR``."""
+        clauses = [a for a in args if a is not None]
+        if not clauses:
+            return None
+        if len(clauses) == 1:
+            return clauses[0]
+        return or_(*clauses)
+
+    flt_empty = None
+
+    def remove_many(self, flt):
+        """Delete every row matching ``flt``.
+
+        Mirrors :meth:`MongoDBRir.remove_many` -- used by the
+        idempotent re-import path
+        (:meth:`DBRir.import_files`) to drop the prior
+        generation of records sourced from the same file.
+        """
+        with self.db.begin() as conn:
+            conn.execute(
+                delete(self.tables.rir).where(flt if flt is not None else true())
+            )
+
+    @classmethod
+    def _row2rec(cls, row):
+        """Project a :class:`Rir` row into the dict shape the
+        Mongo path returns (so ``rirlookup`` /
+        :meth:`DBRir.import_files` consumers see one shape on
+        either backend).
+
+        ``aut_num`` / ``as_name`` are renamed back to the
+        whois-native ``aut-num`` / ``as-name`` keys; values from
+        the ``extra`` JSONB bag are flattened into the top-level
+        dict.  ``size`` round-trips as :class:`Decimal` (matches
+        Mongo's ``Decimal128`` shape after the JSON decode).
+        """
+        rec = {}
+        for col_name, key in _RIR_TYPED_COLUMNS_INVERSE.items():
+            value = getattr(row, col_name)
+            if value is not None:
+                rec[key] = value
+        if row.size is not None:
+            rec["size"] = row.size
+        if row.schema_version is not None:
+            rec["schema_version"] = row.schema_version
+        if row.extra:
+            for key, value in row.extra.items():
+                rec.setdefault(key, value)
+        rec["_id"] = row.id
+        return rec
+
+    def get(self, spec, limit=None, skip=None, sort=None, fields=None):
+        """Iterate rows matching ``spec`` (a SA expression
+        returned by one of the ``searchXXX`` helpers, or
+        ``None`` for the match-all case).
+
+        Mirrors :meth:`MongoDBRir.get`'s contract: each yielded
+        record is a dict with the same key shape Mongo
+        produces.  ``fields`` is accepted for API compatibility
+        with the abstract :meth:`DB.get` signature but ignored
+        here -- the projection is cheap (one row, one table)
+        and the ``rirlookup`` consumer expects every column
+        anyway.
+        """
+        del fields  # unused; signature parity with DB.get
+        stmt = select(self.tables.rir)
+        if spec is not None:
+            stmt = stmt.where(spec)
+        for col in self._sort_to_sa(sort):
+            stmt = stmt.order_by(col)
+        if skip is not None:
+            stmt = stmt.offset(skip)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        with self.db.connect() as conn:
+            for row in conn.execute(stmt):
+                yield self._row2rec(row[0])
+
+    def _sort_to_sa(self, sort):
+        """Translate a Mongo-shaped ``sort=[(field, dir), ...]``
+        list into SA ``order_by`` columns.
+
+        ``dir`` is ``-1`` for descending, anything else for
+        ascending (matches PyMongo).  Unknown field names raise
+        ``ValueError`` so a caller drift surfaces here, not on
+        the live DB lane.
+        """
+        if not sort:
+            return []
+        out = []
+        for field, direction in sort:
+            col_name = _RIR_TYPED_COLUMNS.get(field, field)
+            try:
+                col = getattr(self.tables.rir, col_name)
+            except AttributeError as exc:
+                raise ValueError(f"Unknown rir sort field {field!r}") from exc
+            out.append(desc(col) if direction == -1 else col)
+        return out
+
+    def count(self, flt):
+        """Return the row count matching ``flt``."""
+        stmt = select(func.count()).select_from(self.tables.rir)
+        if flt is not None:
+            stmt = stmt.where(flt)
+        with self.db.connect() as conn:
+            return conn.execute(stmt).scalar() or 0
+
+    def distinct(self, field, flt=None, sort=None, limit=None, skip=None):
+        """Yield distinct values of ``field`` matching ``flt``.
+
+        ``field`` accepts either a typed column name
+        (``country``, ``netname``, ``aut-num``, ...) or a JSONB
+        path into ``extra`` (the shape ``MongoDBRir.distinct``
+        accepts).  Typed columns map to the SQL column directly;
+        JSONB paths use the ``->>`` operator.
+        """
+        col = self._field_to_sa(field)
+        stmt = select(col).distinct()
+        if flt is not None:
+            stmt = stmt.where(flt)
+        if sort:
+            for s_field, direction in sort:
+                s_col = self._field_to_sa(s_field)
+                stmt = stmt.order_by(desc(s_col) if direction == -1 else s_col)
+        if skip is not None:
+            stmt = stmt.offset(skip)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        with self.db.connect() as conn:
+            for row in conn.execute(stmt):
+                yield row[0]
+
+    def _field_to_sa(self, field):
+        """Translate a Mongo-style field path into a SA column /
+        JSONB accessor.
+
+        Typed columns (the keys of :data:`_RIR_TYPED_COLUMNS`,
+        plus ``size`` / ``schema_version``) map to the column
+        directly.  Anything else is treated as a JSONB path into
+        :attr:`Rir.extra` via the ``->>`` operator (textual
+        projection).
+        """
+        if field in _RIR_TYPED_COLUMNS:
+            return getattr(self.tables.rir, _RIR_TYPED_COLUMNS[field])
+        if field in {"size", "schema_version", "id"}:
+            return getattr(self.tables.rir, field)
+        return self.tables.rir.extra.op("->>")(field)
+
+    def topvalues(
+        self,
+        field,
+        flt=None,
+        topnbr=10,
+        sort=None,
+        limit=None,
+        skip=None,
+        least=False,
+    ):
+        """Yield ``(value, count)`` pairs of the most common
+        values of ``field`` matching ``flt``.
+
+        Mirrors :meth:`MongoDBRir.topvalues` -- ``least=True``
+        flips the order to least-common-first, ``topnbr`` caps
+        the number of buckets, ``flt`` narrows the population.
+        """
+        del sort, limit, skip  # absorbed into the aggregation below
+        col = self._field_to_sa(field)
+        cnt = func.count().label("count")
+        stmt = select(col.label("value"), cnt)
+        if flt is not None:
+            stmt = stmt.where(flt)
+        stmt = stmt.group_by(col)
+        stmt = stmt.order_by(cnt.asc() if least else cnt.desc())
+        if topnbr:
+            stmt = stmt.limit(int(topnbr))
+        with self.db.connect() as conn:
+            for row in conn.execute(stmt):
+                yield {"_id": row.value, "count": row.count}
+
+    # -- Ingestion path ----------------------------------------------
+    #
+    # The shared :meth:`DBRir.import_files` parser drives one
+    # ``insert_bulk(bulk, rec)`` call per parsed whois block; the
+    # SQL backend accumulates bound rows in the bulk and flushes
+    # via ``executemany`` either when the batch fills up or at
+    # ``stop_bulk`` time.  Mirrors
+    # :meth:`MongoDBRir.start_bulk` / ``insert_bulk`` /
+    # ``stop_bulk``.
+
+    @staticmethod
+    def start_bulk():
+        """Allocate a fresh in-memory bulk-insert buffer."""
+        return []
+
+    def insert_bulk(self, bulk, rec):
+        """Append a parsed whois record to the bulk buffer.
+
+        Flushes the bulk to the database (and resets it to an
+        empty list) once it reaches
+        :data:`config.POSTGRES_BATCH_SIZE`, matching the
+        chunk-flush rhythm :meth:`MongoDBRir.insert_bulk` uses
+        for ``MONGODB_BATCH_SIZE``.
+        """
+        bulk.append(self._record_to_row(rec))
+        if len(bulk) >= config.POSTGRES_BATCH_SIZE:
+            self._flush_bulk(bulk)
+            return []
+        return bulk
+
+    def stop_bulk(self, bulk):
+        """Flush any remaining buffered rows."""
+        if bulk:
+            self._flush_bulk(bulk)
+
+    def _flush_bulk(self, bulk):
+        """Issue an ``executemany`` ``INSERT`` for ``bulk``.
+
+        SQLAlchemy's :func:`insert` plus a list-of-dicts
+        executemany is enough on the SQL side -- RIR rows are
+        bulk-only loaded (no per-record updates), so no ON
+        CONFLICT path is needed.
+        """
+        if not bulk:
+            return
+        utils.LOGGER.debug("DB:SQL bulk RIR insert: %d", len(bulk))
+        with self.db.begin() as conn:
+            conn.execute(insert(self.tables.rir), bulk)
+
+    @classmethod
+    def _record_to_row(cls, rec):
+        """Translate a parsed whois record dict (the shape
+        :meth:`DBRir.import_files` passes to ``insert_bulk``)
+        into a SQL row dict for :class:`Rir`.
+
+        The typed columns (:data:`_RIR_TYPED_COLUMNS`) are
+        projected directly; ``size`` is computed for
+        inet[6]num records via :func:`_compute_rir_size_sql`
+        (mirrors :meth:`MongoDBRir._compute_rir_size`); every
+        other key lands in :attr:`Rir.extra` for forward
+        compatibility.
+        """
+        row = {col_name: None for col_name in _RIR_TYPED_COLUMNS_INVERSE}
+        extra = {}
+        for key, value in rec.items():
+            col_name = _RIR_TYPED_COLUMNS.get(key)
+            if col_name is None:
+                extra[key] = value
+                continue
+            row[col_name] = value
+        # ``aut-num`` records carry the integer in ``aut_num``
+        # already (the parser coerces it via ``int(...)`` in
+        # :meth:`DBRir.import_files`).  Pin the type so
+        # SQLAlchemy doesn't bind it as a string.
+        if row["aut_num"] is not None and not isinstance(row["aut_num"], int):
+            row["aut_num"] = int(row["aut_num"])
+        row["size"] = _compute_rir_size_sql(row.get("start"), row.get("stop"))
+        row["extra"] = extra or None
+        row["schema_version"] = cls.SCHEMA_VERSION
+        return row
+
+
+def _coerce_asnum_sql(asnum):
+    """Coerce an AS-number argument to ``int``.
+
+    Mirrors :func:`ivre.db.mongo._coerce_asnum`'s scalar shape
+    (the SA-side ``_search_field`` already handles regex / list
+    dispatch around it).  Strings starting with ``"AS"`` /
+    ``"as"`` strip the prefix; bare strings parse as ``int``.
+    """
+    if isinstance(asnum, int):
+        return asnum
+    s = str(asnum).strip()
+    if s[:2].upper() == "AS":
+        s = s[2:]
+    return int(s)
+
+
+def _compute_rir_size_sql(start, stop):
+    """Return the inclusive address-count of a ``(start, stop)``
+    IP range as a Python ``int`` (cast to ``Decimal`` by the SA
+    layer thanks to the ``Numeric(40, 0)`` column type).
+
+    Mirrors :meth:`MongoDBRir._compute_rir_size` -- the value is
+    pinned at insert time so the web ``/rir`` route can sort
+    narrowest-first without an aggregation pipeline.  Returns
+    ``None`` for ``aut-num`` records (no range).
+    """
+    if start is None or stop is None:
+        return None
+    try:
+        start_int = int(utils.ip2int(start))
+        stop_int = int(utils.ip2int(stop))
+    except (ValueError, OSError):
+        return None
+    return stop_int - start_int + 1

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -67,6 +67,7 @@ from ivre.db.sql import (
     SQLDBFlow,
     SQLDBNmap,
     SQLDBPassive,
+    SQLDBRir,
     SQLDBView,
 )
 
@@ -2687,3 +2688,20 @@ class PostgresDBPassive(PostgresDB, SQLDBPassive):
                 except KeyError:
                     pass
             yield (addr, currec)
+
+
+class PostgresDBRir(PostgresDB, SQLDBRir):
+    """PostgreSQL backend for the RIR data category.
+
+    Pure inheritance: every method is reachable via the MRO
+    ``(PostgresDB, SQLDBRir)``.  PostgresDB layers the dialect
+    helpers (``ip2internal`` / ``_searchstring_re`` / FTS
+    operator dispatch) on top of :class:`SQLDBRir`'s
+    backend-agnostic search / aggregate / ingestion path.  No
+    per-method override is needed at this point: PostgreSQL
+    natively supports every operator the RIR queries emit
+    (``INET`` ordering for range overlap, ``to_tsvector(...) @@
+    plainto_tsquery(...)`` for full-text matches against the
+    ``rir_idx_fts`` GIN index, ``executemany`` ``INSERT`` for
+    the bulk ingestion path).
+    """

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     Index,
     Integer,
     LargeBinary,
+    Numeric,
     Sequence,
     String,
     Text,
@@ -772,3 +773,137 @@ class Passive(Base):
     # unicity on insertion (the unicity is guaranteed by the value)
     # for performance reasons
     schema_version = Column(Integer, default=passive.SCHEMA_VERSION)
+
+
+# RIR (Regional Internet Registry whois data)
+#
+# Schema mirrors :class:`MongoDBRir` (``ivre/db/mongo.py:5796``);
+# every record is one ``inetnum`` / ``inet6num`` / ``aut-num``
+# block from a downloaded RIR database file (RIPE / ARIN / APNIC
+# / AFRINIC / LACNIC).  Mongo decomposes the IP range into a
+# ``(start_0, start_1)`` / ``(stop_0, stop_1)`` pair of int128
+# halves; the SQL backend uses native ``INET`` columns instead so
+# range queries can use the dialect-native ``<=`` / ``>=`` /
+# ``<<=`` operators rather than dual-key compares.  ``aut-num``
+# records leave ``start`` / ``stop`` ``NULL`` and populate
+# ``aut_num`` instead (mutually exclusive on the wire, so the
+# ``aut_num`` partial index keeps the lookup tight).
+#
+# Text columns (``netname`` / ``descr`` / ``remarks`` / ``notify``
+# / ``org``) are projected from :data:`DBRir.text_fields` and
+# accelerate ``searchtext`` via the GIN index declared below.  All
+# other RIR fields land in the ``extra`` :data:`SQLJSONB` bag for
+# forward compatibility (RIR formats grow keys over time; we
+# don't want a schema migration on every new attribute).
+_seq_rir_id = Sequence("seq_rir_id")
+
+
+class Rir(Base):
+    """One ``inetnum`` / ``inet6num`` / ``aut-num`` whois record.
+
+    Populated by :meth:`SQLDBRir.import_files` (the shared
+    ingestion path inherited from :class:`DBRir`); read by the
+    ``ivre rirlookup`` CLI and the ``/rir`` web route.
+    """
+
+    __tablename__ = "rir"
+    id = Column(
+        Integer,
+        _seq_rir_id,
+        server_default=_seq_rir_id.next_value(),
+        primary_key=True,
+    )
+    # IP-range columns -- NULL on ``aut-num`` records, populated
+    # on ``inetnum`` / ``inet6num``.  Native ``INET`` keeps range
+    # comparisons simple and lets PostgreSQL pick a B-tree index.
+    start = Column(SQLINET)
+    stop = Column(SQLINET)
+    # Pre-computed inclusive address-count of the range, mirrors
+    # Mongo's ``size`` field (``mongo.py:6160``).  Pinned at
+    # insert time so the web ``/rir`` route can sort
+    # narrowest-first without a runtime expression.  ``Numeric``
+    # rather than ``BigInteger`` because IPv6 ranges can reach
+    # ``2 ** 128`` (overflows ``BigInt``); 40 digits cover that.
+    size = Column(Numeric(40, 0))
+    # ``aut-num`` records carry an integer AS number instead of a
+    # range.  Mutually exclusive with ``start`` / ``stop`` on the
+    # wire; the partial index below targets the populated form.
+    aut_num = Column(Integer)
+    as_name = Column(Text)
+    # Text columns surfaced as filterable attributes (mirrors
+    # :data:`DBRir.text_fields`).  Multi-line values are joined
+    # with ``\n`` by the shared :meth:`DBRir.gen_records` parser.
+    netname = Column(Text)
+    descr = Column(Text)
+    remarks = Column(Text)
+    notify = Column(Text)
+    org = Column(Text)
+    # Two-letter country code on inet[6]num records.
+    country = Column(String(8))
+    # ``language`` was renamed to ``lang`` by
+    # :meth:`DBRir.gen_records` (``ivre/db/__init__.py:5199``)
+    # to work around a historical Mongo bulk-insert bug.  Keep
+    # the same name on the SQL side for wire-format parity.
+    lang = Column(String(64))
+    # Source RIR (``afrinic`` / ``apnic`` / ``arin`` /
+    # ``lacnic`` / ``ripe``).  Set from the imported file's
+    # name when the parser doesn't yield it.
+    source = Column(String(64))
+    # ``source_file`` is the basename of the imported RIR
+    # database file; ``source_hash`` is its SHA-256 hex digest.
+    # Together they support the ``ivre rirlookup --remove`` /
+    # idempotent re-import paths (see
+    # :meth:`DBRir.import_files`).
+    source_file = Column(String(256))
+    source_hash = Column(String(128))
+    # Forward-compatible bag for any RIR attribute we don't
+    # call out as a typed column above (``mnt-by``, ``admin-c``,
+    # ``tech-c``, ...).  Kept as JSONB so future ``searchXX``
+    # helpers can index into the bag without a schema migration.
+    extra = Column(SQLJSONB)
+    # Bound to ``MongoDBRir.schema_latest_versions[0]`` so a
+    # mixed PG / Mongo deployment shares the same migration
+    # generation marker.
+    schema_version = Column(Integer)
+    __table_args__ = (
+        # Range lookup index covering the
+        # ``searchhost`` / ``searchnet`` / ``searchrange`` paths
+        # (PostgreSQL B-tree over ``INET`` accepts ``<=`` /
+        # ``>=`` / range-overlap predicates; the planner picks
+        # this index for the ``WHERE start <= addr AND stop >=
+        # addr`` shape :meth:`SQLDBRir.searchhost` builds).
+        Index("rir_idx_range", "start", "stop"),
+        # Partial index targeting the populated half of the
+        # mutually-exclusive ``aut_num`` / range columns; keeps
+        # the lookup tight for ``aut-num`` records.
+        Index(
+            "rir_idx_aut_num",
+            "aut_num",
+            postgresql_where=column("aut_num").isnot(None),
+        ),
+        Index("rir_idx_country", "country"),
+        Index("rir_idx_source", "source"),
+        Index("rir_idx_source_file", "source_file"),
+        Index("rir_idx_source_hash", "source_hash"),
+        Index("rir_idx_schema_version", "schema_version"),
+        # Pre-computed range-size index; the web ``/rir`` route
+        # sorts by ``size`` ascending to surface the most
+        # specific allocation first (mirrors the Mongo path's
+        # ``sort=[("size", 1)]`` default).
+        Index("rir_idx_size", "size"),
+        # GIN FTS index over the concatenation of every text
+        # column.  Same expression on both sides of the
+        # query / index split so the planner picks the index
+        # for ``to_tsvector('english', ...) @@ plainto_tsquery
+        # ('english', :term)`` clauses (see
+        # :func:`_fts_index` for the byte-for-byte match
+        # rationale).  Stripped on DuckDB by
+        # :func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb`
+        # (no GIN support); the FTS extension's
+        # ``match_bm25`` path is wired in a follow-up sub-PR.
+        _fts_index(
+            "rir_idx_fts",
+            "rir",
+            ("netname", "descr", "remarks", "notify", "org", "as_name"),
+        ),
+    )

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -8441,6 +8441,353 @@ class DuckDBFlowLiveIntegrationTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBRirTests -- pin :class:`ivre.db.sql.SQLDBRir`'s schema +
+# search SQL shapes + ingestion record translation.
+#
+# The schema part walks the declared :class:`Rir` table and pins
+# every column / index inventory item so a future refactor that
+# drops one surfaces here.  The search part compiles each ``search
+# XXX`` helper against the PostgreSQL dialect (with literal_binds)
+# and asserts the rendered SQL fragment.  The ingestion part
+# exercises :meth:`SQLDBRir._record_to_row` /
+# :meth:`SQLDBRir._row2rec` round-trip semantics so the wire
+# shapes Mongo / SQL share stay aligned byte-for-byte.
+# ---------------------------------------------------------------------
+
+
+try:
+    from ivre.db.sql import SQLDBRir as _SQLDBRir_for_tests  # noqa: E402
+    from ivre.db.sql.tables import Rir as _Rir_for_tests  # noqa: E402
+
+    _HAVE_SQLDB_RIR = True
+except ImportError:
+    _HAVE_SQLDB_RIR = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_RIR,
+    "SQLAlchemy is required for SQLDBRirTests",
+)
+class SQLDBRirTests(unittest.TestCase):
+    """Behaviour-pin for :class:`ivre.db.sql.SQLDBRir`.
+
+    Mirrors :class:`ivre.db.mongo.MongoDBRir`'s public method
+    surface so a ``DB = postgresql://...`` configuration drives
+    the same ``ivre rirlookup`` paths Mongo does.
+    """
+
+    @staticmethod
+    def _compile_pg(stmt):
+        from sqlalchemy.dialects import postgresql
+
+        return str(
+            stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    # -- schema -------------------------------------------------------
+
+    def test_schema_columns_present(self):
+        # Every typed column the ingestion / search paths
+        # reference must be declared on the table.  A missing
+        # column would surface here, not at runtime.
+        cols = {c.name for c in _Rir_for_tests.__table__.columns}
+        for expected in (
+            "id",
+            "start",
+            "stop",
+            "size",
+            "aut_num",
+            "as_name",
+            "netname",
+            "descr",
+            "remarks",
+            "notify",
+            "org",
+            "country",
+            "lang",
+            "source",
+            "source_file",
+            "source_hash",
+            "extra",
+            "schema_version",
+        ):
+            self.assertIn(expected, cols)
+
+    def test_schema_inet_columns_render_natively(self):
+        # ``start`` / ``stop`` must compile as ``INET`` on PG so
+        # range comparisons use the dialect-native operators.
+        from sqlalchemy.schema import CreateTable
+
+        sql = self._compile_pg(CreateTable(_Rir_for_tests.__table__))
+        self.assertIn("start INET", sql)
+        self.assertIn("stop INET", sql)
+        # ``size`` must be ``NUMERIC(40, 0)`` so IPv6 ranges
+        # (up to 2**128 addresses) round-trip without
+        # overflow.
+        self.assertIn("size NUMERIC(40, 0)", sql)
+
+    def test_schema_indexes_inventory(self):
+        # The full set of expected indexes -- pin so a refactor
+        # that drops one surfaces here, not on a slow live
+        # query.
+        names = {ix.name for ix in _Rir_for_tests.__table__.indexes}
+        for expected in (
+            "rir_idx_range",
+            "rir_idx_aut_num",
+            "rir_idx_country",
+            "rir_idx_source",
+            "rir_idx_source_file",
+            "rir_idx_source_hash",
+            "rir_idx_schema_version",
+            "rir_idx_size",
+            "rir_idx_fts",
+        ):
+            self.assertIn(expected, names)
+
+    def test_schema_fts_index_is_gin(self):
+        # The FTS index must be declared with ``USING GIN`` so
+        # the planner picks it for ``to_tsvector(...) @@
+        # plainto_tsquery(...)`` clauses.
+        idx_by_name = {ix.name: ix for ix in _Rir_for_tests.__table__.indexes}
+        self.assertEqual(
+            idx_by_name["rir_idx_fts"].kwargs.get("postgresql_using"),
+            "gin",
+        )
+
+    def test_schema_aut_num_partial_index(self):
+        # The aut-num index is partial (``WHERE aut_num IS
+        # NOT NULL``) so it doesn't bloat with the inet[6]num
+        # rows that always leave ``aut_num`` NULL.
+        idx_by_name = {ix.name: ix for ix in _Rir_for_tests.__table__.indexes}
+        where = idx_by_name["rir_idx_aut_num"].kwargs.get("postgresql_where")
+        self.assertIsNotNone(where)
+        sql = self._compile_pg(where)
+        self.assertIn("aut_num IS NOT NULL", sql)
+
+    # -- search* SQL shapes ------------------------------------------
+
+    def test_searchhost_shape(self):
+        # ``WHERE start <= addr AND stop >= addr`` -- the
+        # ``rir_idx_range`` B-tree accelerates the lookup on
+        # same-family ranges.
+        sql = self._compile_pg(_SQLDBRir_for_tests.searchhost("10.0.0.1"))
+        self.assertIn("rir.start <=", sql)
+        self.assertIn("rir.stop >=", sql)
+        # The ``INETLiteral.bind_expression`` wraps the literal
+        # in ``CAST('10.0.0.1'::inet AS INET)`` so PostgreSQL
+        # coerces the value at execution time even when the
+        # column is created on a different connection.
+        self.assertIn("'10.0.0.1'::inet", sql)
+
+    def test_searchhost_neg_raises(self):
+        # Mirrors :meth:`MongoDBRir.searchhost`'s contract --
+        # negation has no meaningful interpretation on a range
+        # overlap, so the helper raises rather than silently
+        # returning a no-op clause.
+        with self.assertRaises(ValueError):
+            _SQLDBRir_for_tests.searchhost("10.0.0.1", neg=True)
+
+    def test_searchnet_overlap_shape(self):
+        # ``net2range('10.0.0.0/8') == ('10.0.0.0',
+        # '10.255.255.255')``; the overlap predicate is
+        # ``record.start <= 10.255.255.255 AND record.stop
+        # >= 10.0.0.0``.
+        sql = self._compile_pg(_SQLDBRir_for_tests.searchnet("10.0.0.0/8"))
+        self.assertIn("'10.0.0.0'::inet", sql)
+        self.assertIn("'10.255.255.255'::inet", sql)
+
+    def test_searchasnum_int_and_string(self):
+        # Both ``15169`` (int) and ``"AS15169"`` / ``"15169"``
+        # (string) must coerce to the same SQL clause.
+        for value in (15169, "AS15169", "as15169", "15169"):
+            sql = self._compile_pg(_SQLDBRir_for_tests.searchasnum(value))
+            self.assertIn("rir.aut_num = 15169", sql)
+
+    def test_searchasnum_list(self):
+        # A list of AS numbers translates to ``IN (...)``;
+        # mixed int / string values normalise to int via
+        # ``_coerce_asnum_sql``.
+        sql = self._compile_pg(_SQLDBRir_for_tests.searchasnum([15169, "AS32934"]))
+        self.assertIn("rir.aut_num IN", sql)
+        self.assertIn("15169", sql)
+        self.assertIn("32934", sql)
+
+    def test_searchasname_regex(self):
+        # Regex match through PG's ``~*`` (case-insensitive)
+        # / ``~`` (case-sensitive) operators.
+        import re as _re
+
+        sql = self._compile_pg(
+            _SQLDBRir_for_tests.searchasname(_re.compile("Google", _re.IGNORECASE))
+        )
+        self.assertIn("rir.as_name ~*", sql)
+        self.assertIn("Google", sql)
+
+    def test_searchcountry_unaliased(self):
+        # ``country_unalias`` collapses synonyms (``"UK"``
+        # -> ``"GB"``); pin so a future tweak to the alias
+        # table doesn't silently change query behaviour.
+        sql = self._compile_pg(_SQLDBRir_for_tests.searchcountry("UK"))
+        self.assertIn("rir.country", sql)
+        self.assertIn("GB", sql)
+
+    def test_searchsourcefile_and_searchfileid(self):
+        sql = self._compile_pg(
+            _SQLDBRir_for_tests.searchsourcefile("ripe.db.inetnum.gz")
+        )
+        self.assertIn("rir.source_file = 'ripe.db.inetnum.gz'", sql)
+        sql = self._compile_pg(_SQLDBRir_for_tests.searchfileid("deadbeef"))
+        self.assertIn("rir.source_hash = 'deadbeef'", sql)
+
+    def test_flt_and_or_drop_none(self):
+        # ``flt_and(None, x)`` returns ``x`` directly; mirrors
+        # Mongo's ``flt_and`` shape so call sites that chain
+        # optional filters keep working unchanged.
+        clause = _SQLDBRir_for_tests.searchcountry("FR")
+        self.assertIs(_SQLDBRir_for_tests.flt_and(None, clause), clause)
+        self.assertIsNone(_SQLDBRir_for_tests.flt_and(None, None))
+
+    # -- ingestion record translation --------------------------------
+
+    def test_record_to_row_inetnum(self):
+        # An ``inetnum`` record gets ``size`` computed and
+        # ``aut_num`` left NULL; unknown keys go to ``extra``.
+        rec = {
+            "start": "10.0.0.0",
+            "stop": "10.255.255.255",
+            "netname": "TEST-NET",
+            "country": "FR",
+            "descr": "test description",
+            "source_file": "ripe.db.inetnum.gz",
+            "source_hash": "deadbeef",
+            "mnt-by": "MAINTAINER-MNT",
+        }
+        row = _SQLDBRir_for_tests._record_to_row(rec)
+        self.assertEqual(row["start"], "10.0.0.0")
+        self.assertEqual(row["stop"], "10.255.255.255")
+        self.assertEqual(row["netname"], "TEST-NET")
+        self.assertEqual(row["country"], "FR")
+        self.assertEqual(row["source_file"], "ripe.db.inetnum.gz")
+        self.assertEqual(row["source_hash"], "deadbeef")
+        # /8 = 2**24 = 16 777 216 addresses.
+        self.assertEqual(row["size"], 16777216)
+        self.assertIsNone(row["aut_num"])
+        # ``mnt-by`` is not a typed column -> ``extra`` bag.
+        self.assertEqual(row["extra"], {"mnt-by": "MAINTAINER-MNT"})
+        self.assertEqual(row["schema_version"], _SQLDBRir_for_tests.SCHEMA_VERSION)
+
+    def test_record_to_row_aut_num(self):
+        # An ``aut-num`` record carries ``aut_num`` (int) and
+        # leaves ``start`` / ``stop`` / ``size`` NULL.  The
+        # parser's whois-native ``aut-num`` / ``as-name`` keys
+        # rename to the SQL columns ``aut_num`` / ``as_name``.
+        rec = {
+            "aut-num": 15169,
+            "as-name": "GOOGLE",
+            "country": "US",
+            "source_file": "arin.db.gz",
+            "source_hash": "cafebabe",
+        }
+        row = _SQLDBRir_for_tests._record_to_row(rec)
+        self.assertEqual(row["aut_num"], 15169)
+        self.assertEqual(row["as_name"], "GOOGLE")
+        self.assertIsNone(row["start"])
+        self.assertIsNone(row["stop"])
+        self.assertIsNone(row["size"])
+        self.assertIsNone(row["extra"])
+
+    def test_record_to_row_size_overflow(self):
+        # IPv6 ranges can reach 2**128 -- the size column is
+        # ``Numeric(40, 0)`` precisely so the value
+        # round-trips through the SQL layer without overflow.
+        rec = {"start": "::", "stop": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}
+        row = _SQLDBRir_for_tests._record_to_row(rec)
+        self.assertEqual(row["size"], 2**128)
+
+    def test_row2rec_round_trip(self):
+        # ``_row2rec`` must rebuild the Mongo-shaped dict the
+        # ``rirlookup`` consumer expects: typed columns map
+        # back to whois-native keys (``aut-num`` / ``as-name``),
+        # ``extra`` JSONB flattens into the top level, and
+        # NULLs drop out so a sparse record stays compact.
+
+        class _FakeRow:
+            id = 1
+            start = "10.0.0.0"
+            stop = "10.255.255.255"
+            size = 16777216
+            aut_num = None
+            as_name = None
+            netname = "TEST-NET"
+            descr = "test"
+            remarks = None
+            notify = None
+            org = None
+            country = "FR"
+            lang = None
+            source = None
+            source_file = "ripe.db.inetnum.gz"
+            source_hash = "deadbeef"
+            extra = {"mnt-by": "MAINTAINER-MNT"}
+            schema_version = 2
+
+        rec = _SQLDBRir_for_tests._row2rec(_FakeRow())
+        self.assertEqual(rec["start"], "10.0.0.0")
+        self.assertEqual(rec["stop"], "10.255.255.255")
+        self.assertEqual(rec["netname"], "TEST-NET")
+        self.assertEqual(rec["country"], "FR")
+        self.assertEqual(rec["mnt-by"], "MAINTAINER-MNT")
+        self.assertEqual(rec["size"], 16777216)
+        self.assertEqual(rec["schema_version"], 2)
+        self.assertEqual(rec["_id"], 1)
+        # NULL columns must not surface in the dict.
+        self.assertNotIn("aut-num", rec)
+        self.assertNotIn("as-name", rec)
+        self.assertNotIn("remarks", rec)
+
+    def test_row2rec_aut_num_renames(self):
+        class _FakeRow:
+            id = 7
+            start = None
+            stop = None
+            size = None
+            aut_num = 15169
+            as_name = "GOOGLE"
+            netname = None
+            descr = None
+            remarks = None
+            notify = None
+            org = None
+            country = "US"
+            lang = None
+            source = None
+            source_file = "arin.db.gz"
+            source_hash = "cafebabe"
+            extra = None
+            schema_version = 2
+
+        rec = _SQLDBRir_for_tests._row2rec(_FakeRow())
+        # aut_num / as_name rename to whois-native keys.
+        self.assertEqual(rec["aut-num"], 15169)
+        self.assertEqual(rec["as-name"], "GOOGLE")
+        self.assertNotIn("aut_num", rec)
+        self.assertNotIn("as_name", rec)
+
+    # -- backend registration ----------------------------------------
+
+    def test_postgres_backend_registered(self):
+        from ivre.db import DBRir
+
+        self.assertEqual(
+            DBRir.backends.get("postgresql"),
+            ("sql.postgres", "PostgresDBRir"),
+        )
+
+
+# ---------------------------------------------------------------------
 # HttpDBFlowTests -- pin :class:`ivre.db.http.HttpDBFlow`'s URL /
 # request-body shapes.  The HTTP backend proxies every flow query
 # to a remote IVRE's ``/flows`` endpoint; without these tests a


### PR DESCRIPTION
Open the M4.7 'Rir on PG + DuckDB + DocumentDB' matrix: bring the RIR (Regional Internet Registry whois) data category to the PostgreSQL backend so DB = postgresql://... can drive 'ivre rirlookup' / the /rir web route end-to-end.

Schema (ivre/db/sql/tables.py):
- New 'rir' table with native INET 'start' / 'stop' columns (range comparisons use the dialect-native operators; no dual-key compares like Mongo's 'start_0' / 'start_1' int128 split), Numeric(40, 0) 'size' (pre-computed inclusive address-count, sized for IPv6 /0), partial 'aut_num' index (mutually exclusive with the range columns on the wire), text columns mirroring DBRir.text_fields, and a JSONB 'extra' bag for forward-compatible RIR attributes.
- GIN index 'rir_idx_fts' over the same _fts_concat expression searchtext queries emit -- byte-for-byte match required for the planner to pick the index.

SQLDBRir (ivre/db/sql/__init__.py):
- Mirrors MongoDBRir's public surface byte-for-byte: searchhost / searchnet / searchrange / searchasnum / searchasname / searchcountry / searchsourcefile / searchfileid + flt_and / flt_or / get / count / distinct / topvalues / remove_many.
- Bulk ingestion (start_bulk / insert_bulk / stop_bulk) driving an executemany INSERT.  _record_to_row translates the parser's whois-native 'aut-num' / 'as-name' keys onto the SQL columns, computes 'size' for inet[6]num records, and lands unknown keys in 'extra'.  _row2rec is the inverse for the read path.
- SCHEMA_VERSION pinned to 2 (matches MongoDBRir's latest generation).

PostgresDBRir (ivre/db/sql/postgres.py):
- Pure inheritance: '(PostgresDB, SQLDBRir)' MRO; PostgresDB layers ip2internal / _searchstring_re / FTS operator dispatch on top of SQLDBRir's backend-agnostic path.  No per-method override needed -- PostgreSQL natively supports every operator the RIR queries emit.

Backend registration (ivre/db/__init__.py):
- DBRir.backends['postgresql'] = ('sql.postgres', 'PostgresDBRir').

Pinned by 20 new SQLDBRirTests covering schema column / index inventory, INET / Numeric column rendering, GIN FTS index declaration, the partial aut_num index, every search* SQL shape (compiled to PostgreSQL with literal binds), the _record_to_row / _row2rec round-trip
(including the size overflow case for IPv6 /0 ranges), and the backend registration.