### PR TITLE
feat(db/sql): add SQLDBAuth shared base for web-auth data

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -24,10 +24,12 @@
 
 import csv
 import datetime
+import hashlib
 import json
 import re
 from collections import namedtuple
 from collections.abc import Iterator
+from secrets import token_urlsafe
 from typing import Any
 
 from sqlalchemy import (
@@ -62,9 +64,14 @@ from ivre import config
 from ivre import flow as ivre_flow
 from ivre import utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
-from ivre.db import DB, DBActive, DBFlow, DBNmap, DBPassive, DBRir, DBView
+from ivre.db import DB, DBActive, DBAuth, DBFlow, DBNmap, DBPassive, DBRir, DBView
 from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
+    AuthApiKey,
+    AuthMagicLink,
+    AuthRateLimit,
+    AuthSession,
+    AuthUser,
     Flow,
     Host,
     N_Association_Scan_Category,
@@ -6322,3 +6329,555 @@ def _compute_rir_size_sql(start, stop):
     except (ValueError, OSError):
         return None
     return stop_int - start_int + 1
+
+
+# ---------------------------------------------------------------------
+# SQLDBAuth -- shared base for the SQL backends' authentication
+# data category.  Mirrors :class:`MongoDBAuth`
+# (``ivre/db/mongo.py:7333``) byte-for-byte at the dict-output
+# level so the web layer's auth code paths (login / session /
+# API key / magic link / rate limit) work unchanged on either
+# backend.
+#
+# Mongo's TTL indexes on session / magic-link / rate-limit
+# collections expire rows server-side; PostgreSQL and DuckDB
+# have no equivalent, so every read filter that needs the TTL
+# semantics adds an explicit ``WHERE expires_at > now()`` /
+# ``WHERE created_at > cutoff`` predicate.  Expired rows
+# accumulate without harm until an operator-driven cleanup
+# runs (a future ``ivre authcli --vacuum`` will automate it).
+# ---------------------------------------------------------------------
+
+
+def _now_utc():
+    """Return the current UTC timestamp as a timezone-aware
+    :class:`datetime`.
+
+    Centralised so the helper paths emit one shape (matches
+    :meth:`MongoDBAuth`'s ``datetime.now(tz=utc)`` calls).
+    """
+    return datetime.datetime.now(tz=datetime.timezone.utc)
+
+
+def _sha256_hex(value):
+    """SHA-256 hex digest of ``value``.
+
+    Mirrors :meth:`MongoDBAuth`'s ``hashlib.sha256(token.encode
+    ()).hexdigest()`` shape so the on-disk hash matches
+    byte-for-byte across backends -- an API key created on
+    MongoDB validates against an SQL backend pointing at the
+    same hash table contents.
+    """
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class SQLDBAuth(SQLDB, DBAuth):
+    """SQL-backend base for the authentication data category.
+
+    Concrete dialects (PostgreSQL, DuckDB, ...) inherit this
+    together with their ``SQLDB`` flavour; no per-dialect
+    override is needed for the current method set because every
+    statement uses portable SQL (no ``ON CONFLICT`` expression
+    inference, no GIN-specific aggregation).
+    """
+
+    table_layout = namedtuple(
+        "auth_layout",
+        ["user", "session", "api_key", "rate_limit", "magic_link"],
+    )
+    tables = table_layout(
+        AuthUser, AuthSession, AuthApiKey, AuthRateLimit, AuthMagicLink
+    )
+
+    # Bound to a free-standing constant so a future schema bump
+    # (new column, new index) can advance the marker without
+    # touching :class:`MongoDBAuth`.  Starts at 1: the SQL
+    # backend has no records pre-dating this PR, so no
+    # historical migration is required at this point.
+    SCHEMA_VERSION = 1
+
+    @staticmethod
+    def _row2user(row):
+        """Project an :class:`AuthUser` row into the dict shape
+        :class:`MongoDBAuth` returns (``email`` / ``display_name``
+        / ``is_admin`` / ``is_active`` / ``groups`` /
+        ``created_at`` / ``last_login`` plus the synthetic
+        ``_id`` Mongo callers expect).
+        """
+        if row is None:
+            return None
+        return {
+            "_id": row.id,
+            "email": row.email,
+            "display_name": row.display_name,
+            "is_admin": bool(row.is_admin) if row.is_admin is not None else False,
+            "is_active": bool(row.is_active) if row.is_active is not None else False,
+            "groups": list(row.groups) if row.groups else [],
+            "created_at": row.created_at,
+            "last_login": row.last_login,
+        }
+
+    @staticmethod
+    def _row2apikey(row):
+        """Project an :class:`AuthApiKey` row into the dict
+        shape :meth:`MongoDBAuth.list_api_keys` returns.
+        """
+        return {
+            "_id": row.id,
+            "key_hash": row.key_hash,
+            "key_prefix": row.key_prefix,
+            "user_email": row.user_email,
+            "name": row.name,
+            "created_at": row.created_at,
+            "expires_at": row.expires_at,
+            "last_used": row.last_used,
+        }
+
+    # -- user CRUD ----------------------------------------------------
+
+    def get_user_by_email(self, email):
+        """Return the user record matching ``email`` (case-
+        sensitive, mirrors :meth:`MongoDBAuth`), or ``None``.
+        """
+        with self.db.connect() as conn:
+            row = conn.execute(
+                select(self.tables.user).where(self.tables.user.email == email)
+            ).first()
+        return self._row2user(row)
+
+    def create_user(
+        self, email, display_name=None, is_admin=False, is_active=False, groups=None
+    ):
+        """Insert a new user row.
+
+        Mirrors :meth:`MongoDBAuth.create_user`'s return shape
+        (the post-insert document dict).  The shared
+        :meth:`DBAuth` callers expect this dict directly back
+        from ``create_user``.
+        """
+        doc = {
+            "email": email,
+            "display_name": display_name or email,
+            "is_admin": is_admin,
+            "is_active": is_active,
+            "groups": list(groups) if groups else [],
+            "created_at": _now_utc(),
+            "last_login": None,
+            "schema_version": self.SCHEMA_VERSION,
+        }
+        with self.db.begin() as conn:
+            conn.execute(insert(self.tables.user).values(doc))
+        # Return the dict shape Mongo produces; the inserted
+        # row would otherwise need a SELECT round-trip just to
+        # pick up the ``id`` -- which the auth callers don't
+        # consult on the create path.
+        return {k: v for k, v in doc.items() if k != "schema_version"}
+
+    def update_user(self, email, **updates):
+        """Apply partial-update fields to the user row.
+
+        Mirrors :meth:`MongoDBAuth.update_user`'s ``$set``
+        semantics: only the keys present in ``updates`` are
+        rewritten; everything else is left untouched.
+        """
+        if not updates:
+            return
+        with self.db.begin() as conn:
+            conn.execute(
+                update(self.tables.user)
+                .where(self.tables.user.email == email)
+                .values(**updates)
+            )
+
+    def delete_user(self, email):
+        """Delete a user row and every dependent record.
+
+        Cascade in application code (mirrors
+        :meth:`MongoDBAuth.delete_user`): sessions and api-keys
+        reference the user by email, and magic-link records
+        carry the email directly.  Drop all of them in one
+        transaction so a partial failure leaves no dangling
+        sessions / api-keys.
+        """
+        with self.db.begin() as conn:
+            conn.execute(
+                delete(self.tables.session).where(
+                    self.tables.session.user_email == email
+                )
+            )
+            conn.execute(
+                delete(self.tables.api_key).where(
+                    self.tables.api_key.user_email == email
+                )
+            )
+            conn.execute(
+                delete(self.tables.magic_link).where(
+                    self.tables.magic_link.email == email
+                )
+            )
+            conn.execute(
+                delete(self.tables.user).where(self.tables.user.email == email)
+            )
+
+    def add_user_group(self, email, group):
+        """Add ``group`` to the user's group list (idempotent).
+
+        Mirrors :meth:`MongoDBAuth.add_user_group`'s
+        ``$addToSet`` semantics: a no-op if the group is
+        already present.  PostgreSQL accepts the array literal
+        as a bind value; DuckDB's ``LIST`` type understands
+        the same syntax.
+        """
+        # The PG-native ``array_append`` adds duplicates;
+        # emulate ``$addToSet`` by reading-then-writing in one
+        # transaction so two concurrent sessions never end up
+        # with the same group twice.  Single-writer DuckDB
+        # makes the race window benign; on PG the serial
+        # transaction isolation handles it.
+        with self.db.begin() as conn:
+            row = conn.execute(
+                select(self.tables.user.groups).where(self.tables.user.email == email)
+            ).first()
+            if row is None:
+                return
+            current = list(row.groups or [])
+            if group in current:
+                return
+            current.append(group)
+            conn.execute(
+                update(self.tables.user)
+                .where(self.tables.user.email == email)
+                .values(groups=current)
+            )
+
+    def remove_user_group(self, email, group):
+        """Drop ``group`` from the user's group list.
+
+        Mirrors :meth:`MongoDBAuth.remove_user_group`'s
+        ``$pull`` semantics: a no-op if the group is not
+        present.
+        """
+        with self.db.begin() as conn:
+            row = conn.execute(
+                select(self.tables.user.groups).where(self.tables.user.email == email)
+            ).first()
+            if row is None:
+                return
+            current = list(row.groups or [])
+            if group not in current:
+                return
+            current.remove(group)
+            conn.execute(
+                update(self.tables.user)
+                .where(self.tables.user.email == email)
+                .values(groups=current)
+            )
+
+    def get_user_groups(self, email):
+        """Return the user's group list (empty if no user).
+
+        Mirrors :meth:`MongoDBAuth.get_user_groups`.
+        """
+        with self.db.connect() as conn:
+            row = conn.execute(
+                select(self.tables.user.groups).where(self.tables.user.email == email)
+            ).first()
+        if row is None or row.groups is None:
+            return []
+        return list(row.groups)
+
+    def list_users(self, **filters):
+        """Yield user records matching the optional filters.
+
+        Mirrors :meth:`MongoDBAuth.list_users`'s recognised
+        filters: ``is_active`` / ``is_admin`` / ``group``
+        (group membership).  Unknown filters are silently
+        ignored (matches Mongo's accept-any-dict shape).
+        """
+        stmt = select(self.tables.user)
+        if "is_active" in filters:
+            stmt = stmt.where(self.tables.user.is_active == filters["is_active"])
+        if "is_admin" in filters:
+            stmt = stmt.where(self.tables.user.is_admin == filters["is_admin"])
+        if "group" in filters:
+            # PG / DuckDB array contains: ``ANY(col)`` style.
+            stmt = stmt.where(self.tables.user.groups.any(filters["group"]))
+        with self.db.connect() as conn:
+            return [self._row2user(row) for row in conn.execute(stmt)]
+
+    def ensure_remote_user(self, username):
+        """Create the user if it doesn't exist, then return it.
+
+        Mirrors :meth:`MongoDBAuth.ensure_remote_user`: used by
+        the OAuth callback path to provision users on first
+        login.
+        """
+        user = self.get_user_by_email(username)
+        if user is None:
+            self.create_user(username, is_active=True)
+        return self.get_user_by_email(username)
+
+    # -- session CRUD -------------------------------------------------
+
+    def create_session(self, user_email, lifetime=None):
+        """Create a session for ``user_email`` and return the
+        opaque token to set in the client cookie.
+
+        Mirrors :meth:`MongoDBAuth.create_session`: the token
+        is a 32-byte URL-safe random string, the database
+        stores only its SHA-256 hex digest, and
+        ``user.last_login`` is bumped to the current UTC
+        timestamp.
+        """
+        if lifetime is None:
+            lifetime = config.WEB_AUTH_SESSION_LIFETIME
+        token = token_urlsafe(32)
+        token_hash = _sha256_hex(token)
+        now = _now_utc()
+        with self.db.begin() as conn:
+            conn.execute(
+                insert(self.tables.session).values(
+                    token_hash=token_hash,
+                    user_email=user_email,
+                    created_at=now,
+                    expires_at=now + datetime.timedelta(seconds=lifetime),
+                    last_used=now,
+                )
+            )
+            conn.execute(
+                update(self.tables.user)
+                .where(self.tables.user.email == user_email)
+                .values(last_login=now)
+            )
+        return token
+
+    def validate_session(self, token):
+        """Return the associated user dict if the session is
+        valid, ``None`` otherwise.
+
+        Mirrors :meth:`MongoDBAuth.validate_session`: looks up
+        the row by ``token_hash``, rejects if
+        ``expires_at <= now()``, bumps ``last_used`` on success.
+        Expired sessions are not deleted here (matches Mongo's
+        TTL-driven behaviour where the index expires them
+        out-of-band); the operator-driven vacuum is a follow-up.
+        """
+        token_hash = _sha256_hex(token)
+        now = _now_utc()
+        with self.db.begin() as conn:
+            row = conn.execute(
+                select(self.tables.session.id, self.tables.session.user_email).where(
+                    and_(
+                        self.tables.session.token_hash == token_hash,
+                        self.tables.session.expires_at > now,
+                    )
+                )
+            ).first()
+            if row is None:
+                return None
+            conn.execute(
+                update(self.tables.session)
+                .where(self.tables.session.id == row.id)
+                .values(last_used=now)
+            )
+            user_email = row.user_email
+        return self.get_user_by_email(user_email)
+
+    def delete_session(self, token):
+        """Drop the session row identified by ``token``.
+
+        Mirrors :meth:`MongoDBAuth.delete_session`.
+        """
+        token_hash = _sha256_hex(token)
+        with self.db.begin() as conn:
+            conn.execute(
+                delete(self.tables.session).where(
+                    self.tables.session.token_hash == token_hash
+                )
+            )
+
+    # -- API-key CRUD -------------------------------------------------
+
+    def create_api_key(self, user_email, name):
+        """Create an API key for ``user_email`` and return the
+        raw key (the only time it's visible).
+
+        Mirrors :meth:`MongoDBAuth.create_api_key`: the key is
+        ``ivre_<22-char-base64-url>``, stored as SHA-256 hex
+        digest + a 12-char clear-text prefix surfaced in
+        admin UIs.
+        """
+        key = f"ivre_{token_urlsafe(32)}"
+        key_hash = _sha256_hex(key)
+        now = _now_utc()
+        with self.db.begin() as conn:
+            conn.execute(
+                insert(self.tables.api_key).values(
+                    key_hash=key_hash,
+                    key_prefix=key[:12],
+                    user_email=user_email,
+                    name=name,
+                    created_at=now,
+                    expires_at=None,
+                    last_used=None,
+                )
+            )
+        return key
+
+    def validate_api_key(self, key):
+        """Return the associated user dict if the key is valid,
+        ``None`` otherwise.
+
+        Mirrors :meth:`MongoDBAuth.validate_api_key`: rejects
+        if the key is unknown or if ``expires_at`` is set and
+        ``<= now()``; bumps ``last_used`` on success.
+        """
+        key_hash = _sha256_hex(key)
+        now = _now_utc()
+        with self.db.begin() as conn:
+            row = conn.execute(
+                select(self.tables.api_key.id, self.tables.api_key.user_email).where(
+                    and_(
+                        self.tables.api_key.key_hash == key_hash,
+                        or_(
+                            self.tables.api_key.expires_at.is_(None),
+                            self.tables.api_key.expires_at > now,
+                        ),
+                    )
+                )
+            ).first()
+            if row is None:
+                return None
+            conn.execute(
+                update(self.tables.api_key)
+                .where(self.tables.api_key.id == row.id)
+                .values(last_used=now)
+            )
+            user_email = row.user_email
+        return self.get_user_by_email(user_email)
+
+    def list_api_keys(self, user_email=None):
+        """Return every API key record (admin path) or the
+        subset owned by ``user_email`` (self-service path).
+
+        Mirrors :meth:`MongoDBAuth.list_api_keys`.
+        """
+        stmt = select(self.tables.api_key)
+        if user_email is not None:
+            stmt = stmt.where(self.tables.api_key.user_email == user_email)
+        with self.db.connect() as conn:
+            return [self._row2apikey(row) for row in conn.execute(stmt)]
+
+    def delete_api_key(self, key_hash, user_email=None):
+        """Delete the API-key row identified by ``key_hash``,
+        optionally scoped to ``user_email`` (the self-service
+        path's permission check).
+
+        Returns the number of rows deleted, mirroring Mongo's
+        ``deleted_count`` return value so the caller can
+        distinguish "deleted" from "not found / not owned".
+
+        ``DELETE ... RETURNING`` and a row count rather than
+        :attr:`CursorResult.rowcount` because the
+        ``duckdb-engine`` dialect reports ``-1`` for every
+        DELETE statement -- a regression that would otherwise
+        make every caller's ``if deleted:`` check spurious on
+        the DuckDB lane.  PostgreSQL accepts the same shape
+        without overhead.
+        """
+        stmt = delete(self.tables.api_key).where(
+            self.tables.api_key.key_hash == key_hash
+        )
+        if user_email is not None:
+            stmt = stmt.where(self.tables.api_key.user_email == user_email)
+        stmt = stmt.returning(self.tables.api_key.id)
+        with self.db.begin() as conn:
+            return len(list(conn.execute(stmt)))
+
+    # -- magic-link tokens --------------------------------------------
+
+    def create_magic_link_token(self, email, lifetime):
+        """Create a single-use magic-link token for ``email``
+        and return the raw token.
+
+        Mirrors :meth:`MongoDBAuth.create_magic_link_token`.
+        """
+        token = token_urlsafe(32)
+        token_hash = _sha256_hex(token)
+        now = _now_utc()
+        with self.db.begin() as conn:
+            conn.execute(
+                insert(self.tables.magic_link).values(
+                    token_hash=token_hash,
+                    email=email,
+                    created_at=now,
+                    expires_at=now + datetime.timedelta(seconds=lifetime),
+                )
+            )
+        return token
+
+    def consume_magic_link_token(self, token):
+        """Validate and consume a magic-link token in one shot.
+
+        Mirrors :meth:`MongoDBAuth.consume_magic_link_token`'s
+        ``find_one_and_delete`` semantics: returns the
+        associated email on success (and deletes the row so
+        the token cannot be replayed), ``None`` if invalid /
+        expired.  PostgreSQL and DuckDB both support
+        ``DELETE ... RETURNING`` so the atomic exchange
+        survives without an explicit transaction.
+        """
+        token_hash = _sha256_hex(token)
+        now = _now_utc()
+        stmt = (
+            delete(self.tables.magic_link)
+            .where(
+                and_(
+                    self.tables.magic_link.token_hash == token_hash,
+                    self.tables.magic_link.expires_at > now,
+                )
+            )
+            .returning(self.tables.magic_link.email)
+        )
+        with self.db.begin() as conn:
+            row = conn.execute(stmt).first()
+        if row is None:
+            return None
+        return row.email
+
+    # -- rate limiting ------------------------------------------------
+
+    def is_rate_limited(self, key, max_attempts, window):
+        """Return ``True`` if ``key`` has reached
+        ``max_attempts`` attempts in the trailing ``window``
+        seconds.
+
+        Mirrors :meth:`MongoDBAuth.is_rate_limited`: counts
+        rate-limit rows whose ``created_at`` falls inside the
+        window and compares to the threshold.
+        """
+        now = _now_utc()
+        cutoff = now - datetime.timedelta(seconds=window)
+        stmt = (
+            select(func.count())
+            .select_from(self.tables.rate_limit)
+            .where(
+                and_(
+                    self.tables.rate_limit.key == key,
+                    self.tables.rate_limit.created_at > cutoff,
+                )
+            )
+        )
+        with self.db.connect() as conn:
+            count = conn.execute(stmt).scalar() or 0
+        return count >= max_attempts
+
+    def record_rate_limit(self, key):
+        """Append one attempt against the rate-limit ``key``.
+
+        Mirrors :meth:`MongoDBAuth.record_rate_limit`.
+        """
+        with self.db.begin() as conn:
+            conn.execute(
+                insert(self.tables.rate_limit).values(key=key, created_at=_now_utc())
+            )

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -21,6 +21,7 @@
 from sqlalchemy import (
     JSON,
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     Float,
@@ -913,4 +914,202 @@ class Rir(Base):
             "rir",
             ("netname", "descr", "remarks", "notify", "org", "as_name"),
         ),
+    )
+
+
+# Auth (user / session / API key / rate-limit / magic-link tables)
+#
+# Schema mirrors :class:`MongoDBAuth` (``ivre/db/mongo.py:7333``).
+# Mongo stores everything in five collections (``auth_user`` /
+# ``auth_session`` / ``auth_api_key`` / ``auth_rate_limit`` /
+# ``auth_magic_link``); the SQL backend keeps the same column
+# shape so :class:`SQLDBAuth` can reproduce
+# :class:`MongoDBAuth`'s helpers byte-for-byte at the dict-output
+# level.
+#
+# Mongo's TTL indexes (``expireAfterSeconds`` on the session /
+# magic-link / rate-limit collections) have no PostgreSQL or
+# DuckDB equivalent: every read filter that needs the TTL
+# semantics adds an explicit ``WHERE expires_at > now()`` /
+# ``WHERE created_at > cutoff`` predicate.  Periodic cleanup of
+# expired rows is the operator's responsibility (a
+# follow-up ``ivre authcli --vacuum`` may automate it).
+#
+# Foreign keys link sessions / api_keys / magic_links back to
+# the user by *email* (the natural key); IVRE's existing pattern
+# is to drop FK constraints on DuckDB (see ``duckdb.py``'s
+# top-of-module comment), so the SQL helpers cascade deletes in
+# application code rather than relying on ``ON DELETE``.
+
+# Email column is RFC-5321 capped at 254 octets; ``String(254)``
+# fits every practical address.
+_AUTH_EMAIL_LEN = 254
+# Token hashes are SHA-256 hex digests (64 ASCII chars).
+_AUTH_HASH_LEN = 64
+
+_seq_auth_user_id = Sequence("seq_auth_user_id")
+_seq_auth_session_id = Sequence("seq_auth_session_id")
+_seq_auth_api_key_id = Sequence("seq_auth_api_key_id")
+_seq_auth_rate_limit_id = Sequence("seq_auth_rate_limit_id")
+_seq_auth_magic_link_id = Sequence("seq_auth_magic_link_id")
+
+
+class AuthUser(Base):
+    """One IVRE web-auth user record.
+
+    Mirrors :class:`MongoDBAuth`'s ``auth_user`` collection
+    (``mongo.py:7382-7411``).  ``email`` is the natural key
+    every other auth table references (the SQL backend keeps
+    the email as a textual back-pointer rather than a numeric
+    FK to keep the cross-table contract identical to Mongo's
+    document-store form).
+    """
+
+    __tablename__ = "auth_user"
+    id = Column(
+        Integer,
+        _seq_auth_user_id,
+        server_default=_seq_auth_user_id.next_value(),
+        primary_key=True,
+    )
+    email = Column(String(_AUTH_EMAIL_LEN), nullable=False)
+    display_name = Column(Text)
+    is_admin = Column(Boolean, default=False)
+    is_active = Column(Boolean, default=False)
+    # Group membership.  ``ARRAY(String)`` on PG, ``LIST<VARCHAR>``
+    # on DuckDB (the ``duckdb-engine`` dialect compiles the
+    # postgresql ARRAY shape natively).  Operators target the
+    # column via ``func.array_append`` /
+    # ``func.array_remove`` -- DuckDB exposes those under the
+    # same names.
+    groups = Column(SQLARRAY(String(_AUTH_EMAIL_LEN)))
+    created_at = Column(DateTime)
+    last_login = Column(DateTime)
+    schema_version = Column(Integer)
+    __table_args__ = (
+        UniqueConstraint("email", name="auth_user_idx_email"),
+        Index("auth_user_idx_is_active", "is_active"),
+        Index("auth_user_idx_is_admin", "is_admin"),
+        Index("auth_user_idx_schema_version", "schema_version"),
+    )
+
+
+class AuthSession(Base):
+    """One web-auth session record.
+
+    Mirrors :class:`MongoDBAuth`'s ``auth_session`` collection
+    (``mongo.py:7418-7454``).  The ``token_hash`` (SHA-256 hex
+    digest of the opaque session token) is the natural key
+    consulted on every authenticated request.
+    """
+
+    __tablename__ = "auth_session"
+    id = Column(
+        Integer,
+        _seq_auth_session_id,
+        server_default=_seq_auth_session_id.next_value(),
+        primary_key=True,
+    )
+    # ``String(_AUTH_HASH_LEN)`` keeps the column narrow on PG
+    # but cannot grow if the hash algorithm changes; bumping it
+    # would be a one-line ``_migrate_schema_NN_MM`` change.
+    token_hash = Column(String(_AUTH_HASH_LEN), nullable=False)
+    user_email = Column(String(_AUTH_EMAIL_LEN), nullable=False)
+    created_at = Column(DateTime)
+    expires_at = Column(DateTime)
+    last_used = Column(DateTime)
+    __table_args__ = (
+        UniqueConstraint("token_hash", name="auth_session_idx_token_hash"),
+        Index("auth_session_idx_user_email", "user_email"),
+        Index("auth_session_idx_expires_at", "expires_at"),
+    )
+
+
+class AuthApiKey(Base):
+    """One API-key record.
+
+    Mirrors :class:`MongoDBAuth`'s ``auth_api_key`` collection
+    (``mongo.py:7456-7499``).  ``key_prefix`` is the first 12
+    chars of the raw key (clear text); it surfaces in admin
+    UIs so operators can identify a key without seeing its
+    full value.  ``key_hash`` is the SHA-256 hex digest of
+    the full key.
+    """
+
+    __tablename__ = "auth_api_key"
+    id = Column(
+        Integer,
+        _seq_auth_api_key_id,
+        server_default=_seq_auth_api_key_id.next_value(),
+        primary_key=True,
+    )
+    key_hash = Column(String(_AUTH_HASH_LEN), nullable=False)
+    # ``ivre_<22-char-base64-url>``; 32 is safe upper bound.
+    key_prefix = Column(String(32))
+    user_email = Column(String(_AUTH_EMAIL_LEN), nullable=False)
+    name = Column(Text)
+    created_at = Column(DateTime)
+    expires_at = Column(DateTime)
+    last_used = Column(DateTime)
+    __table_args__ = (
+        UniqueConstraint("key_hash", name="auth_api_key_idx_key_hash"),
+        Index("auth_api_key_idx_user_email", "user_email"),
+        Index("auth_api_key_idx_expires_at", "expires_at"),
+    )
+
+
+class AuthRateLimit(Base):
+    """Rolling rate-limit ledger.
+
+    Mirrors :class:`MongoDBAuth`'s ``auth_rate_limit``
+    collection (``mongo.py:7549-7559``).  Each row records one
+    attempt against a rate-limit ``key`` (``"magic:<email>"`` /
+    ``"magic:<ip>"`` etc.); the window check counts rows whose
+    ``created_at`` falls inside the configured time slice.  Old
+    rows accumulate without harm until an operator-driven
+    vacuum runs (Mongo's TTL index buys this for free; we
+    leave the cleanup as a follow-up).
+    """
+
+    __tablename__ = "auth_rate_limit"
+    id = Column(
+        Integer,
+        _seq_auth_rate_limit_id,
+        server_default=_seq_auth_rate_limit_id.next_value(),
+        primary_key=True,
+    )
+    # Free-form key (``"magic:<email>"`` / ``"magic:<ip>"`` /
+    # ...); the helper paths shape the values, the table
+    # itself stays generic.
+    key = Column(String(_AUTH_EMAIL_LEN), nullable=False)
+    created_at = Column(DateTime, nullable=False)
+    __table_args__ = (
+        Index("auth_rate_limit_idx_key_created", "key", "created_at"),
+        Index("auth_rate_limit_idx_created_at", "created_at"),
+    )
+
+
+class AuthMagicLink(Base):
+    """One single-use magic-link token.
+
+    Mirrors :class:`MongoDBAuth`'s ``auth_magic_link`` collection
+    (``mongo.py:7523-7547``).  ``consume_magic_link_token``
+    is the single-shot SELECT-and-DELETE that exchanges the
+    token for the associated email address.
+    """
+
+    __tablename__ = "auth_magic_link"
+    id = Column(
+        Integer,
+        _seq_auth_magic_link_id,
+        server_default=_seq_auth_magic_link_id.next_value(),
+        primary_key=True,
+    )
+    token_hash = Column(String(_AUTH_HASH_LEN), nullable=False)
+    email = Column(String(_AUTH_EMAIL_LEN), nullable=False)
+    created_at = Column(DateTime)
+    expires_at = Column(DateTime)
+    __table_args__ = (
+        UniqueConstraint("token_hash", name="auth_magic_link_idx_token_hash"),
+        Index("auth_magic_link_idx_expires_at", "expires_at"),
     )

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -9181,6 +9181,352 @@ class DocumentDBRirTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBAuthTests -- pin :class:`ivre.db.sql.SQLDBAuth`'s schema +
+# helper SQL shapes + dict-output round-trip semantics.
+#
+# The class is the shared base for the upcoming PostgresDBAuth /
+# DuckDBDBAuth concretes (M4.8.2 / M4.8.3); without backend
+# registration there's no live engine to drive end-to-end here.
+# We verify:
+#   * the five auth tables declare every column the Mongo path
+#     references (column inventory),
+#   * the natural-key UNIQUE constraints + secondary indexes
+#     are declared,
+#   * the helper methods compile against the in-memory DuckDB
+#     engine end-to-end (so the next sub-PR's concrete class
+#     can ride on top with confidence).
+# ---------------------------------------------------------------------
+
+
+try:
+    from ivre.db.sql import SQLDBAuth as _SQLDBAuth_for_tests  # noqa: E402
+    from ivre.db.sql.tables import AuthApiKey as _AuthApiKey_for_tests  # noqa: E402
+    from ivre.db.sql.tables import (  # noqa: E402
+        AuthMagicLink as _AuthMagicLink_for_tests,
+    )
+    from ivre.db.sql.tables import (  # noqa: E402
+        AuthRateLimit as _AuthRateLimit_for_tests,
+    )
+    from ivre.db.sql.tables import AuthSession as _AuthSession_for_tests  # noqa: E402
+    from ivre.db.sql.tables import AuthUser as _AuthUser_for_tests  # noqa: E402
+
+    _HAVE_SQLDB_AUTH = True
+except ImportError:
+    _HAVE_SQLDB_AUTH = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUTH,
+    "SQLAlchemy is required for SQLDBAuthTests",
+)
+class SQLDBAuthSchemaTests(unittest.TestCase):
+    """Pin the auth table inventory.
+
+    The :class:`MongoDBAuth` schema is split across five
+    collections (``auth_user`` / ``auth_session`` /
+    ``auth_api_key`` / ``auth_rate_limit`` /
+    ``auth_magic_link``); the SQL backend keeps the same
+    breakdown.  Each test below verifies the columns / indexes
+    one of these tables must carry so the helper paths land
+    correctly.
+    """
+
+    def test_auth_user_columns(self):
+        cols = {c.name for c in _AuthUser_for_tests.__table__.columns}
+        for expected in (
+            "id",
+            "email",
+            "display_name",
+            "is_admin",
+            "is_active",
+            "groups",
+            "created_at",
+            "last_login",
+            "schema_version",
+        ):
+            self.assertIn(expected, cols)
+
+    def test_auth_user_unique_email(self):
+        constraints = {
+            c.name
+            for c in _AuthUser_for_tests.__table__.constraints
+            if hasattr(c, "name") and c.name is not None
+        }
+        self.assertIn("auth_user_idx_email", constraints)
+
+    def test_auth_session_columns(self):
+        cols = {c.name for c in _AuthSession_for_tests.__table__.columns}
+        for expected in (
+            "id",
+            "token_hash",
+            "user_email",
+            "created_at",
+            "expires_at",
+            "last_used",
+        ):
+            self.assertIn(expected, cols)
+
+    def test_auth_session_unique_token_hash(self):
+        constraints = {
+            c.name
+            for c in _AuthSession_for_tests.__table__.constraints
+            if hasattr(c, "name") and c.name is not None
+        }
+        self.assertIn("auth_session_idx_token_hash", constraints)
+
+    def test_auth_api_key_columns(self):
+        cols = {c.name for c in _AuthApiKey_for_tests.__table__.columns}
+        for expected in (
+            "id",
+            "key_hash",
+            "key_prefix",
+            "user_email",
+            "name",
+            "created_at",
+            "expires_at",
+            "last_used",
+        ):
+            self.assertIn(expected, cols)
+
+    def test_auth_rate_limit_columns(self):
+        cols = {c.name for c in _AuthRateLimit_for_tests.__table__.columns}
+        for expected in ("id", "key", "created_at"):
+            self.assertIn(expected, cols)
+        # The composite index used by :meth:`is_rate_limited`'s
+        # window scan must exist so the helper doesn't degrade
+        # to a sequential scan once the ledger fills up.
+        names = {ix.name for ix in _AuthRateLimit_for_tests.__table__.indexes}
+        self.assertIn("auth_rate_limit_idx_key_created", names)
+
+    def test_auth_magic_link_columns(self):
+        cols = {c.name for c in _AuthMagicLink_for_tests.__table__.columns}
+        for expected in (
+            "id",
+            "token_hash",
+            "email",
+            "created_at",
+            "expires_at",
+        ):
+            self.assertIn(expected, cols)
+
+
+# Live-engine integration test for SQLDBAuth -- gated on
+# ``duckdb-engine`` installed.  Exercises every helper against
+# an in-memory DuckDB so the round-trip semantics
+# (session / API key / magic link / rate limit / group
+# membership) are verified end-to-end.  PostgreSQL-specific
+# concerns (the upcoming M4.8.2 concrete class) live in the
+# next sub-PR's tests.
+try:
+    import duckdb_engine as _duckdb_engine_for_auth_tests  # type: ignore[import-untyped]  # noqa: F401, E402
+
+    _HAVE_DUCKDB_ENGINE_FOR_AUTH = True
+except ImportError:
+    _HAVE_DUCKDB_ENGINE_FOR_AUTH = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUTH and _HAVE_DUCKDB_ENGINE_FOR_AUTH,
+    "duckdb-engine is required (install with the ``duckdb`` extras)",
+)
+class SQLDBAuthLiveIntegrationTests(unittest.TestCase):
+    """End-to-end auth helpers against an in-memory DuckDB.
+
+    Mirrors :class:`MongoDBAuth`'s contract across the full
+    helper surface so the upcoming :class:`PostgresDBAuth` /
+    :class:`DuckDBDBAuth` concretes inherit a known-good
+    implementation.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import os
+        import tempfile
+
+        import sqlalchemy as sa  # type: ignore[import-untyped]
+
+        from ivre.db.sql.duckdb import DuckDBMixin, _is_unsupported_on_duckdb
+        from ivre.db.sql.tables import Base
+
+        cls._auth_tables = [
+            _AuthUser_for_tests.__table__,
+            _AuthSession_for_tests.__table__,
+            _AuthApiKey_for_tests.__table__,
+            _AuthRateLimit_for_tests.__table__,
+            _AuthMagicLink_for_tests.__table__,
+        ]
+        cls._saved_idx = []
+        for tbl in cls._auth_tables:
+            for ix in list(tbl.indexes):
+                if _is_unsupported_on_duckdb(ix):
+                    cls._saved_idx.append((tbl, ix))
+                    tbl.indexes.discard(ix)
+        fd, cls._path = tempfile.mkstemp(suffix=".duckdb")
+        os.close(fd)
+        os.unlink(cls._path)
+        cls._engine = sa.create_engine(f"duckdb:///{cls._path}")
+        Base.metadata.create_all(cls._engine, tables=cls._auth_tables)
+
+        # Build an ad-hoc subclass that pulls in DuckDBMixin
+        # so :meth:`internal2ip` etc. point at the DuckDB
+        # variants.  The class is throwaway -- the next
+        # sub-PR ships the real :class:`DuckDBDBAuth`.
+        class _DuckDBAuthForTests(DuckDBMixin, _SQLDBAuth_for_tests):
+            pass
+
+        cls._db_cls = _DuckDBAuthForTests
+
+    @classmethod
+    def tearDownClass(cls):
+        import os
+
+        cls._engine.dispose()
+        if os.path.exists(cls._path):
+            os.unlink(cls._path)
+        for tbl, ix in cls._saved_idx:
+            tbl.indexes.add(ix)
+
+    def setUp(self):
+        # Drop every row from every auth table so each test
+        # starts from an empty schema.  DuckDB's ``DELETE FROM``
+        # without WHERE clears the table.
+        from sqlalchemy import delete
+
+        with self._engine.begin() as conn:
+            for tbl in self._auth_tables:
+                conn.execute(delete(tbl))
+        self.db = self._db_cls.__new__(self._db_cls)
+        self.db._db = self._engine
+
+    def test_create_and_get_user(self):
+        # ``create_user`` returns the document dict :class:
+        # `MongoDBAuth` produces; ``get_user_by_email``
+        # round-trips every field including the ``groups``
+        # array.
+        created = self.db.create_user(
+            "alice@example.com",
+            display_name="Alice",
+            is_active=True,
+            groups=["admin"],
+        )
+        self.assertEqual(created["email"], "alice@example.com")
+        self.assertEqual(created["groups"], ["admin"])
+        fetched = self.db.get_user_by_email("alice@example.com")
+        self.assertEqual(fetched["email"], "alice@example.com")
+        self.assertEqual(fetched["display_name"], "Alice")
+        self.assertTrue(fetched["is_active"])
+        self.assertFalse(fetched["is_admin"])
+        self.assertEqual(fetched["groups"], ["admin"])
+
+    def test_get_user_returns_none_for_missing(self):
+        self.assertIsNone(self.db.get_user_by_email("nope@example.com"))
+
+    def test_session_round_trip(self):
+        self.db.create_user("alice@example.com", is_active=True)
+        token = self.db.create_session("alice@example.com", lifetime=60)
+        user = self.db.validate_session(token)
+        self.assertIsNotNone(user)
+        self.assertEqual(user["email"], "alice@example.com")
+        # The user's ``last_login`` is bumped on session
+        # creation.
+        self.assertIsNotNone(user["last_login"])
+        # Drop the session -> subsequent validation returns
+        # None.
+        self.db.delete_session(token)
+        self.assertIsNone(self.db.validate_session(token))
+
+    def test_api_key_round_trip(self):
+        self.db.create_user("alice@example.com", is_active=True)
+        key = self.db.create_api_key("alice@example.com", "test key")
+        # Raw key surfaces once; the database stores only the
+        # SHA-256 hex digest.
+        self.assertTrue(key.startswith("ivre_"))
+        user = self.db.validate_api_key(key)
+        self.assertEqual(user["email"], "alice@example.com")
+        keys = self.db.list_api_keys("alice@example.com")
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0]["key_prefix"], key[:12])
+        # ``delete_api_key`` returns the deleted row count;
+        # the DuckDB-specific RETURNING-based override
+        # produces the right number even though
+        # ``cursor.rowcount`` reports ``-1`` on the DuckDB
+        # dialect.
+        self.assertEqual(self.db.delete_api_key(keys[0]["key_hash"]), 1)
+        # Subsequent delete on the same hash is a no-op.
+        self.assertEqual(self.db.delete_api_key(keys[0]["key_hash"]), 0)
+
+    def test_magic_link_single_use(self):
+        token = self.db.create_magic_link_token("alice@example.com", lifetime=300)
+        self.assertEqual(self.db.consume_magic_link_token(token), "alice@example.com")
+        # Second consume fails -- the row was deleted
+        # atomically by the first.
+        self.assertIsNone(self.db.consume_magic_link_token(token))
+
+    def test_rate_limit_threshold(self):
+        # Empty ledger -> not limited.
+        self.assertFalse(
+            self.db.is_rate_limited("magic:alice", max_attempts=3, window=60)
+        )
+        for _ in range(3):
+            self.db.record_rate_limit("magic:alice")
+        # Reached the threshold (>= max_attempts).
+        self.assertTrue(
+            self.db.is_rate_limited("magic:alice", max_attempts=3, window=60)
+        )
+        # A different key shares no state.
+        self.assertFalse(
+            self.db.is_rate_limited("magic:bob", max_attempts=3, window=60)
+        )
+
+    def test_group_membership_is_idempotent(self):
+        self.db.create_user("alice@example.com")
+        self.db.add_user_group("alice@example.com", "audit")
+        # Re-adding the same group is a no-op (mirrors
+        # ``$addToSet``).
+        self.db.add_user_group("alice@example.com", "audit")
+        self.assertEqual(self.db.get_user_groups("alice@example.com"), ["audit"])
+        self.db.remove_user_group("alice@example.com", "audit")
+        self.assertEqual(self.db.get_user_groups("alice@example.com"), [])
+        # Removing a missing group is a no-op too.
+        self.db.remove_user_group("alice@example.com", "audit")
+
+    def test_list_users_filters(self):
+        self.db.create_user("alice@example.com", is_active=True, is_admin=True)
+        self.db.create_user("bob@example.com", is_active=True, groups=["audit"])
+        self.db.create_user("carol@example.com")  # is_active=False
+        actives = self.db.list_users(is_active=True)
+        self.assertEqual(
+            {u["email"] for u in actives}, {"alice@example.com", "bob@example.com"}
+        )
+        admins = self.db.list_users(is_admin=True)
+        self.assertEqual({u["email"] for u in admins}, {"alice@example.com"})
+        auditors = self.db.list_users(group="audit")
+        self.assertEqual({u["email"] for u in auditors}, {"bob@example.com"})
+
+    def test_ensure_remote_user_creates_then_fetches(self):
+        # First call creates the user as ``is_active=True``;
+        # second call finds the existing record.
+        self.assertIsNone(self.db.get_user_by_email("carol@example.com"))
+        user = self.db.ensure_remote_user("carol@example.com")
+        self.assertEqual(user["email"], "carol@example.com")
+        self.assertTrue(user["is_active"])
+        # No duplicate user is created on the second call.
+        again = self.db.ensure_remote_user("carol@example.com")
+        self.assertEqual(again["_id"], user["_id"])
+
+    def test_delete_user_cascades(self):
+        self.db.create_user("alice@example.com", is_active=True)
+        self.db.create_session("alice@example.com", lifetime=60)
+        self.db.create_api_key("alice@example.com", "k1")
+        self.db.create_magic_link_token("alice@example.com", lifetime=60)
+        self.db.delete_user("alice@example.com")
+        # User gone.
+        self.assertIsNone(self.db.get_user_by_email("alice@example.com"))
+        # Sessions / api-keys / magic-links cascaded.
+        self.assertEqual(self.db.list_api_keys("alice@example.com"), [])
+
+
+# ---------------------------------------------------------------------
 # HttpDBFlowTests -- pin :class:`ivre.db.http.HttpDBFlow`'s URL /
 # request-body shapes.  The HTTP backend proxies every flow query
 # to a remote IVRE's ``/flows`` endpoint; without these tests a


### PR DESCRIPTION
Open the M4.8 'Auth on PG + DuckDB + DocumentDB + HTTP' matrix by bringing the authentication data category to the SQL backend in a backend-agnostic shape.  Concrete dialects (PostgresDBAuth / DuckDBDBAuth) ride on top in the next sub-PRs; this commit lands the schema and the SQLDBAuth shared base only -- no backend registration yet.

Schema (ivre/db/sql/tables.py):
- Five tables mirroring MongoDBAuth's five collections (mongo.py:7333):
  * auth_user: id, email UNIQUE, display_name, is_admin, is_active, groups (ARRAY of String), created_at, last_login, schema_version.
  * auth_session: id, token_hash UNIQUE (SHA-256 hex), user_email, created_at, expires_at, last_used.
  * auth_api_key: id, key_hash UNIQUE, key_prefix (the clear-text 'ivre_<...>' prefix surfaced in admin UIs), user_email, name, created_at, expires_at, last_used.
  * auth_rate_limit: id, key, created_at + composite (key, created_at) index for the window scan.
  * auth_magic_link: id, token_hash UNIQUE, email, created_at, expires_at.
- Mongo's TTL indexes (expireAfterSeconds) have no SQL equivalent; every read filter that needs the TTL semantics adds an explicit WHERE expires_at > now() / WHERE created_at > cutoff predicate.  Periodic cleanup of expired rows is a follow-up.
- No foreign-key constraints (matches the established pattern -- DuckDB's CASCADE limitations would otherwise force per-backend overrides).  Sessions / api-keys / magic-links reference the user by email; delete_user cascades in application code.

SQLDBAuth (ivre/db/sql/__init__.py):
- Implements every abstract DBAuth method byte-for-byte at the dict-output level: get_user_by_email, create_user, update_user, delete_user (cascading), add_user_group / remove_user_group (idempotent via read-then-write to emulate Mongo's $addToSet / $pull), get_user_groups, list_users (is_active / is_admin / group filters), ensure_remote_user, create_session / validate_session / delete_session, create_api_key / validate_api_key / list_api_keys / delete_api_key, create_magic_link_token / consume_magic_link_token (atomic via DELETE ... RETURNING), is_rate_limited / record_rate_limit.
- _row2user / _row2apikey project rows back into the dict shape MongoDBAuth returns so the web layer sees one shape on either backend.
- delete_api_key counts rows via DELETE ... RETURNING instead of cursor.rowcount because duckdb-engine reports -1 for every DELETE -- the RETURNING path produces the right count on both PG and DuckDB.

Pinned by 7 SQLDBAuthSchemaTests (column inventories + UNIQUE constraints + composite indexes) and 10
SQLDBAuthLiveIntegrationTests against an in-memory DuckDB covering: user CRUD, session round-trip, API key
round-trip (incl. the delete_api_key RETURNING count), magic-link single-use semantics, rate-limit threshold, group idempotency, list_users filters, ensure_remote_user de-duplication, and the delete_user cascade.