### PR TITLE
fix(ci): run elasticsearch-gated no-backend tests

### DIFF
--- a/.github/workflows/nobackend.yml
+++ b/.github/workflows/nobackend.yml
@@ -17,6 +17,12 @@
 # Runs tests/tests_no_backend.py: regression tests that do not require
 # a configured database backend (XML parser hardening, screenshot path
 # containment, and the formerly-`test_utils` catch-all suite).
+#
+# The ``[elasticsearch]`` extras are installed so the
+# ``ElasticDB*`` pin tests in ``tests_no_backend.py`` (which are
+# gated on ``_HAVE_ELASTICSEARCH_DSL``) run end-to-end -- they
+# only need the ``elasticsearch_dsl`` Python module to compile
+# queries in-process, no live ES cluster.
 
 name: No-backend tests
 
@@ -46,6 +52,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - run: pip install '.[elasticsearch]'
 
     - name: Install IVRE
       uses: ./.github/actions/install

--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -26,8 +26,8 @@ import re
 from urllib.parse import unquote
 
 from elasticsearch import Elasticsearch, helpers
-from elasticsearch_dsl import Q
-from elasticsearch_dsl.query import Query
+from elasticsearch_dsl import Q  # pylint: disable=no-name-in-module
+from elasticsearch_dsl.query import Query  # pylint: disable=no-name-in-module
 
 from ivre import utils
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
@@ -76,7 +76,7 @@ class ElasticDB(DB):
         """Initializes the mappings."""
         for idxnum, mapping in enumerate(self.mappings):
             idxname = self.indexes[idxnum]
-            self.db_client.indices.delete(
+            self.db_client.indices.delete(  # pylint: disable=unexpected-keyword-arg
                 index=idxname,
                 ignore=[400, 404],
             )

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -1442,27 +1442,44 @@ class ElasticDBSearchTextTests(unittest.TestCase):
     def test_searchtext_emits_or_of_multi_match_groups(self):
         body = self._ED().searchtext("honeypot").to_dict()
         # OR composition: ``bool.should`` of one root
-        # ``multi_match`` plus one ``nested`` per nested path.
+        # ``multi_match`` plus one ``nested`` per nested path
+        # that carries any text field.  The non-root groups
+        # currently come from
+        # :data:`ElasticDBActive.nested_fields` -- ``ports``
+        # (service / screenwords), ``ports.scripts``
+        # (output), ``tags`` (info / value), and
+        # ``traces.hops`` (host).  A top-level
+        # ``multi_match`` against a nested-typed field
+        # silently returns no hits in Elasticsearch, which is
+        # why the split is required; the test pins the
+        # partition so a future drift between
+        # :data:`text_fields` and :data:`nested_fields`
+        # surfaces here.
         self.assertEqual(set(body), {"bool"})
         self.assertEqual(set(body["bool"]), {"should"})
         clauses = body["bool"]["should"]
-        # 1 root + 3 nested (ports, ports.scripts, tags).
-        self.assertEqual(len(clauses), 4)
-        # Root-level ``multi_match`` over ``categories``,
-        # ``cpes.*``, ``hostnames.*``, ``os.*``,
-        # ``traces.hops.host``.
+        # 1 root + 4 nested groups.
+        self.assertEqual(len(clauses), 5)
+        # Root-level ``multi_match`` over the flat fields
+        # (``categories`` / ``cpes.*`` / ``hostnames.*`` /
+        # ``os.*``).
         root = next(c["multi_match"] for c in clauses if "multi_match" in c)
         self.assertEqual(root["query"], "honeypot")
         self.assertIn("categories", root["fields"])
         self.assertIn("hostnames.name", root["fields"])
-        self.assertIn("traces.hops.host", root["fields"])
-        # No nested fields leaked into the root group.
+        # No nested fields leaked into the root group --
+        # ``traces.hops.host`` lands in the ``traces.hops``
+        # nested clause, not at the root.
         self.assertNotIn("ports.service_name", root["fields"])
         self.assertNotIn("tags.value", root["fields"])
+        self.assertNotIn("traces.hops.host", root["fields"])
         # And every nested group wraps a ``multi_match`` over
         # its own path's fields.
         nested_paths = {c["nested"]["path"] for c in clauses if "nested" in c}
-        self.assertEqual(nested_paths, {"ports", "ports.scripts", "tags"})
+        self.assertEqual(
+            nested_paths,
+            {"ports", "ports.scripts", "tags", "traces.hops"},
+        )
         for clause in clauses:
             if "nested" not in clause:
                 continue
@@ -1482,8 +1499,8 @@ class ElasticDBSearchTextTests(unittest.TestCase):
         # under ``bool.must_not`` instead of ``bool.should``.
         self.assertEqual(set(body), {"bool"})
         self.assertEqual(set(body["bool"]), {"must_not"})
-        # Same fan-out (1 root + 3 nested).
-        self.assertEqual(len(body["bool"]["must_not"]), 4)
+        # Same fan-out (1 root + 4 nested).
+        self.assertEqual(len(body["bool"]["must_not"]), 5)
 
     def test_searchtext_text_fields_are_partitioned_correctly(self):
         # Pin that every entry in


### PR DESCRIPTION
The 7 ``ElasticDB*`` test classes in ``tests/tests_no_backend.py`` are gated on ``_HAVE_ELASTICSEARCH_DSL`` and silently skipped in every CI run because no workflow installs the ``[elasticsearch]`` extras. That hid 113 tests, including 2 latent failures.

Changes:

- ``.github/workflows/nobackend.yml``: install ``.[elasticsearch]`` before the install action so ``elasticsearch_dsl`` is importable. The in-process query-compilation tests need only the Python module; no live ES cluster is required.
- ``tests/tests_no_backend.py``: update ``ElasticDBSearchTextTests.test_searchtext_emits_or_of_multi_match_groups`` and ``test_searchtext_negation_wraps_in_must_not`` for the ``traces.hops`` nested group added to ``ElasticDBActive.nested_fields`` (clause / must_not count 4 -> 5, ``traces.hops`` added to the nested paths set, stale ``traces.hops.host`` root-fields assertion removed since the field now lands in the nested group).
- ``ivre/db/elastic.py``: add per-line ``pylint`` disables for ``no-name-in-module`` on the two ``elasticsearch_dsl`` imports (the package is a thin re-export shim from ``elasticsearch.dsl`` in 8.x; pylint cannot follow the dynamic re-exports) and ``unexpected-keyword-arg`` on ``indices.delete(ignore=...)`` (dynamic ``**kwargs`` dispatch in the elasticsearch client). These were previously silenced by pylint's inability to resolve the unimported package; making the import work surfaces them.