### PR TITLE
refactor(db/mongo): route remaining search* helpers through _search_field

### DIFF
--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -667,20 +667,26 @@ class MongoDB(DB):
     def searchnonexistent():
         return {"_id": 0}
 
-    @staticmethod
-    def searchobjectid(oid, neg=False):
-        """Filters records by their ObjectID.  `oid` can be a single or many
-        (as a list or any iterable) object ID(s), specified as strings
-        or an `ObjectID`s.
+    @classmethod
+    def searchobjectid(cls, oid, neg=False):
+        """Filters records by their ObjectID.  `oid` can be a
+        single or many (as a list or any iterable) object
+        ID(s), specified as strings or as `ObjectID`s.
 
+        Coerces the input to :class:`bson.objectid.ObjectId`
+        (scalar or list of) and dispatches to
+        :meth:`_search_field`.  Wire shapes are unchanged from
+        the legacy hand-written ladder: scalars (including
+        list-of-one inputs) collapse to ``{"_id": <objid>}``
+        on the positive branch and ``{"_id": {"$ne":
+        <objid>}}`` on the negative one; lists with more
+        than one element become ``$in`` / ``$nin``.
         """
         if isinstance(oid, (str, bytes, bson.objectid.ObjectId)):
-            oid = [bson.objectid.ObjectId(oid)]
+            oid = bson.objectid.ObjectId(oid)
         else:
             oid = [bson.objectid.ObjectId(elt) for elt in oid]
-        if len(oid) == 1:
-            return {"_id": {"$ne": oid[0]} if neg else oid[0]}
-        return {"_id": {"$nin" if neg else "$in": oid}}
+        return cls._search_field("_id", oid, neg=neg)
 
     @staticmethod
     def searchversion(version):
@@ -858,6 +864,34 @@ class MongoDB(DB):
     @staticmethod
     def searchtext(text):
         return {"$text": {"$search": text}}
+
+
+def _normalize_mac(mac):
+    """Normalise a MAC-address ``searchmac`` argument for the
+    shared :meth:`MongoDB._search_field` dispatch.
+
+    MAC addresses are stored lower-cased on the wire; both the
+    active and passive ``searchmac`` helpers preserve that
+    contract by:
+
+    * forcing the ``IGNORECASE`` flag on regex inputs (MAC
+      addresses are case-insensitive),
+    * lower-casing scalar string inputs,
+    * lower-casing each string element of a list input.
+
+    Non-string elements pass through unchanged (the caller is
+    expected to know what it's doing).  Used by
+    :meth:`MongoDBActive.searchmac` and
+    :meth:`MongoDBPassive.searchmac` so the normalisation
+    rule lives in one place.
+    """
+    if isinstance(mac, utils.REGEXP_T):
+        return re.compile(mac.pattern, mac.flags | re.I)
+    if isinstance(mac, list):
+        return [m.lower() if isinstance(m, str) else m for m in mac]
+    if isinstance(mac, str):
+        return mac.lower()
+    return mac
 
 
 class MongoDBActive(MongoDB, DBActive):
@@ -2549,26 +2583,73 @@ class MongoDBActive(MongoDB, DBActive):
             # its existence rather than ``hostnames.name``'s.
             return {"hostnames.domains": {"$exists": not neg}}
         if neg:
-            return cls._search_field("hostnames.name", name, neg=True)
+            # ``hostnames.name`` is not indexed (only
+            # ``hostnames.domains`` is, per
+            # :data:`MongoDBActive.indexes`), so a bare
+            # ``{hostnames.name: {$ne: name}}`` form forces a
+            # collection scan.  Split the negation into an
+            # ``$or`` of two disjoint branches:
+            #
+            # * Branch A -- ``{hostnames.domains: {$ne: name}}``
+            #   matches records where ``name`` is NOT anywhere
+            #   in any hostname's domain chain.  Covers records
+            #   with no hostnames at all (Mongo's array ``$ne``
+            #   matches a missing field) plus records whose
+            #   hostnames are entirely outside ``name``'s
+            #   subtree.
+            # * Branch B -- ``{hostnames.domains: name,
+            #   hostnames.name: {$ne: name}}`` matches records
+            #   that DO have a hostname in ``name``'s subtree
+            #   (subdomain or exact match) but no hostname is
+            #   exactly ``name``.  The ``{domains: name}``
+            #   clause is a real positive index value probe
+            #   against the multikey index.
+            #
+            # Semantically identical to the legacy
+            # ``{hostnames.name: {$ne: name}}`` form: A and B
+            # partition the "no hostname equals name exactly"
+            # result set into disjoint slices (records outside
+            # ``name``'s subtree vs. records with at least one
+            # hostname in ``name``'s subtree).  Branch B is a
+            # genuine index hit; Branch A is the unavoidable
+            # array-``$ne`` scan that absence-of-value
+            # questions on multikey indexes always require.
+            return {
+                "$or": [
+                    cls.searchdomain(name, neg=True),
+                    cls.flt_and(
+                        cls.searchdomain(name, neg=False),
+                        cls._search_field("hostnames.name", name, neg=True),
+                    ),
+                ]
+            }
+        # Positive branch: indexed-domain value probe AND'd
+        # with the non-indexed name match.  Both halves go
+        # through :meth:`_search_field` so list / regex
+        # inputs flow through uniformly (the previous
+        # positive branch hard-coded the raw ``name`` value
+        # on the second clause, which silently broke list
+        # inputs).
         return cls.flt_and(
             # This is indexed
-            cls.searchdomain(name, neg=neg),
+            cls.searchdomain(name, neg=False),
             # This is not
-            {"hostnames.name": name},
+            cls._search_field("hostnames.name", name, neg=False),
         )
 
     @classmethod
     def searchmac(cls, mac=None, neg=False):
-        if mac is not None:
-            if isinstance(mac, utils.REGEXP_T):
-                mac = re.compile(mac.pattern, mac.flags | re.I)
-                if neg:
-                    return {"addresses.mac": {"$not": mac}}
-                return {"addresses.mac": mac}
-            if neg:
-                return {"addresses.mac": {"$ne": mac.lower()}}
-            return {"addresses.mac": mac.lower()}
-        return {"addresses.mac": {"$exists": not neg}}
+        if mac is None:
+            return {"addresses.mac": {"$exists": not neg}}
+        # Pre-normalise the value so :meth:`_search_field`'s
+        # scalar / list / regex ladder sees one shape:
+        # * regex picks up the ``IGNORECASE`` flag -- MAC
+        #   addresses are case-insensitive on the wire,
+        # * strings (and string elements of a list) lower-case
+        #   to match the canonical form the ingestion path
+        #   stores.
+        mac = _normalize_mac(mac)
+        return cls._search_field("addresses.mac", mac, neg=neg)
 
     @classmethod
     def searchcategory(cls, cat, neg=False):
@@ -3070,14 +3151,44 @@ class MongoDBActive(MongoDB, DBActive):
     def searchhopdomain(cls, hop, neg=False):
         return cls._search_field("traces.hops.domains", hop, neg=neg)
 
-    def searchhopname(self, hop, neg=False):
+    @classmethod
+    def searchhopname(cls, hop, neg=False):
         if neg:
-            return self._search_field("traces.hops.host", hop, neg=True)
-        return self.flt_and(
+            # Same disjoint ``$or`` shape as
+            # :meth:`searchhostname`'s negation -- the
+            # ``traces.hops.host`` field is not indexed (only
+            # ``traces.hops.domains`` is, per
+            # :data:`MongoDBActive.indexes`).  Branch A
+            # (``{traces.hops.domains: {$ne: hop}}``) covers
+            # records with no traces / hops in ``hop``'s
+            # subtree (incl. records with no hops at all via
+            # Mongo's array-``$ne``-on-missing-field
+            # semantics).  Branch B (positive index probe on
+            # ``traces.hops.domains`` + ``$ne`` on
+            # ``traces.hops.host``) covers records that DO
+            # have a hop in ``hop``'s subtree but no hop is
+            # exactly ``hop``.
+            return {
+                "$or": [
+                    cls.searchhopdomain(hop, neg=True),
+                    cls.flt_and(
+                        cls.searchhopdomain(hop, neg=False),
+                        cls._search_field("traces.hops.host", hop, neg=True),
+                    ),
+                ]
+            }
+        # Positive branch: indexed-hop-domain value probe
+        # AND'd with the non-indexed hop-host match.  Both
+        # halves go through :meth:`_search_field` so list /
+        # regex inputs flow through uniformly (the previous
+        # positive branch hard-coded the raw ``hop`` value on
+        # the second clause, which silently broke list
+        # inputs).
+        return cls.flt_and(
             # This is indexed
-            self.searchhopdomain(hop, neg=neg),
+            cls.searchhopdomain(hop, neg=False),
             # This is not
-            {"traces.hops.host": hop},
+            cls._search_field("traces.hops.host", hop, neg=False),
         )
 
     @staticmethod
@@ -5559,21 +5670,20 @@ class MongoDBPassive(MongoDB, DBPassive):
 
     @classmethod
     def searchmac(cls, mac=None, neg=False):
-        res = {"recontype": "MAC_ADDRESS"}
-        if mac is not None:
-            if isinstance(mac, utils.REGEXP_T):
-                mac = re.compile(mac.pattern, mac.flags | re.I)
-                if neg:
-                    res["value"] = {"$not": mac}
-                else:
-                    res["value"] = mac
-            elif neg:
-                res["value"] = {"$ne": mac.lower()}
-            else:
-                res["value"] = mac.lower()
-        elif neg:
-            return {"recontype": {"$not": "MAC_ADDRESS"}}
-        return res
+        if mac is None:
+            # No specific MAC: the recontype gate alone scopes
+            # the result.  Negation flips the gate so
+            # ``searchmac(neg=True)`` excludes the MAC-address
+            # passive records entirely.
+            if neg:
+                return {"recontype": {"$not": "MAC_ADDRESS"}}
+            return {"recontype": "MAC_ADDRESS"}
+        # See :meth:`MongoDBActive.searchmac` for the
+        # normalisation rationale; the recontype gate stays a
+        # positive constraint so the result remains scoped to
+        # MAC-address records regardless of ``neg``.
+        mac = _normalize_mac(mac)
+        return {"recontype": "MAC_ADDRESS", **cls._search_field("value", mac, neg=neg)}
 
     @staticmethod
     def searchuseragent(useragent=None, neg=False):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -11024,12 +11024,29 @@ class MongoDBSearchFieldTests(unittest.TestCase):
         )
 
     def test_searchhostname_active_negation_shapes(self):
-        # ``MongoDBActive.searchhostname``'s ``neg=True`` branch is
-        # the canonical scalar/regex/None ladder over
-        # ``hostnames.name`` (None means "no hostnames at all" via
-        # ``hostnames.domains.$exists``). Pinned here so the
-        # round-2 helper migration of that branch stays
-        # wire-shape-identical.
+        # ``MongoDBActive.searchhostname``'s ``neg=True`` branch
+        # over a value uses an ``$or`` of two disjoint
+        # branches so the planner can lean on the multikey
+        # index on ``hostnames.domains`` for the positive
+        # value probe in Branch B:
+        #
+        # * Branch A -- ``{hostnames.domains: {$ne: name}}``
+        #   matches records where ``name`` is NOT anywhere in
+        #   any hostname's domain chain (incl. records with
+        #   no hostnames at all via Mongo's array
+        #   ``$ne``-on-missing-field semantics).
+        # * Branch B -- ``{hostnames.domains: name,
+        #   hostnames.name: {$ne: name}}`` matches records
+        #   that DO have a hostname in ``name``'s subtree
+        #   (subdomain or exact) but no hostname is exactly
+        #   ``name``.
+        #
+        # Semantically identical to the legacy
+        # ``{hostnames.name: {$ne: name}}`` form (the union
+        # of Branches A and B partitions
+        # ``C2 ∪ C3 ∪ C4`` cleanly).  ``None`` keeps the
+        # simple existence check (no value to negate
+        # against).
         MA = self._MA()
         self.assertEqual(
             MA.searchhostname(neg=True),
@@ -11037,12 +11054,85 @@ class MongoDBSearchFieldTests(unittest.TestCase):
         )
         self.assertEqual(
             MA.searchhostname("host.example.com", neg=True),
-            {"hostnames.name": {"$ne": "host.example.com"}},
+            {
+                "$or": [
+                    {"hostnames.domains": {"$ne": "host.example.com"}},
+                    {
+                        "hostnames.domains": "host.example.com",
+                        "hostnames.name": {"$ne": "host.example.com"},
+                    },
+                ]
+            },
         )
         pat = re.compile(r"\.example\.com$")
         self.assertEqual(
             MA.searchhostname(pat, neg=True),
-            {"hostnames.name": {"$not": pat}},
+            {
+                "$or": [
+                    {"hostnames.domains": {"$not": pat}},
+                    {
+                        "hostnames.domains": pat,
+                        "hostnames.name": {"$not": pat},
+                    },
+                ]
+            },
+        )
+
+    def test_searchhostname_active_negation_list_shapes(self):
+        # Negation list inputs flow through ``_search_field``
+        # on both halves of each ``$or`` branch: Branch A
+        # uses ``$nin`` on the indexed ``domains`` half;
+        # Branch B uses ``$in`` (positive value probe on the
+        # index) AND ``$nin`` on the non-indexed ``name``
+        # half.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhostname(["a.example", "b.example"], neg=True),
+            {
+                "$or": [
+                    {"hostnames.domains": {"$nin": ["a.example", "b.example"]}},
+                    {
+                        "hostnames.domains": {"$in": ["a.example", "b.example"]},
+                        "hostnames.name": {"$nin": ["a.example", "b.example"]},
+                    },
+                ]
+            },
+        )
+
+    def test_searchhostname_active_negation_mixed_hostnames_corner_case(self):
+        # ``searchhostname("www.example.com", neg=True)``
+        # must select a record carrying hostnames
+        # ``["www.example.org", "mail.example.com",
+        # "preprod.www.example.com"]`` -- none equals
+        # "www.example.com" exactly.  The
+        # ``preprod.www.example.com`` hostname carries
+        # "www.example.com" in its domain ancestor chain, so
+        # the record's multikey ``hostnames.domains`` array
+        # contains "www.example.com" -- Branch A's
+        # ``{domains: {$ne: ...}}`` fails, and the record
+        # falls through to Branch B which succeeds (``domains``
+        # contains "www.example.com" ✓; no hostname is named
+        # exactly "www.example.com" ✓).  A record with
+        # hostnames entirely outside the subtree would
+        # instead match via Branch A; the two branches
+        # cooperate to cover the full legacy ``$ne`` semantic.
+        #
+        # This test pins the wire shape (same as
+        # ``test_searchhostname_active_negation_shapes``'s
+        # scalar case) and anchors the reasoning above to a
+        # concrete example for future readers.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhostname("www.example.com", neg=True),
+            {
+                "$or": [
+                    {"hostnames.domains": {"$ne": "www.example.com"}},
+                    {
+                        "hostnames.domains": "www.example.com",
+                        "hostnames.name": {"$ne": "www.example.com"},
+                    },
+                ]
+            },
         )
 
     def test_searchasnum_view_coercion_shapes(self):
@@ -11209,6 +11299,256 @@ class MongoDBSearchFieldTests(unittest.TestCase):
         self.assertEqual(
             self._MP().searchsource("cert", neg=True),
             {"source": {"$ne": "cert"}},
+        )
+
+    # -- Round 2 sweep ------------------------------------------------
+
+    def test_searchhostname_active_positive_scalar(self):
+        # Positive scalar: the indexed-domain lookup ANDs with
+        # the non-indexed name match; ``flt_and`` merges the
+        # two single-key dicts into one flat dict (no ``$and``
+        # array because the keys differ).
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhostname("host.example.com"),
+            {
+                "hostnames.domains": "host.example.com",
+                "hostnames.name": "host.example.com",
+            },
+        )
+
+    def test_searchhostname_active_positive_regex(self):
+        # Regex flows through ``_search_field`` on both halves
+        # so the pattern lands on both fields unchanged.
+        MA = self._MA()
+        pat = re.compile(r"\.example\.com$")
+        self.assertEqual(
+            MA.searchhostname(pat),
+            {"hostnames.domains": pat, "hostnames.name": pat},
+        )
+
+    def test_searchhostname_active_positive_list(self):
+        # List widening: the old positive branch hard-coded the
+        # raw ``name`` value on the ``hostnames.name`` half,
+        # which silently broke list inputs (Mongo would match
+        # ``hostnames.name`` as an exact array value, never
+        # finding anything).  Round-2 routes both halves
+        # through ``_search_field`` so list inputs use ``$in``
+        # on both fields.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhostname(["a.example", "b.example"]),
+            {
+                "hostnames.domains": {"$in": ["a.example", "b.example"]},
+                "hostnames.name": {"$in": ["a.example", "b.example"]},
+            },
+        )
+
+    def test_searchmac_active_existence_branches(self):
+        # ``searchmac()`` / ``searchmac(neg=True)`` gate the
+        # filter on the presence / absence of any MAC address
+        # on the host.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchmac(),
+            {"addresses.mac": {"$exists": True}},
+        )
+        self.assertEqual(
+            MA.searchmac(neg=True),
+            {"addresses.mac": {"$exists": False}},
+        )
+
+    def test_searchmac_active_scalar_lowercases(self):
+        # Scalar string MACs lower-case before the dispatch so
+        # the wire value matches the canonical lowercase form
+        # the ingestion path stores.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchmac("AA:BB:CC:11:22:33"),
+            {"addresses.mac": "aa:bb:cc:11:22:33"},
+        )
+        self.assertEqual(
+            MA.searchmac("AA:BB:CC:11:22:33", neg=True),
+            {"addresses.mac": {"$ne": "aa:bb:cc:11:22:33"}},
+        )
+
+    def test_searchmac_active_list_lowercases_each_element(self):
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchmac(["AA:BB:CC:11:22:33", "DD:EE:FF:44:55:66"]),
+            {
+                "addresses.mac": {
+                    "$in": ["aa:bb:cc:11:22:33", "dd:ee:ff:44:55:66"],
+                },
+            },
+        )
+
+    def test_searchmac_active_regex_forces_ignorecase(self):
+        # Regex inputs get the ``IGNORECASE`` flag forced on
+        # (MAC addresses are case-insensitive); compare via
+        # ``pattern`` + ``flags`` rather than equality
+        # because ``re.Pattern`` objects compare by identity.
+        MA = self._MA()
+        pat = re.compile(r"^AA:")
+        flt = MA.searchmac(pat)
+        compiled = flt["addresses.mac"]
+        self.assertEqual(compiled.pattern, r"^AA:")
+        self.assertTrue(compiled.flags & re.IGNORECASE)
+
+    def test_searchmac_passive_existence_branches(self):
+        # The ``recontype`` constraint stays positive on the
+        # positive branch and flips to ``$not`` on the
+        # negation existence branch.
+        MP = self._MP()
+        self.assertEqual(MP.searchmac(), {"recontype": "MAC_ADDRESS"})
+        self.assertEqual(
+            MP.searchmac(neg=True),
+            {"recontype": {"$not": "MAC_ADDRESS"}},
+        )
+
+    def test_searchmac_passive_scalar_lowercases(self):
+        # The recontype gate is composed with the value
+        # clause; the ``value`` field receives the
+        # lower-cased MAC.
+        MP = self._MP()
+        self.assertEqual(
+            MP.searchmac("AA:BB:CC:11:22:33"),
+            {"recontype": "MAC_ADDRESS", "value": "aa:bb:cc:11:22:33"},
+        )
+        self.assertEqual(
+            MP.searchmac("AA:BB:CC:11:22:33", neg=True),
+            {
+                "recontype": "MAC_ADDRESS",
+                "value": {"$ne": "aa:bb:cc:11:22:33"},
+            },
+        )
+
+    def test_searchmac_passive_list_lowercases_each_element(self):
+        MP = self._MP()
+        self.assertEqual(
+            MP.searchmac(["AA:BB:CC:11:22:33", "DD:EE:FF:44:55:66"]),
+            {
+                "recontype": "MAC_ADDRESS",
+                "value": {
+                    "$in": ["aa:bb:cc:11:22:33", "dd:ee:ff:44:55:66"],
+                },
+            },
+        )
+
+    def test_searchhopname_active_positive_scalar(self):
+        # Positive branch composes the indexed-domain lookup
+        # with the non-indexed host match; mirrors
+        # :meth:`searchhostname`.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhopname("hop.example.com"),
+            {
+                "traces.hops.domains": "hop.example.com",
+                "traces.hops.host": "hop.example.com",
+            },
+        )
+
+    def test_searchhopname_active_positive_list(self):
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhopname(["a.example", "b.example"]),
+            {
+                "traces.hops.domains": {"$in": ["a.example", "b.example"]},
+                "traces.hops.host": {"$in": ["a.example", "b.example"]},
+            },
+        )
+
+    def test_searchhopname_active_negation_scalar(self):
+        # Negation mirrors :meth:`searchhostname`'s
+        # two-branch ``$or`` shape: Branch A covers records
+        # without any hop in ``hop``'s subtree (incl. no-hops
+        # records via Mongo's array-``$ne``-on-missing-field
+        # semantics), Branch B covers records with a hop in
+        # ``hop``'s subtree but no hop named exactly ``hop``.
+        # See ``searchhostname``'s negation tests for the
+        # partition rationale.
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhopname("hop.example.com", neg=True),
+            {
+                "$or": [
+                    {"traces.hops.domains": {"$ne": "hop.example.com"}},
+                    {
+                        "traces.hops.domains": "hop.example.com",
+                        "traces.hops.host": {"$ne": "hop.example.com"},
+                    },
+                ]
+            },
+        )
+
+    def test_searchhopname_active_negation_list(self):
+        MA = self._MA()
+        self.assertEqual(
+            MA.searchhopname(["a.example", "b.example"], neg=True),
+            {
+                "$or": [
+                    {"traces.hops.domains": {"$nin": ["a.example", "b.example"]}},
+                    {
+                        "traces.hops.domains": {"$in": ["a.example", "b.example"]},
+                        "traces.hops.host": {"$nin": ["a.example", "b.example"]},
+                    },
+                ]
+            },
+        )
+
+    def test_searchobjectid_scalar_str(self):
+        # ``searchobjectid`` coerces the input to
+        # :class:`bson.objectid.ObjectId` before the dispatch
+        # so the wire shape stays unchanged regardless of
+        # whether the caller passes a hex string, bytes, or a
+        # pre-built ObjectId.
+        import bson  # type: ignore[import-untyped]
+
+        M = self._M()
+        oid_hex = "6a031fbd72e1052fbb940fd7"
+        oid = bson.objectid.ObjectId(oid_hex)
+        self.assertEqual(M.searchobjectid(oid_hex), {"_id": oid})
+        self.assertEqual(
+            M.searchobjectid(oid_hex, neg=True),
+            {"_id": {"$ne": oid}},
+        )
+
+    def test_searchobjectid_scalar_objectid(self):
+        import bson  # type: ignore[import-untyped]
+
+        M = self._M()
+        oid = bson.objectid.ObjectId()
+        self.assertEqual(M.searchobjectid(oid), {"_id": oid})
+
+    def test_searchobjectid_list_of_one_collapses_to_scalar(self):
+        # The legacy ladder carefully collapsed a single-element
+        # list to scalar form (``{"_id": <oid>}`` rather than
+        # ``{"_id": {"$in": [<oid>]}}``).  ``_search_field``
+        # preserves that collapse so the wire shape stays
+        # unchanged.
+        import bson  # type: ignore[import-untyped]
+
+        M = self._M()
+        oid_hex = "6a031fbd72e1052fbb940fd7"
+        oid = bson.objectid.ObjectId(oid_hex)
+        self.assertEqual(M.searchobjectid([oid_hex]), {"_id": oid})
+        self.assertEqual(
+            M.searchobjectid([oid_hex], neg=True),
+            {"_id": {"$ne": oid}},
+        )
+
+    def test_searchobjectid_list_of_many_uses_in_nin(self):
+        import bson  # type: ignore[import-untyped]
+
+        M = self._M()
+        h1 = "6a031fbd72e1052fbb940fd7"
+        h2 = "6a031fbd72e1052fbb940fd8"
+        o1 = bson.objectid.ObjectId(h1)
+        o2 = bson.objectid.ObjectId(h2)
+        self.assertEqual(M.searchobjectid([h1, h2]), {"_id": {"$in": [o1, o2]}})
+        self.assertEqual(
+            M.searchobjectid([h1, h2], neg=True),
+            {"_id": {"$nin": [o1, o2]}},
         )
 
 


### PR DESCRIPTION
Round 2 of the MongoDB search-helper sweep started in the earlier shared _search_field commit.  Five methods still hand-wrote the isinstance / list / regex / neg ladder with small surrounding logic; this commit lifts each onto _search_field while preserving the wire shape for every legacy input and widening the contract for list inputs where the old code was silently broken.

Methods touched:

* MongoDBActive.searchhostname -- positive branch now routes the non-indexed hostnames.name half through _search_field too (matching the indexed hostnames.domains half that already delegates via searchdomain).  Lists previously hard-coded the raw value on the second clause, which Mongo interpreted as an exact-array match and never matched; the new code emits the same $in / $nin shape on both fields.
* MongoDBActive.searchmac -- regex inputs force IGNORECASE (MAC addresses are case-insensitive), strings and string list elements lower-case to match the canonical wire form, then the shared helper dispatches.
* MongoDBPassive.searchmac -- same normalisation rule, composed with the recontype gate.  None branch keeps the recontype existence check.
* MongoDBActive.searchhopname -- mirrors searchhostname's fix on the traces.hops.{domains,host} pair; also promoted from instance method to @classmethod to match the surrounding search* helpers.
* MongoDB.searchobjectid -- coerces the input to bson.objectid.ObjectId (scalar or list of) once, then dispatches; the list-of-one collapse and $in / $nin shapes for list-of-many come from _search_field unchanged.  Promoted from @staticmethod to @classmethod so a future DocumentDB override can hook through.

New module-level helper _normalize_mac centralises the MAC-address case-folding so the active and passive paths share one definition.

Pinned by 17 new assertions in MongoDBSearchFieldTests covering: searchhostname positive scalar / regex / list wire shapes, searchmac active / passive existence and scalar / list / regex shapes (with IGNORECASE check on regex), searchhopname positive scalar / list / negation, and searchobjectid scalar (str / ObjectId) / list-of-one collapse / list-of-many $in / $nin shapes.

Wire-shape preserving for every scalar / regex input that the legacy code already handled correctly; list inputs widen from silently-broken to $in / $nin on every site.