### PR TITLE
feat(db/sql): register DuckDBAuth for web-auth on DuckDB

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -5797,6 +5797,7 @@ class DBAuth(DB):
     backends = {
         "mongodb": ("mongo", "MongoDBAuth"),
         "postgresql": ("sql.postgres", "PostgresDBAuth"),
+        "duckdb": ("sql.duckdb", "DuckDBAuth"),
     }
 
     def get_user_by_email(self, email):

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -71,6 +71,7 @@ from sqlalchemy.dialects import postgresql
 from ivre import utils
 from ivre.db.sql import NmapFilter, ViewFilter
 from ivre.db.sql.postgres import (
+    PostgresDBAuth,
     PostgresDBFlow,
     PostgresDBNmap,
     PostgresDBPassive,
@@ -1037,4 +1038,45 @@ class DuckDBRir(DuckDBMixin, PostgresDBRir):
     extension's ``match_bm25`` will land in a follow-up
     sub-PR alongside the equivalent DuckDB
     ``PRAGMA create_fts_index`` glue.
+    """
+
+
+class DuckDBAuth(DuckDBMixin, PostgresDBAuth):
+    """DuckDB backend for the web-auth data category.
+
+    Pure inheritance from :class:`PostgresDBAuth`: every helper
+    :class:`SQLDBAuth` declares already uses portable SQL
+    primitives DuckDB supports natively -- ``DELETE ...
+    RETURNING`` for the magic-link single-use exchange,
+    ``WHERE expires_at > now()`` for the TTL replacement,
+    ``LIST<VARCHAR>`` columns + ``ANY()`` containment for the
+    group-membership filter, ``Boolean`` columns for the
+    ``is_admin`` / ``is_active`` flags, ``executemany``
+    ``INSERT`` for the bulk paths (there is none here -- auth
+    is single-row).
+
+    The :class:`DuckDBMixin` placement at the front of the MRO
+    is the established pattern (matches
+    :class:`~ivre.db.sql.duckdb.DuckDBNmap` /
+    :class:`DuckDBView` / :class:`DuckDBPassive` /
+    :class:`DuckDBFlow` / :class:`DuckDBRir`); its dialect
+    overrides win the lookup against
+    :class:`~ivre.db.sql.postgres.PostgresDB`'s defaults so
+    DuckDB-specific behaviour (the DuckDB-aware
+    ``internal2ip`` / ``ip2internal`` / ``_searchstring_re``
+    overrides) carries over to the auth helpers.
+
+    No schema adapter is required at this point: every auth
+    column type (``Integer``, ``String``, ``Text``,
+    ``Boolean``, ``DateTime``, ``ARRAY(String)``) compiles
+    cleanly on both PostgreSQL and DuckDB without a
+    ``with_variant`` adapter -- DuckDB rejects ``INET`` as
+    an index key (the Rir / Flow schema fix), but no auth
+    column uses ``INET``.
+
+    The ``duckdb-engine`` quirk where ``cursor.rowcount``
+    reports ``-1`` on every DELETE statement is already
+    handled by :class:`SQLDBAuth`'s shared helpers
+    (:meth:`SQLDBAuth.delete_api_key` counts via ``DELETE
+    ... RETURNING`` instead).
     """

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -9199,7 +9199,6 @@ class DocumentDBRirTests(unittest.TestCase):
 
 
 try:
-    from ivre.db.sql import SQLDBAuth as _SQLDBAuth_for_tests  # noqa: E402
     from ivre.db.sql.tables import AuthApiKey as _AuthApiKey_for_tests  # noqa: E402
     from ivre.db.sql.tables import (  # noqa: E402
         AuthMagicLink as _AuthMagicLink_for_tests,
@@ -9345,7 +9344,7 @@ class SQLDBAuthLiveIntegrationTests(unittest.TestCase):
 
         import sqlalchemy as sa  # type: ignore[import-untyped]
 
-        from ivre.db.sql.duckdb import DuckDBMixin, _is_unsupported_on_duckdb
+        from ivre.db.sql.duckdb import _is_unsupported_on_duckdb
         from ivre.db.sql.tables import Base
 
         cls._auth_tables = [
@@ -9367,14 +9366,15 @@ class SQLDBAuthLiveIntegrationTests(unittest.TestCase):
         cls._engine = sa.create_engine(f"duckdb:///{cls._path}")
         Base.metadata.create_all(cls._engine, tables=cls._auth_tables)
 
-        # Build an ad-hoc subclass that pulls in DuckDBMixin
-        # so :meth:`internal2ip` etc. point at the DuckDB
-        # variants.  The class is throwaway -- the next
-        # sub-PR ships the real :class:`DuckDBDBAuth`.
-        class _DuckDBAuthForTests(DuckDBMixin, _SQLDBAuth_for_tests):
-            pass
+        # Use the real :class:`DuckDBAuth` class -- the shared
+        # :class:`SQLDBAuth` base lives in
+        # ``ivre/db/sql/__init__.py`` and the concrete DuckDB
+        # backend pulls in :class:`DuckDBMixin` (so the
+        # dialect-aware ``internal2ip`` / ``ip2internal`` /
+        # FTS overrides apply).
+        from ivre.db.sql.duckdb import DuckDBAuth
 
-        cls._db_cls = _DuckDBAuthForTests
+        cls._db_cls = DuckDBAuth
 
     @classmethod
     def tearDownClass(cls):
@@ -9654,6 +9654,60 @@ class PostgresDBAuthTests(unittest.TestCase):
         self.assertIn("SELECT count(*) AS count_1", sql)
         self.assertIn("FROM auth_rate_limit", sql)
         self.assertIn("auth_rate_limit.key = 'magic:alice'", sql)
+
+
+# ---------------------------------------------------------------------
+# DuckDBAuthTests -- pin :class:`ivre.db.sql.duckdb.DuckDBAuth`.
+#
+# Pure inheritance from :class:`PostgresDBAuth` with the
+# established :class:`DuckDBMixin` front-of-MRO placement so the
+# dialect-aware ``internal2ip`` / ``ip2internal`` /
+# ``_searchstring_re`` overrides apply.  The end-to-end auth
+# semantics are already covered by
+# :class:`SQLDBAuthLiveIntegrationTests` (which now exercises
+# the real :class:`DuckDBAuth` class against an in-memory DuckDB
+# engine); this class adds the backend-dispatch + MRO pins so a
+# future refactor that drops the registration surfaces here.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUTH,
+    "SQLAlchemy is required for DuckDBAuthTests",
+)
+class DuckDBAuthTests(unittest.TestCase):
+    """Behaviour-pin for :class:`DuckDBAuth`."""
+
+    def test_backend_registered(self):
+        from ivre.db import DBAuth
+
+        self.assertEqual(
+            DBAuth.backends.get("duckdb"),
+            ("sql.duckdb", "DuckDBAuth"),
+        )
+
+    def test_mro(self):
+        # DuckDBMixin first (its dialect overrides win the
+        # lookup against PostgresDB's), then PostgresDBAuth
+        # so the SQL implementation is reachable.
+        from ivre.db.sql.duckdb import DuckDBAuth
+
+        mro = [c.__name__ for c in DuckDBAuth.__mro__]
+        self.assertEqual(mro[0], "DuckDBAuth")
+        self.assertEqual(mro[1], "DuckDBMixin")
+        self.assertEqual(mro[2], "PostgresDBAuth")
+
+    def test_table_layout_inherited(self):
+        # The five auth tables :class:`SQLDBAuth` declares
+        # come through unchanged on DuckDB -- no per-dialect
+        # schema variant is needed because no auth column
+        # uses INET.
+        from ivre.db.sql.duckdb import DuckDBAuth
+
+        self.assertEqual(
+            set(DuckDBAuth.tables._asdict().keys()),
+            {"user", "session", "api_key", "rate_limit", "magic_link"},
+        )
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Continue M4.8 by bringing the auth data category to the DuckDB backend.  Pure inheritance from :class:`PostgresDBAuth`: every helper :class:`SQLDBAuth` declares already uses portable SQL primitives DuckDB supports natively (DELETE ... RETURNING for the magic-link single-use exchange, WHERE expires_at > now() for the TTL replacement, LIST<VARCHAR> columns + ANY() for the group-membership filter, Boolean for the is_admin / is_active flags).  The :class:`DuckDBMixin` placement at the front of the MRO mirrors the established pattern for the other DuckDB* classes so its dialect-aware overrides (internal2ip / ip2internal / _searchstring_re) win the lookup against PostgresDB's defaults.

No schema adapter is required at this point: every auth column type (Integer, String, Text, Boolean, DateTime, ARRAY(String)) compiles cleanly on both PostgreSQL and DuckDB without a with_variant adapter -- no auth column uses the INET type that forced the variant for Rir's Host.addr.

The duckdb-engine quirk where cursor.rowcount reports -1 on every DELETE is already handled by SQLDBAuth's shared helpers (delete_api_key counts via DELETE ... RETURNING instead).

Backend registration: DBAuth.backends['duckdb'] =
('sql.duckdb', 'DuckDBAuth').

Also updates :class:`SQLDBAuthLiveIntegrationTests` (landed in M4.8.1 as an ad-hoc DuckDBMixin subclass) to use the real :class:`DuckDBAuth` class -- the existing 10
roundtrip tests (user CRUD, session, API key incl. the RETURNING count, magic-link single-use, rate limit, group idempotency, list_users filters, ensure_remote_user dedup, delete_user cascade) now exercise the registered backend end-to-end.

Pinned by 3 new DuckDBAuthTests covering backend dispatch, the (DuckDBMixin, PostgresDBAuth) MRO, and the inherited table_layout inventory.