### PR TITLE
feat(db/document): register DocumentDBAuth for web-auth

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -5796,6 +5796,7 @@ class DBAuth(DB):
 
     backends = {
         "mongodb": ("mongo", "MongoDBAuth"),
+        "documentdb": ("document", "DocumentDBAuth"),
         "postgresql": ("sql.postgres", "PostgresDBAuth"),
         "duckdb": ("sql.duckdb", "DuckDBAuth"),
     }

--- a/ivre/db/document.py
+++ b/ivre/db/document.py
@@ -103,6 +103,7 @@ operators running IVRE on cloud-native infrastructure.
 
 from ivre.db.mongo import (
     MongoDBActive,
+    MongoDBAuth,
     MongoDBFlow,
     MongoDBNmap,
     MongoDBPassive,
@@ -146,3 +147,40 @@ class DocumentDBRir(MongoDBRir):
     # text-index removal is the only adjustment needed for
     # parity.
     indexes = [MongoDBRir.indexes[0][:-1]]
+
+
+class DocumentDBAuth(MongoDBAuth):
+    """DocumentDB backend for the web-auth data category.
+
+    Pure inheritance from :class:`MongoDBAuth`: every operator
+    the auth helpers emit is supported on AWS DocumentDB at
+    the MongoDB 5.0 compatibility level the
+    ``documentdb.yml`` CI workflow exercises (``$set`` /
+    ``$addToSet`` / ``$pull`` / ``$or`` / ``$gt`` / ``$lt`` /
+    ``$in``, ``insert_one`` / ``find_one`` /
+    ``find_one_and_delete`` / ``update_one`` / ``delete_one``
+    / ``delete_many`` / ``count_documents``).  ``MongoDBAuth``
+    has no text index and no ``$text`` operator (auth records
+    carry no free-text fields the web layer searches), so the
+    index list survives unchanged -- no override needed.
+
+    TTL indexes (``expireAfterSeconds`` on the
+    ``auth_session`` / ``auth_rate_limit`` / ``auth_magic_link``
+    collections) are supported on DocumentDB since the 4.0
+    compatibility level; the existing
+    :class:`MongoDBAuth.indexes` declarations apply
+    unchanged.
+
+    No ``$floor`` aggregation operator
+    (:class:`MongoDBActive.topvalues` /
+    :class:`MongoDBPassive.topvalues` use it -- auth helpers
+    don't), and no long-running cursors that would need the
+    ``no_cursor_timeout`` flip
+    (:class:`MongoDB.migrate_schema` is the only consumer --
+    auth records have no schema migration at this
+    generation).  ``is_documentdb = True`` is set anyway so
+    a future helper that grows one of those usage patterns
+    picks up the existing workarounds automatically.
+    """
+
+    is_documentdb = True

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -9711,6 +9711,81 @@ class DuckDBAuthTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# DocumentDBAuthTests -- pin :class:`ivre.db.document.DocumentDBAuth`.
+#
+# Pure inheritance from :class:`MongoDBAuth` with the
+# ``is_documentdb = True`` flag enabling the existing
+# ``MongoDBAuth`` workarounds for the few DocumentDB-incompatible
+# patterns (none currently exercised in the auth helpers -- the
+# flag is set for forward compatibility).
+#
+# Auth records carry no free-text fields the web layer
+# searches, so :class:`MongoDBAuth.indexes` has no ``"text"``
+# index entry that would need stripping (unlike
+# :class:`DocumentDBRir`).  Every operator the helpers emit
+# (``$set`` / ``$addToSet`` / ``$pull`` / ``$or`` / ``$gt`` /
+# ``$lt`` / ``$in``, ``find_one_and_delete``,
+# ``count_documents``) is supported on AWS DocumentDB at the
+# MongoDB 5.0 compatibility level the documentdb.yml CI
+# workflow targets.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_PYMONGO,
+    "pymongo is required for DocumentDBAuthTests",
+)
+class DocumentDBAuthTests(unittest.TestCase):
+    """Behaviour-pin for :class:`ivre.db.document.DocumentDBAuth`."""
+
+    def test_backend_registered(self):
+        from ivre.db import DBAuth
+
+        self.assertEqual(
+            DBAuth.backends.get("documentdb"),
+            ("document", "DocumentDBAuth"),
+        )
+
+    def test_subclasses_mongodb_auth(self):
+        # Pure inheritance from :class:`MongoDBAuth`; the
+        # ``is_documentdb`` flag activates the existing
+        # ``MongoDBAuth`` workarounds (none currently
+        # exercised on this code path -- set for forward
+        # compatibility).
+        from ivre.db.document import DocumentDBAuth
+        from ivre.db.mongo import MongoDBAuth
+
+        self.assertTrue(issubclass(DocumentDBAuth, MongoDBAuth))
+        self.assertTrue(DocumentDBAuth.is_documentdb)
+
+    def test_no_text_index(self):
+        # Auth records carry no free-text fields the web
+        # layer searches, so :class:`MongoDBAuth.indexes`
+        # has no ``"text"`` index entry.  Pin so a future
+        # refactor that adds one (which DocumentDB would
+        # reject) surfaces here.
+        from ivre.db.document import DocumentDBAuth
+
+        for col_indexes in DocumentDBAuth.indexes:
+            for index_keys, _kwargs in col_indexes:
+                for _field, index_type in index_keys:
+                    self.assertNotEqual(
+                        index_type,
+                        "text",
+                        f"DocumentDBAuth.indexes contains a text index: {index_keys}",
+                    )
+
+    def test_indexes_inherit_unchanged(self):
+        # The full :class:`MongoDBAuth.indexes` structure
+        # passes through unchanged (no per-column override
+        # needed, unlike :class:`DocumentDBRir`).
+        from ivre.db.document import DocumentDBAuth
+        from ivre.db.mongo import MongoDBAuth
+
+        self.assertEqual(DocumentDBAuth.indexes, MongoDBAuth.indexes)
+
+
+# ---------------------------------------------------------------------
 # HttpDBFlowTests -- pin :class:`ivre.db.http.HttpDBFlow`'s URL /
 # request-body shapes.  The HTTP backend proxies every flow query
 # to a remote IVRE's ``/flows`` endpoint; without these tests a


### PR DESCRIPTION
Close the M4.8 'Auth on PG + DuckDB + DocumentDB' matrix by bringing the auth data category to the DocumentDB backend. Pure inheritance from :class:`MongoDBAuth`: every operator the auth helpers emit ($set / $addToSet / $pull / $or / $gt / $lt / $in, insert_one / find_one /
find_one_and_delete / update_one / delete_one / delete_many / count_documents) is supported on AWS DocumentDB at the MongoDB 5.0 compatibility level the documentdb.yml CI workflow targets.

Auth records carry no free-text fields the web layer searches, so :class:`MongoDBAuth.indexes` has no "text" index entry that would need stripping (unlike
:class:`DocumentDBRir`).  Every index (UNIQUE on email / token_hash / key_hash, secondary on user_email,
expireAfterSeconds TTL on expires_at / created_at) passes through unchanged -- DocumentDB has supported TTL indexes since the 4.0 compatibility level.

The is_documentdb = True flag is set for forward
compatibility even though no auth helper currently emits one of the DocumentDB-incompatible patterns the flag gates ($floor aggregation, no_cursor_timeout cursor flip).  A future helper that grows one of those usage patterns will pick up the existing :class:`MongoDBAuth` workarounds automatically.

Backend registration: DBAuth.backends['documentdb'] = ('document', 'DocumentDBAuth').

Pinned by 4 new DocumentDBAuthTests covering backend dispatch, MRO + is_documentdb flag, the no-text-index invariant, and the byte-for-byte index inheritance from MongoDBAuth.

M4.8 is now complete: the auth data category lives on PostgreSQL, DuckDB, MongoDB, and DocumentDB.  HTTP is intentionally out of scope -- authentication state belongs to the IVRE web instance fronting the data store (see the matrix in ROADMAP.md s2 and the milestone M4.8 detail).