### PR TITLE
feat(db): capability registry on each backend + skip migration sweep

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -114,6 +114,37 @@ class DB:
     list_fields = []
     text_fields = []
     cursor_timeout_exceptions = ()
+    # Capability registry consumed by the test suite (see
+    # :func:`tests.tests.IvreTests`) and by future callers that
+    # want to branch on backend behaviour without hard-coding
+    # the ``DATABASE`` environment variable.  Concrete backend
+    # subclasses extend this with capability flags they
+    # support; the default empty frozenset means "no opt-in
+    # behaviour".  Membership is tested as
+    # ``"<flag>" in db.<purpose>.supports``.  Existing flags:
+    #
+    # * ``view_seed_from_mongo_dump`` -- the view backend
+    #   seeds from a Mongo dump produced by the nmap/passive
+    #   lanes' CI matrix (Elasticsearch only).
+    # * ``passive_no_bulk_ingestion`` -- the passive backend
+    #   accepts ``ivre passiverecon2db --no-bulk`` end-to-end
+    #   (every backend except PostgreSQL today; PG's
+    #   per-record path is broken under the real-world p0f
+    #   fixture pending a deferred investigation).
+    # * ``passive_source_field_invariant`` -- the passive
+    #   backend's ``source`` column is reachable for the
+    #   "no NULL source field" sanity check (MongoDB API
+    #   shape only).
+    # * ``flow_array_topvalues`` -- the flow backend's
+    #   ``topvalues`` aggregate unwinds array-typed columns
+    #   (``sports``, ``times``, ...) and the ``meta.<name>``
+    #   sub-document (MongoDB only; SQL backends defer the
+    #   ``meta`` JSONB merge and the timeslot ingestion).
+    # * ``nmap_init_terminates`` -- ``ivre scancli --init``
+    #   terminates cleanly in the test cleanup phase (every
+    #   backend except PostgreSQL today; PG hangs -- root
+    #   cause not yet investigated).
+    supports = frozenset()
 
     def __init__(self):
         self.argparser = ArgumentParser(add_help=False)

--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -3511,6 +3511,15 @@ return result;
 
 
 class ElasticDBView(ElasticDBActive, DBView):
+    # The Elasticsearch view backend is populated from a
+    # MongoDB dump produced by the upstream nmap/passive lanes
+    # (the CI matrix runs the dump as a separate step, then
+    # restores it into a sidecar MongoDB before driving
+    # ``ivre db2view`` from there into Elasticsearch).  The
+    # flag gates the ``test_20_fake_nmap_passive`` setup that
+    # only makes sense on the elastic lane.
+    supports = frozenset({"view_seed_from_mongo_dump"})
+
     def __init__(self, url):
         super().__init__(url)
         self.indexes = [

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -4355,6 +4355,10 @@ class MongoDBActive(MongoDB, DBActive):
 
 
 class MongoDBNmap(MongoDBActive, DBNmap):
+    # ``scancli --init`` terminates cleanly on every backend
+    # except PostgreSQL (the PG path hangs in the cleanup phase
+    # of ``test_90_cleanup``; root cause not yet investigated).
+    supports = frozenset({"nmap_init_terminates"})
     content_handler = Nmap2Mongo
     schema_migrations_indexes: list[
         dict[int, dict[str, list[tuple[list[IndexKey] | str, dict[str, Any]]]]]
@@ -4658,6 +4662,16 @@ class MongoDBView(MongoDBActive, DBView):
 
 
 class MongoDBPassive(MongoDB, DBPassive):
+    # Mongo's ``passive`` collection supports both the per-row
+    # ingestion path (``ivre passiverecon2db --no-bulk``) and
+    # the bulk ones; PostgreSQL's per-row path is broken under
+    # the real-world p0f fixture pending a deferred
+    # investigation.  ``passive_source_field_invariant`` gates
+    # the ``test_40_passive`` MongoDB-API sanity check that
+    # ``rec["source"]`` is never ``None``.
+    supports = frozenset(
+        {"passive_no_bulk_ingestion", "passive_source_field_invariant"}
+    )
     column_passive = 0
     _features_column = 0
     indexes = [
@@ -6174,6 +6188,14 @@ class MongoDBRir(MongoDB, DBRir):
 
 
 class MongoDBFlow(MongoDB, DBFlow, metaclass=DBFlowMeta):
+    # Mongo's flow ``topvalues`` unwinds array-typed columns
+    # (``sports`` / ``codes`` / ``times``) and the per-protocol
+    # ``meta.<name>`` JSONB sub-documents via ``$unwind`` /
+    # ``$objectToArray``; the SQL backends defer the
+    # ``meta`` JSONB merge and the ``times`` timeslot
+    # ingestion, so the equivalent ``topvalues`` paths over
+    # the array forms are not available there yet.
+    supports = frozenset({"flow_array_topvalues"})
     column_flow = 0
 
     datefields = [

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -855,6 +855,12 @@ class _DuckDBActiveSearchMixin:
 class DuckDBNmap(DuckDBMixin, _DuckDBActiveSearchMixin, PostgresDBNmap):
     """DuckDB backend for the ``nmap`` (active-scan) data category."""
 
+    # ``scancli --init`` terminates cleanly here (unlike the
+    # PostgreSQL backend whose cleanup phase hangs); the test
+    # cleanup path branches on this flag instead of the
+    # backend name.
+    supports = frozenset({"nmap_init_terminates"})
+
     base_filter = DuckDBNmapFilter
 
     # The override is an instance method (``self``) where the
@@ -904,6 +910,11 @@ class DuckDBPassive(DuckDBMixin, PostgresDBPassive):
     :exc:`NotImplementedError` on DuckDB until parity work
     lands.  Per-row :meth:`insert_or_update` works today.
     """
+
+    # Per-row ingestion (``ivre passiverecon2db --no-bulk``)
+    # works on DuckDB; the bulk-only restriction PG carries
+    # does not apply here.
+    supports = frozenset({"passive_no_bulk_ingestion"})
 
 
 class DuckDBFlow(DuckDBMixin, PostgresDBFlow):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -692,7 +692,10 @@ class IvreTests(unittest.TestCase):
         purposes to feed Elasticsearch view.
 
         """
-        if DATABASE != "elastic":
+        # Capability-gated: only the view backends that seed
+        # their data from a Mongo dump produced by the upstream
+        # nmap / passive CI lanes (Elasticsearch today) opt in.
+        if "view_seed_from_mongo_dump" not in ivre.db.db.view.supports:
             return
         subprocess.check_call(["mongorestore", "--db", "ivre", "../backup/"])
         for cmd in ["scancli", "ipinfo"]:
@@ -1349,6 +1352,17 @@ class IvreTests(unittest.TestCase):
         for query in queries:
             result = ivre.db.db.nmap.get(query)
             count = ivre.db.db.nmap.count(query)
+            # Intentional DATABASE branch -- the ``explain``
+            # output shape is dialect-specific and matched by
+            # very different assertions (Mongo emits a JSON
+            # blob whose ``nscanned`` / ``executionStats``
+            # field carries the document-scan count; PG emits
+            # the textual ``EXPLAIN`` plan and the only
+            # assertion that survives across query optimisers
+            # is the index-name substring).  Migrating this
+            # block to a capability flag would split each
+            # half behind its own ``if`` and add no
+            # readability, so the branch stays.
             if DATABASE == "mongo":
                 nscanned = json.loads(
                     ivre.db.db.nmap.explain(ivre.db.db.nmap._get(query))
@@ -1796,11 +1810,15 @@ class IvreTests(unittest.TestCase):
         self.assertEqual(count, 0)
 
     def test_40_passive(self):
-        if DATABASE == "postgres":
-            # FIXME: tests are broken with PostgreSQL & --no-bulk
-            bulk_mode = random.choice(["--bulk", "--local-bulk"])
-        else:
+        # Capability-gated: only the backends whose per-row
+        # ingestion path works end-to-end accept ``--no-bulk``;
+        # PostgreSQL's per-record path is broken under the
+        # real-world p0f fixture pending a deferred
+        # investigation.
+        if "passive_no_bulk_ingestion" in ivre.db.db.passive.supports:
             bulk_mode = random.choice(["--bulk", "--no-bulk", "--local-bulk"])
+        else:
+            bulk_mode = random.choice(["--bulk", "--local-bulk"])
         print("Running passive tests with %s" % bulk_mode)
 
         # Init DB
@@ -2650,7 +2668,12 @@ class IvreTests(unittest.TestCase):
 
         signal.signal(signal.SIGALRM, old_handler)
 
-        if DATABASE == "mongo":
+        # Capability-gated: the MongoDB-API ``get(flt_empty,
+        # fields=["source"])`` shape this sanity check relies
+        # on is set on the passive backend whose document
+        # model exposes ``source`` as a typed top-level field
+        # (MongoDB today).
+        if "passive_source_field_invariant" in ivre.db.db.passive.supports:
             # Check no None value can actually exist in DB
             self.assertFalse(
                 None
@@ -3295,7 +3318,14 @@ class IvreTests(unittest.TestCase):
             collect_fields=["src.addr", "dst.addr"],
         )
 
-        if DATABASE == "mongo":
+        # Capability-gated: ``topvalues`` over array-typed
+        # columns (``sports``, ``times``) and per-protocol
+        # ``meta.<name>`` sub-documents requires the backend
+        # to unwind those forms in its aggregation pipeline
+        # (MongoDB's ``$unwind`` does it; the SQL backends
+        # defer the ``meta`` JSONB merge and the timeslot
+        # ingestion).
+        if "flow_array_topvalues" in ivre.db.db.flow.supports:
             # More top values test
             self.check_flow_top_values("flow_top_sport", ["sport"])
             self.check_flow_top_values("flow_top_sport", ["sports"])
@@ -3484,6 +3514,15 @@ class IvreTests(unittest.TestCase):
         # Reinit data DB since we have downloaded the files
         ivre.db.db.data.reload_files()
 
+        # Intentional DATABASE branch -- the remaining
+        # assertions exercise the MaxMind ``.mmdb`` reader's
+        # behaviour (GeoIP / AS / city lookups against the
+        # downloaded files).  No other backend implements
+        # ``DBData`` -- the matrix puts the ``data`` purpose
+        # exclusively on the MaxMind backend (and the HTTP
+        # proxy that forwards to it).  A capability flag
+        # would just rename the same backend-name check
+        # without adding clarity.
         if DATABASE != "maxmind":
             print(
                 "Database files have been downloaded -- " "other data tests won't run"
@@ -3800,6 +3839,13 @@ class IvreTests(unittest.TestCase):
         """
         if not os.environ.get("IVRE_DUMP_NMAP_PASSIVE"):
             return
+        # Intentional DATABASE branch -- ``mongodump`` is a
+        # MongoDB-shipped binary; the dump is the canonical
+        # input :meth:`test_20_fake_nmap_passive` consumes on
+        # the Elasticsearch CI lane.  No capability flag
+        # captures "the backend can produce a Mongo-shaped
+        # dump", and the producer is fundamentally a
+        # MongoDB-only path.
         if DATABASE != "mongo":
             return
         backup_dir = "../backup"
@@ -4988,8 +5034,11 @@ class IvreTests(unittest.TestCase):
 
     def test_90_cleanup(self):
         # Clean DB
-        if DATABASE != "postgres":
-            # FIXME: for some reason, this does not terminate
+        # Capability-gated: ``scancli --init`` terminates
+        # cleanly on every backend except PostgreSQL, whose
+        # cleanup path hangs here (root cause not yet
+        # investigated; tracked as a deferred follow-up).
+        if "nmap_init_terminates" in ivre.db.db.nmap.supports:
             RUN(["ivre", "scancli", "--init"], stdin=subprocess.DEVNULL)
         RUN(["ivre", "ipinfo", "--init"], stdin=subprocess.DEVNULL)
         RUN(["ivre", "view", "--init"], stdin=subprocess.DEVNULL)

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -9786,6 +9786,140 @@ class DocumentDBAuthTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# CapabilityRegistryTests -- pin :attr:`DB.supports` per backend.
+#
+# The capability registry lets the test suite branch on backend
+# behaviour without hard-coding the ``DATABASE`` environment
+# variable; the migration is documented inline in
+# ``tests/tests.py``.  These tests pin the per-backend
+# capability flags so a future refactor that drops one
+# silently (and re-introduces a ``DATABASE`` skip) surfaces
+# here.
+# ---------------------------------------------------------------------
+
+
+class CapabilityRegistryTests(unittest.TestCase):
+    """Behaviour-pin for the ``supports`` frozenset on each
+    concrete backend class.
+
+    Only the backends importable without optional dependencies
+    (MongoDB / DocumentDB / the abstract ``DB`` base) are
+    exercised here; the SQL backends pull in ``sqlalchemy`` at
+    import time and live in
+    :class:`SQLCapabilityRegistryTests` below.
+    """
+
+    def test_base_supports_is_empty(self):
+        # The opt-in default: a backend without any capability
+        # flag inherits the empty frozenset from
+        # :class:`DB`.
+        from ivre.db import DB
+
+        self.assertEqual(DB.supports, frozenset())
+
+    def test_mongo_nmap_supports_init_terminates(self):
+        from ivre.db.mongo import MongoDBNmap
+
+        self.assertIn("nmap_init_terminates", MongoDBNmap.supports)
+
+    def test_documentdb_nmap_inherits_init_terminates(self):
+        # :class:`DocumentDBNmap` inherits the Mongo flag set
+        # unchanged.
+        from ivre.db.document import DocumentDBNmap
+
+        self.assertIn("nmap_init_terminates", DocumentDBNmap.supports)
+
+    def test_mongo_passive_supports_no_bulk_and_source_invariant(self):
+        from ivre.db.mongo import MongoDBPassive
+
+        self.assertIn("passive_no_bulk_ingestion", MongoDBPassive.supports)
+        self.assertIn("passive_source_field_invariant", MongoDBPassive.supports)
+
+    def test_mongo_flow_supports_array_topvalues(self):
+        from ivre.db.mongo import MongoDBFlow
+
+        self.assertIn("flow_array_topvalues", MongoDBFlow.supports)
+
+    def test_database_skip_count_under_threshold(self):
+        # Defence in depth: re-grep ``tests/tests.py`` for
+        # ``DATABASE [!=]= "..."`` and fail if the count
+        # ever creeps back up.  The acceptance bar is
+        # ``<= 5`` lines, each commented as intentional;
+        # the current code carries 4 (the dialect-specific
+        # explain assertion split + the maxmind data lane
+        # + the mongodump producer).
+        import os
+        import re
+
+        tests_path = os.path.join(os.path.dirname(__file__), "tests.py")
+        with open(tests_path, encoding="utf-8") as fdesc:
+            matches = [
+                lineno
+                for lineno, line in enumerate(fdesc, start=1)
+                if re.search(r"DATABASE\s*[!=]=", line)
+            ]
+        self.assertLessEqual(
+            len(matches),
+            5,
+            f"tests.py has {len(matches)} ``DATABASE [!=]=`` lines "
+            f"(>5 acceptance bar); migrate excess to capability "
+            f"flags. Lines: {matches}",
+        )
+
+
+# SQL-side capability tests live in a separate class so the
+# ``sqlalchemy`` import they trigger via
+# ``ivre/db/sql/__init__.py`` doesn't break the no-backend CI
+# job (which deliberately skips the ``[postgres]`` / ``[duckdb]``
+# extras).  The ``_HAVE_SQLALCHEMY`` flag declared earlier in
+# this file gates the whole class.
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` or " "``duckdb`` extras)",
+)
+class SQLCapabilityRegistryTests(unittest.TestCase):
+    """Capability-registry pins for the SQL backends."""
+
+    def test_postgres_nmap_drops_init_terminates(self):
+        # PostgreSQL's ``scancli --init`` hangs in the test
+        # cleanup phase; the missing flag gates the
+        # corresponding ``test_90_cleanup`` block.
+        from ivre.db.sql.postgres import PostgresDBNmap
+
+        self.assertNotIn("nmap_init_terminates", PostgresDBNmap.supports)
+
+    def test_duckdb_nmap_supports_init_terminates(self):
+        from ivre.db.sql.duckdb import DuckDBNmap
+
+        self.assertIn("nmap_init_terminates", DuckDBNmap.supports)
+
+    def test_postgres_passive_drops_no_bulk(self):
+        # PG's per-row passive ingestion path is broken
+        # under the real-world p0f fixture pending a
+        # deferred investigation; the missing flag forces
+        # ``test_40_passive`` to bulk-only mode.
+        from ivre.db.sql.postgres import PostgresDBPassive
+
+        self.assertNotIn("passive_no_bulk_ingestion", PostgresDBPassive.supports)
+
+    def test_duckdb_passive_supports_no_bulk(self):
+        from ivre.db.sql.duckdb import DuckDBPassive
+
+        self.assertIn("passive_no_bulk_ingestion", DuckDBPassive.supports)
+
+    def test_sql_flow_drops_array_topvalues(self):
+        # The SQL flow backends defer the per-protocol
+        # ``meta.<name>`` JSONB merge and the timeslot
+        # ingestion; ``topvalues`` over the array forms is
+        # not available there yet.
+        from ivre.db.sql.duckdb import DuckDBFlow
+        from ivre.db.sql.postgres import PostgresDBFlow
+
+        self.assertNotIn("flow_array_topvalues", PostgresDBFlow.supports)
+        self.assertNotIn("flow_array_topvalues", DuckDBFlow.supports)
+
+
+# ---------------------------------------------------------------------
 # HttpDBFlowTests -- pin :class:`ivre.db.http.HttpDBFlow`'s URL /
 # request-body shapes.  The HTTP backend proxies every flow query
 # to a remote IVRE's ``/flows`` endpoint; without these tests a


### PR DESCRIPTION
Introduce `DB.supports` as a frozenset of capability flags each concrete backend extends with the opt-in behaviours it supports.  Five flags ship in this commit:

* `view_seed_from_mongo_dump` -- the view backend seeds from a Mongo dump produced by the upstream nmap / passive CI lanes (ElasticDBView only today).
* `passive_no_bulk_ingestion` -- the passive backend accepts `ivre passiverecon2db --no-bulk` end-to-end (every backend except PostgreSQL today; PG's per-row ingestion path is broken under the real-world p0f fixture pending a deferred investigation).
* `passive_source_field_invariant` -- the passive backend's `source` column is reachable for the MongoDB-API "no NULL source field" sanity check `test_40_passive` runs (MongoDB / DocumentDB only by document shape).
* `flow_array_topvalues` -- the flow backend's `topvalues` aggregate unwinds array-typed columns (`sports`, `times`) and the per-protocol `meta.<name>` sub-document (MongoDB only; the SQL backends defer the JSONB merge and timeslot ingestion).
* `nmap_init_terminates` -- `ivre scancli --init` terminates cleanly (every backend except PostgreSQL today; PG hangs in the cleanup phase pending a deferred investigation).

Five `DATABASE [!=]= "..."` skip blocks in
`tests/tests.py` migrate to capability checks:

* `test_20_fake_nmap_passive` (L695): elastic-only seeding -> `view_seed_from_mongo_dump`.
* `test_40_passive` (L1799): PG `--bulk`-only fallback -> `passive_no_bulk_ingestion`.
* `test_40_passive` (L2653): MongoDB source-None invariant -> `passive_source_field_invariant`.
* `test_60_flow` (L3298): MongoDB array-unwound topvalues -> `flow_array_topvalues`.
* `test_90_cleanup` (L4991): PG `scancli --init` hang -> `nmap_init_terminates`.

The remaining four `DATABASE [!=]=` occurrences are now documented inline as intentional with the rationale for not migrating them:

* L1355 / L1367: the `explain` output shape split between MongoDB's JSON `nscanned` and PostgreSQL's text plan index-name substring.
* L3526: the MaxMind data lane (only `maxmind` implements `DBData`; the rest of the lane is the `.mmdb` reader's behaviour).
* L3849: `mongodump` is a MongoDB-shipped binary that produces the dump `test_20_fake_nmap_passive` consumes.

Pinned by 11 new CapabilityRegistryTests covering: the empty base default, the per-backend flag presence / absence for every shipped flag, the DocumentDB inheritance pattern, and a defence-in-depth check that `grep -E 'DATABASE\s*[!=]=' tests/tests.py` returns no more than 5 lines so a future regression that re-introduces a hard-coded DATABASE skip surfaces here.