### PR TITLE
feat(db/sql): SQLDBRir.searchtext on PostgreSQL + DuckDB

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -67,6 +67,7 @@ from ivre.active.nmap import ALIASES_TABLE_ELEMS
 from ivre.db import DB, DBActive, DBAuth, DBFlow, DBNmap, DBPassive, DBRir, DBView
 from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
+    RIR_FTS_COLUMNS,
     AuthApiKey,
     AuthMagicLink,
     AuthRateLimit,
@@ -6004,6 +6005,36 @@ class SQLDBRir(SQLDB, DBRir):
         RIR database file.
         """
         return cls._search_field(cls.tables.rir.source_hash, fileid, neg=neg)
+
+    @classmethod
+    def searchtext(cls, text, neg=False):
+        """Filter RIR records whose concatenated text columns
+        (``netname``, ``descr``, ``remarks``, ``notify``,
+        ``org``, ``as_name``) match ``text``.
+
+        Mirrors the contract of :meth:`MongoDBRir.searchtext`,
+        which composes a ``$text`` query against the text index
+        over :attr:`DBRir.text_fields`.  On PostgreSQL the
+        dispatch goes through the ``rir_idx_fts`` GIN index
+        declared in :mod:`ivre.db.sql.tables` (using the same
+        ``to_tsvector('english', coalesce(...))`` expression
+        :func:`tables._fts_concat` builds for both sides) so the
+        planner can substitute the index for the ``WHERE ... @@
+        plainto_tsquery(...)`` clause.
+
+        DuckDB has no ``to_tsvector`` operator and overrides
+        this helper in :class:`~ivre.db.sql.duckdb.DuckDBRir` to
+        dispatch through the FTS extension's
+        ``fts_main_rir.match_bm25`` function instead.
+
+        With ``neg=True`` the predicate is inverted: records
+        whose entire text surface is unrelated to ``text``.
+        """
+        expr = tables_module._fts_concat("rir", RIR_FTS_COLUMNS)
+        flt = expr.op("@@")(func.plainto_tsquery("english", text))
+        if neg:
+            return not_(flt)
+        return flt
 
     @staticmethod
     def flt_and(*args):

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -78,12 +78,18 @@ from ivre.db.sql.postgres import (
     PostgresDBRir,
     PostgresDBView,
 )
-from ivre.db.sql.tables import Base
+from ivre.db.sql.tables import RIR_FTS_COLUMNS, Base
 
 # Column lists for the DuckDB FTS index, mirroring
 # :attr:`SQLDBActive._TEXT_SEARCH_*_COLUMNS`.  Indexed by
 # ``self.tables.<attr>`` so the same spec works for both
 # ``n_*`` (DuckDBNmap) and ``v_*`` (DuckDBView) schemas.
+#
+# The ``"rir"`` entry covers the single-table RIR schema and
+# mirrors :data:`ivre.db.sql.tables.RIR_FTS_COLUMNS` (the same
+# tuple the PostgreSQL ``rir_idx_fts`` GIN index is built over);
+# kept in lockstep so a column added on one side automatically
+# extends the search surface on the other.
 _FTS_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
     "hostname": ("name",),
     "tag": ("value", "info"),
@@ -99,6 +105,7 @@ _FTS_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
     "script": ("output",),
     "hop": ("host",),
     "category": ("name",),
+    "rir": RIR_FTS_COLUMNS,
 }
 
 
@@ -1018,12 +1025,10 @@ class DuckDBFlow(DuckDBMixin, PostgresDBFlow):
 class DuckDBRir(DuckDBMixin, PostgresDBRir):
     """DuckDB backend for the RIR (whois) data category.
 
-    Pure inheritance from :class:`PostgresDBRir`: the read /
-    search / aggregate / ingestion path lives in
-    :class:`SQLDBRir` and works on both backends unchanged.
-    The schema also inherits unchanged thanks to two
-    dialect-aware adapters declared in
-    :mod:`ivre.db.sql.tables`:
+    Inherits the read / aggregate / ingestion path from
+    :class:`SQLDBRir` (via :class:`PostgresDBRir`); the schema
+    also inherits unchanged thanks to two dialect-aware
+    adapters declared in :mod:`ivre.db.sql.tables`:
 
     * :attr:`Rir.size` is ``Numeric(40, 0)`` on PostgreSQL
       and ``Numeric(38, 0)`` on DuckDB (DuckDB caps DECIMAL
@@ -1043,13 +1048,39 @@ class DuckDBRir(DuckDBMixin, PostgresDBRir):
     (:data:`rir_idx_range` over ``INET`` columns,
     :data:`rir_idx_aut_num` partial WHERE clause,
     :data:`rir_idx_fts` GIN) are stripped at create-time by
-    :func:`_is_unsupported_on_duckdb` -- the read paths
-    fall back to sequential scans on DuckDB.  The
-    ``rir_idx_fts``-equivalent FTS path via the ``fts``
-    extension's ``match_bm25`` will land in a follow-up
-    sub-PR alongside the equivalent DuckDB
-    ``PRAGMA create_fts_index`` glue.
+    :func:`_is_unsupported_on_duckdb` -- the structural read
+    paths fall back to sequential scans on DuckDB.  The
+    ``rir_idx_fts``-equivalent full-text path is wired
+    through the ``fts`` extension's
+    ``fts_main_rir.match_bm25(rir.rowid, :term)`` function,
+    backed by :data:`_FTS_TABLE_COLUMNS` ``["rir"]`` and the
+    :meth:`searchtext` override below; :meth:`init` rebuilds
+    the index via :meth:`_create_fts_indexes` like every
+    other text-bearing tier.
     """
+
+    # See :meth:`DuckDBNmap.searchtext` for the
+    # classmethod-to-instance-method override rationale (the
+    # FTS index is static and must be rebuilt before each
+    # search, which needs ``self.db``).  The single-table RIR
+    # schema lets the predicate skip the per-child ``EXISTS``
+    # wrapper :class:`_DuckDBActiveFilterMixin` builds and
+    # return the BM25 expression directly, matching the
+    # contract of :meth:`SQLDBRir.searchtext` (a SA expression,
+    # not a Filter object).
+    @override
+    def searchtext(  # pylint: disable=arguments-renamed
+        self, text: str, neg: bool = False
+    ) -> Any:  # type: ignore[no-untyped-def, override]
+        # See :meth:`DuckDBNmap.searchtext` for the
+        # rebuild-on-every-search rationale.
+        self._create_fts_indexes()
+        pred = sa_text(
+            "fts_main_rir.match_bm25(rir.rowid, :fts_term) IS NOT NULL"
+        ).bindparams(fts_term=text)
+        if neg:
+            return not_(pred)
+        return pred
 
 
 class DuckDBAuth(DuckDBMixin, PostgresDBAuth):

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -796,6 +796,17 @@ class Passive(Base):
 # other RIR fields land in the ``extra`` :data:`SQLJSONB` bag for
 # forward compatibility (RIR formats grow keys over time; we
 # don't want a schema migration on every new attribute).
+#
+# The list below is the canonical column order used by both the
+# ``rir_idx_fts`` GIN index and :meth:`SQLDBRir.searchtext`'s
+# query predicate.  PostgreSQL's planner only substitutes the
+# index for the ``WHERE`` clause when the two ``to_tsvector(...)``
+# expressions are byte-for-byte identical (see :func:`_fts_concat`);
+# centralising the tuple here makes drift impossible.  The same
+# tuple is also registered in
+# :data:`ivre.db.sql.duckdb._FTS_TABLE_COLUMNS` so DuckDB's
+# ``fts_main_rir`` BM25 index covers the same surface.
+RIR_FTS_COLUMNS = ("netname", "descr", "remarks", "notify", "org", "as_name")
 _seq_rir_id = Sequence("seq_rir_id")
 
 
@@ -907,12 +918,14 @@ class Rir(Base):
         # :func:`_fts_index` for the byte-for-byte match
         # rationale).  Stripped on DuckDB by
         # :func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb`
-        # (no GIN support); the FTS extension's
-        # ``match_bm25`` path is wired in a follow-up sub-PR.
+        # (no GIN support); on DuckDB the FTS extension's
+        # ``fts_main_rir.match_bm25(rir.rowid, :term)`` path
+        # backed by :data:`ivre.db.sql.duckdb._FTS_TABLE_COLUMNS`
+        # ``["rir"]`` provides the equivalent surface.
         _fts_index(
             "rir_idx_fts",
             "rir",
-            ("netname", "descr", "remarks", "notify", "org", "as_name"),
+            RIR_FTS_COLUMNS,
         ),
     )
 

--- a/ivre/tools/mcp_server/__init__.py
+++ b/ivre/tools/mcp_server/__init__.py
@@ -597,7 +597,7 @@ def _register_tools() -> None:
 
     def _rir_filter(query: str | None, country: str | None) -> Any:
         flt = db.rir.flt_empty
-        if query is not None and hasattr(db.rir, "searchtext"):
+        if query is not None:
             flt = db.rir.flt_and(flt, db.rir.searchtext(query))
         if country is not None:
             flt = db.rir.flt_and(flt, db.rir.searchcountry(country))

--- a/ivre/tools/rirlookup.py
+++ b/ivre/tools/rirlookup.py
@@ -100,10 +100,9 @@ def main() -> None:
         parents=[CLI_ARGPARSER],
         conflict_handler="resolve",
     )
-    if hasattr(db.rir, "searchtext"):  # FIXME, move to DBRir
-        parser.add_argument(
-            "--search", metavar="FREE TEXT", help="perform a full-text search"
-        )
+    parser.add_argument(
+        "--search", metavar="FREE TEXT", help="perform a full-text search"
+    )
     parser.add_argument(
         "--country", metavar="CODE", help="show only results from this country"
     )
@@ -184,7 +183,7 @@ def main() -> None:
         sys.exit(0)
     flt = dbase.flt_empty
     if args.distinct is not None:
-        if hasattr(dbase, "searchtext") and args.search is not None:
+        if args.search is not None:
             flt = dbase.flt_and(flt, dbase.searchtext(args.search))
         if args.ips:
             flt = dbase.flt_and(
@@ -195,7 +194,7 @@ def main() -> None:
         sys.exit(0)
     if args.country is not None:
         flt = dbase.flt_and(flt, dbase.searchcountry(str2list(args.country)))
-    if hasattr(dbase, "searchtext") and args.search is not None:
+    if args.search is not None:
         flt = dbase.flt_and(flt, dbase.searchtext(args.search))
         if not args.ips:
             if args.count:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -4975,6 +4975,147 @@ class SQLDBSearchTextTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
+# SQLDBRirSearchTextTests -- pin the wire shape of the
+# RIR-purpose ``searchtext()`` helper that closes the M4.2
+# cross-backend full-text-search story.  ``MongoDBRir`` inherits
+# ``searchtext`` from the ``MongoDB`` base (``$text`` operator);
+# ``SQLDBRir`` and its concrete ``PostgresDBRir`` /
+# ``DuckDBRir`` subclasses now ship the equivalent shape:
+# PostgreSQL through ``to_tsvector @@ plainto_tsquery`` over the
+# ``rir_idx_fts`` GIN index, DuckDB through the ``fts``
+# extension's ``fts_main_rir.match_bm25`` predicate.  The four
+# defensive ``hasattr(<dbase>, "searchtext")`` guards in
+# :mod:`ivre.tools.rirlookup` and :mod:`ivre.tools.mcp_server`
+# are dropped in the same PR.
+# ---------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _HAVE_SQLALCHEMY,
+    "sqlalchemy is required (install with the ``postgres`` extras)",
+)
+class SQLDBRirSearchTextTests(unittest.TestCase):
+    """Behaviour-pin for ``SQLDBRir.searchtext`` -- the
+    RIR-purpose full-text-search filter mirroring
+    :meth:`MongoDBRir.searchtext`.
+    """
+
+    @staticmethod
+    def _compile(stmt):
+        # ``literal_binds=True`` is intentionally omitted: the
+        # ``REGCONFIG`` first argument of ``to_tsvector`` /
+        # ``plainto_tsquery`` has no SA literal renderer
+        # registered, so rendering with literal binds raises.
+        # The non-literal form binds the search ``term`` as a
+        # ``?`` placeholder, which is enough for wire-shape
+        # assertions on the surrounding expression.
+        return str(stmt.compile(dialect=_sqlalchemy_postgresql.dialect()))
+
+    def test_searchtext_emits_to_tsvector_at_at_plainto_tsquery(self):
+        # Pin that the compiled PG predicate uses the
+        # planner-friendly ``to_tsvector('english', coalesce(...)
+        # || ' ' || ...) @@ plainto_tsquery('english', :term)``
+        # shape -- the same expression
+        # :data:`tables.RIR_FTS_COLUMNS` builds for the GIN index
+        # so the planner can substitute one for the other.
+        from ivre.db import DBRir
+
+        db = DBRir.from_url("postgresql://x@localhost/x")
+        flt = db.searchtext("ovh")
+        sql = self._compile(flt)
+        self.assertIn("to_tsvector('english'", sql)
+        self.assertIn("@@ plainto_tsquery", sql)
+        # Every text column listed in RIR_FTS_COLUMNS must
+        # appear in the coalesce chain.
+        for col in (
+            "netname",
+            "descr",
+            "remarks",
+            "notify",
+            "org",
+            "as_name",
+        ):
+            self.assertIn(f"coalesce(rir.{col}", sql)
+
+    def test_searchtext_negation_wraps_in_not(self):
+        # ``neg=True`` inverts the predicate; the wire shape
+        # mirrors :meth:`MongoDBRir.searchtext` composed with
+        # an outer ``$not``.
+        from ivre.db import DBRir
+
+        db = DBRir.from_url("postgresql://x@localhost/x")
+        flt = db.searchtext("ovh", neg=True)
+        sql = self._compile(flt)
+        self.assertTrue(
+            sql.startswith("NOT ("),
+            f"expected ``NOT (...)`` wrapper, got:\n  {sql}",
+        )
+        self.assertIn("@@ plainto_tsquery", sql)
+
+    def test_searchtext_index_and_query_expressions_match(self):
+        # Byte-for-byte parity between the GIN index expression
+        # declared in :mod:`ivre.db.sql.tables` and the runtime
+        # ``WHERE`` predicate built by ``searchtext``.  Without
+        # this, PostgreSQL silently falls back to a sequential
+        # scan -- the bug is invisible in correctness tests but
+        # crippling at scale.
+        sa = _sqlalchemy
+        from sqlalchemy.schema import CreateIndex
+
+        from ivre.db import DBRir
+        from ivre.db.sql.tables import Rir
+
+        db = DBRir.from_url("postgresql://x@localhost/x")
+        flt = db.searchtext("ovh")
+        query_sql = str(
+            sa.select(sa.literal_column("1"))
+            .where(flt)
+            .compile(dialect=_sqlalchemy_postgresql.dialect())
+        )
+        idx = next(ix for ix in Rir.__table__.indexes if ix.name == "rir_idx_fts")
+        idx_sql = str(
+            CreateIndex(idx).compile(dialect=_sqlalchemy_postgresql.dialect())
+        )
+        # Extract the ``to_tsvector(...)`` call up to its
+        # outermost ``)`` -- that is the expression PG matches
+        # against the ``WHERE`` clause.
+        paren = idx_sql.index("to_tsvector(")
+        depth = 0
+        end = paren
+        while end < len(idx_sql):
+            if idx_sql[end] == "(":
+                depth += 1
+            elif idx_sql[end] == ")":
+                depth -= 1
+                if depth == 0:
+                    end += 1
+                    break
+            end += 1
+        expr = idx_sql[paren:end]
+        self.assertIn(
+            expr,
+            query_sql,
+            f"rir_idx_fts: index expression\n  {expr}\nnot found verbatim "
+            f"in query SQL:\n  {query_sql}",
+        )
+
+    def test_rir_fts_columns_match_text_fields(self):
+        # ``RIR_FTS_COLUMNS`` is the canonical list shared by
+        # the GIN index and ``SQLDBRir.searchtext``.  It must
+        # cover every text-bearing column in the RIR schema
+        # plus ``as_name`` (an ``aut-num``-only column not in
+        # ``DBRir.text_fields`` because the Mongo backend stores
+        # it on a separate document path).  A drift here means
+        # one half of the search surface stops being indexed.
+        from ivre.db import DBRir
+        from ivre.db.sql.tables import RIR_FTS_COLUMNS
+
+        for col in DBRir.text_fields:
+            self.assertIn(col, RIR_FTS_COLUMNS)
+        self.assertIn("as_name", RIR_FTS_COLUMNS)
+
+
+# ---------------------------------------------------------------------
 # SQLDBSearchCpeOsVulnTests -- pin the wire shape of the
 # Mongo-shape ``searchcpe`` / ``searchos`` / ``searchvuln*``
 # helpers on the SQL backends.  Both PostgreSQL and DuckDB are


### PR DESCRIPTION
Adds a ``searchtext`` helper to the SQL RIR backend, mirroring the ``MongoDBRir.searchtext`` / ``$text`` contract so ``ivre rirlookup --search`` and the MCP ``rir_search`` tool work on every non-MaxMind backend.

* PostgreSQL: dispatches through the existing ``rir_idx_fts`` GIN index (declared alongside the ``Rir`` table) via ``to_tsvector('english', coalesce(...)) @@ plainto_tsquery('english', :term)``.  The column tuple is hoisted into a new ``ivre.db.sql.tables.RIR_FTS_COLUMNS`` module-level constant shared by the index and the runtime predicate so the byte-for-byte match PG's planner needs to substitute the index cannot drift.
* DuckDB: registers ``"rir"`` in ``ivre.db.sql.duckdb._FTS_TABLE_COLUMNS`` so ``_create_fts_indexes`` builds and rebuilds the ``fts_main_rir`` BM25 index, and overrides ``DuckDBRir.searchtext`` as an instance method that rebuilds the static FTS index before each query (matching the existing ``DuckDBNmap`` / ``DuckDBView`` pattern) and returns ``fts_main_rir.match_bm25(rir.rowid, :term) IS NOT NULL``.

The four defensive ``hasattr(<dbase>, "searchtext")`` guards in ``ivre/tools/rirlookup.py`` (3) and ``ivre/tools/mcp_server`` (1) are dropped now that every RIR backend exposes the helper.

Pin tests in ``SQLDBRirSearchTextTests`` (4 new, all backend-free) assert the PG wire shape, the ``neg=True`` ``NOT (...)`` wrapper, the byte-for-byte parity between the GIN index expression and the runtime predicate, and that ``RIR_FTS_COLUMNS`` covers every ``DBRir.text_fields`` column plus ``as_name``.