### PR TITLE
refactor(utils): drop REGEXP_T workaround in favour of re.Pattern

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -903,7 +903,7 @@ class DB:
     def _ja3keyvalue(value_or_hash):
         """Returns the key and the value to search for according
         to the nature of the given argument for ja3 filtering"""
-        if isinstance(value_or_hash, utils.REGEXP_T):
+        if isinstance(value_or_hash, re.Pattern):
             return ("raw", value_or_hash)
         if utils.HEX.search(value_or_hash):
             key = {32: "md5", 40: "sha1", 64: "sha256"}.get(len(value_or_hash), "raw")
@@ -1825,7 +1825,7 @@ class DBActive(DB):
         """Search SSH host keys"""
         params = {"name": "ssh-hostkey"}
         if fingerprint is not None:
-            if not isinstance(fingerprint, utils.REGEXP_T):
+            if not isinstance(fingerprint, re.Pattern):
                 fingerprint = fingerprint.replace(":", "").lower()
             params.setdefault("values", {})["fingerprint"] = fingerprint
         if key is not None:
@@ -1938,7 +1938,7 @@ class DBActive(DB):
             hashval = locals()[hashtype]
             if hashval is None:
                 continue
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 values[hashtype] = re.compile(hashval.pattern, hashval.flags | re.I)
                 continue
             values[hashtype] = hashval.lower()
@@ -1953,7 +1953,7 @@ class DBActive(DB):
             if hashval is None:
                 continue
             key = f"pubkey.{hashtype}"
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 values[key] = re.compile(hashval.pattern, hashval.flags | re.I)
                 continue
             values[key] = hashval.lower()
@@ -2293,7 +2293,7 @@ class DBActive(DB):
         elif subdomains:
             flt = self.searchdomain(addr_or_name)
 
-            if isinstance(addr_or_name, utils.REGEXP_T):
+            if isinstance(addr_or_name, re.Pattern):
                 if dnstype is None:
 
                     def cond(hname):
@@ -2325,7 +2325,7 @@ class DBActive(DB):
         else:
             flt = self.searchhostname(name=addr_or_name)
 
-            if isinstance(addr_or_name, utils.REGEXP_T):
+            if isinstance(addr_or_name, re.Pattern):
                 if dnstype is None:
 
                     def cond(hname):

--- a/ivre/db/elastic.py
+++ b/ivre/db/elastic.py
@@ -259,7 +259,7 @@ class ElasticDB(DB):
         values, host script outputs) needs case-insensitive
         matching to mirror the Mongo backend.
         """
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             pattern, flags = utils.regexp2pattern(value)
             unsupported = flags & ~(re.UNICODE | re.IGNORECASE)
             if unsupported:
@@ -285,7 +285,7 @@ class ElasticDB(DB):
         single dispatch over the four input shapes the IVRE web
         filter language can produce.
 
-        - ``value`` is a regex (``utils.REGEXP_T``) → ``regexp``
+        - ``value`` is a regex (``re.Pattern``) → ``regexp``
           query (the pattern is rewritten via :meth:`_get_pattern`
           to match Elasticsearch's anchored-by-default semantics).
         - ``value`` is a list of length one → ``match`` query on
@@ -298,7 +298,7 @@ class ElasticDB(DB):
         ``neg=True`` wraps the result in ``~`` (a ``bool``
         ``must_not`` clause).
         """
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             res = Q("regexp", **{field: cls._get_pattern(value)})
         elif isinstance(value, list):
             if len(value) == 1:
@@ -952,7 +952,7 @@ class ElasticDBActive(ElasticDB, DBActive):
         elif field.startswith("category:") or field.startswith("categories:"):
             subfield = utils.str2regexp(field.split(":", 1)[1])
             flt = self.flt_and(flt, self.searchcategory(subfield))
-            if isinstance(subfield, utils.REGEXP_T):
+            if isinstance(subfield, re.Pattern):
                 subfield = self._get_pattern(subfield)
             else:
                 subfield = re.escape(subfield)
@@ -1507,7 +1507,7 @@ return result;
             else:
                 subfield = utils.str2regexp(field[10:])
                 flt = self.flt_and(flt, self.searchuseragent(useragent=subfield))
-                if isinstance(subfield, utils.REGEXP_T):
+                if isinstance(subfield, re.Pattern):
                     subfield = self._get_pattern(subfield)
                 else:
                     subfield = re.escape(subfield)
@@ -1534,7 +1534,7 @@ return result;
             if ":" in field:
                 field, value = field.split(":", 1)
                 subkey, value = self._ja3keyvalue(utils.str2regexp(value))
-                if isinstance(value, utils.REGEXP_T):
+                if isinstance(value, re.Pattern):
                     include_value = self._get_pattern(value)
                     filter_value = {
                         "regexp": {
@@ -1598,7 +1598,7 @@ return result;
                     value1, value2 = values.split(":", 1)
                     if value1:
                         subkey1, value1 = self._ja3keyvalue(utils.str2regexp(value1))
-                        if isinstance(value1, utils.REGEXP_T):
+                        if isinstance(value1, re.Pattern):
                             filter_value1 = {
                                 "regexp": {
                                     f"ports.scripts.ssl-ja3-server.{subkey1}": self._get_pattern(
@@ -1616,7 +1616,7 @@ return result;
                         subkey1, value1 = None, None
                     if value2:
                         subkey2, value2 = self._ja3keyvalue(utils.str2regexp(value2))
-                        if isinstance(value2, utils.REGEXP_T):
+                        if isinstance(value2, re.Pattern):
                             filter_value2 = {
                                 "regexp": {
                                     f"ports.scripts.ssl-ja3-server.client.{subkey2}": self._get_pattern(
@@ -1634,7 +1634,7 @@ return result;
                         subkey2, value2 = None, None
                 else:
                     subkey1, value1 = self._ja3keyvalue(utils.str2regexp(values))
-                    if isinstance(value1, utils.REGEXP_T):
+                    if isinstance(value1, re.Pattern):
                         filter_value1 = {
                             "regexp": {
                                 f"ports.scripts.ssl-ja3-server.{subkey1}": self._get_pattern(
@@ -1710,7 +1710,7 @@ return result;
         ):
             if ":" in field:
                 field, value = field.split(":", 1)
-                if isinstance(value, utils.REGEXP_T):
+                if isinstance(value, re.Pattern):
                     include_value = self._get_pattern(value)
                 else:
                     include_value = re.escape(value)
@@ -2593,7 +2593,7 @@ return result;
         means "no hop matches" rather than "at least one hop
         differs" (the flat-array semantics).
         """
-        if isinstance(hop, utils.REGEXP_T):
+        if isinstance(hop, re.Pattern):
             inner = Q("regexp", **{"traces.hops.domains": cls._get_pattern(hop)})
         elif isinstance(hop, list):
             if len(hop) == 1:
@@ -2785,7 +2785,7 @@ return result;
             if neg:
                 return ~res
             return res
-        if isinstance(words, utils.REGEXP_T):
+        if isinstance(words, re.Pattern):
             pattern = re.compile(words.pattern.lower(), flags=words.flags)
             res = Q("regexp", **{"ports.screenwords": cls._get_pattern(pattern)})
             if neg:
@@ -2833,7 +2833,7 @@ return result;
         )
 
         def _access_match(field):
-            if isinstance(access_pattern, utils.REGEXP_T):
+            if isinstance(access_pattern, re.Pattern):
                 return Q(
                     "regexp",
                     **{field: cls._get_pattern(access_pattern)},
@@ -3022,7 +3022,7 @@ return result;
             file_q = Q("exists", field=ls_path)
         elif isinstance(fname, list):
             file_q = Q("terms", **{ls_path: fname})
-        elif isinstance(fname, utils.REGEXP_T):
+        elif isinstance(fname, re.Pattern):
             file_q = Q("regexp", **{ls_path: cls._get_pattern(fname)})
         else:
             file_q = Q("match", **{ls_path: fname})
@@ -3062,7 +3062,7 @@ return result;
         if state is None and vulnid is None:
             inner = Q("exists", field="ports.scripts.vulns.id")
         elif state is None:
-            if isinstance(vulnid, utils.REGEXP_T):
+            if isinstance(vulnid, re.Pattern):
                 inner = Q(
                     "regexp",
                     **{"ports.scripts.vulns.id": cls._get_pattern(vulnid)},
@@ -3136,7 +3136,7 @@ return result;
             return Q("exists", field="cpes")
         clauses = []
         for name, value in flt:
-            if isinstance(value, utils.REGEXP_T):
+            if isinstance(value, re.Pattern):
                 clauses.append(Q("regexp", **{f"cpes.{name}": cls._get_pattern(value)}))
             else:
                 clauses.append(Q("match", **{f"cpes.{name}": value}))
@@ -3150,7 +3150,7 @@ return result;
         ORs.
         """
         keys = ("vendor", "osfamily", "osgen", "type")
-        if isinstance(txt, utils.REGEXP_T):
+        if isinstance(txt, re.Pattern):
             pattern = cls._get_pattern(txt)
             return cls.flt_or(
                 *(Q("regexp", **{f"os.osclass.{key}": pattern}) for key in keys)
@@ -3171,12 +3171,12 @@ return result;
         req = []
         if isinstance(name, list):
             req.append(Q("terms", **{"ports.scripts.id": name}))
-        elif isinstance(name, utils.REGEXP_T):
+        elif isinstance(name, re.Pattern):
             req.append(cls._regexp_clause("ports.scripts.id", name))
         elif name is not None:
             req.append(Q("match", **{"ports.scripts.id": name}))
         if output is not None:
-            if isinstance(output, utils.REGEXP_T):
+            if isinstance(output, re.Pattern):
                 req.append(cls._regexp_clause("ports.scripts.output", output))
             else:
                 req.append(Q("match", **{"ports.scripts.output": output}))
@@ -3198,11 +3198,11 @@ return result;
                 req.append(values)
             elif isinstance(values, str):
                 req.append(Q("match", **{f"ports.scripts.{key}": values}))
-            elif isinstance(values, utils.REGEXP_T):
+            elif isinstance(values, re.Pattern):
                 req.append(cls._regexp_clause(f"ports.scripts.{key}", values))
             else:
                 for field, value in values.items():
-                    if isinstance(value, utils.REGEXP_T):
+                    if isinstance(value, re.Pattern):
                         req.append(
                             cls._regexp_clause(f"ports.scripts.{key}.{field}", value)
                         )
@@ -3310,7 +3310,7 @@ return result;
             if hashval is None:
                 continue
             key = f"ports.scripts.ssl-cert.{hashtype}"
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 req.append(Q("regexp", **{key: cls._get_pattern(hashval).lower()}))
                 continue
             if isinstance(hashval, list):
@@ -3318,7 +3318,7 @@ return result;
                 continue
             req.append(Q("match", **{key: hashval.lower()}))
         if subject is not None:
-            if isinstance(subject, utils.REGEXP_T):
+            if isinstance(subject, re.Pattern):
                 req.append(
                     Q(
                         "regexp",
@@ -3334,7 +3334,7 @@ return result;
                     Q("match", **{"ports.scripts.ssl-cert.subject_text": subject})
                 )
         if issuer is not None:
-            if isinstance(issuer, utils.REGEXP_T):
+            if isinstance(issuer, re.Pattern):
                 req.append(
                     Q(
                         "regexp",
@@ -3356,7 +3356,7 @@ return result;
             if hashval is None:
                 continue
             key = f"ports.scripts.ssl-cert.pubkey.{hashtype}"
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 req.append(Q("regexp", **{key: cls._get_pattern(hashval).lower()}))
                 continue
             if isinstance(hashval, list):
@@ -3485,7 +3485,7 @@ return result;
         else:
             # this is not JA3, but we have the exact same logic & needs
             key, value = cls._ja3keyvalue(value_or_hash)
-            if isinstance(value, utils.REGEXP_T):
+            if isinstance(value, re.Pattern):
                 valflt = Q(
                     "regexp",
                     **{
@@ -3552,7 +3552,7 @@ class ElasticDBView(ElasticDBActive, DBView):
                 value = value[0]
             if isinstance(value, list):
                 res = Q("terms", **{f"tags.{key}": value})
-            elif isinstance(value, utils.REGEXP_T):
+            elif isinstance(value, re.Pattern):
                 res = Q("regexp", **{f"tags.{key}": cls._get_pattern(value)})
             else:
                 res = Q("match", **{f"tags.{key}": value})

--- a/ivre/db/http.py
+++ b/ivre/db/http.py
@@ -82,7 +82,7 @@ FLOW_DATETIME_KEYS: frozenset[str] = frozenset({"start_time", "end_time", "ts"})
 
 def serialize(obj):
     """Return a JSON-compatible representation for `obj`"""
-    if isinstance(obj, utils.REGEXP_T):
+    if isinstance(obj, re.Pattern):
         return {
             "f": "regexp",
             "a": [

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -654,7 +654,7 @@ class MongoDB(DB):
         so the refactor is behaviour-preserving (DocumentDB
         semantics included).
         """
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             return {field: {"$not": value} if neg else value}
         if isinstance(value, list):
             if len(value) == 1:
@@ -834,7 +834,7 @@ class MongoDB(DB):
             if hashval is None:
                 continue
             key = f"{prefix}{hashtype}"
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 res[key] = re.compile(hashval.pattern, hashval.flags | re.I)
                 continue
             if isinstance(hashval, list):
@@ -852,7 +852,7 @@ class MongoDB(DB):
             if hashval is None:
                 continue
             key = f"{prefix}pubkey.{hashtype}"
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 res[key] = re.compile(hashval.pattern, hashval.flags | re.I)
                 continue
             if isinstance(hashval, list):
@@ -885,7 +885,7 @@ def _normalize_mac(mac):
     :meth:`MongoDBPassive.searchmac` so the normalisation
     rule lives in one place.
     """
-    if isinstance(mac, utils.REGEXP_T):
+    if isinstance(mac, re.Pattern):
         return re.compile(mac.pattern, mac.flags | re.I)
     if isinstance(mac, list):
         return [m.lower() if isinstance(m, str) else m for m in mac]
@@ -2853,7 +2853,7 @@ class MongoDBActive(MongoDB, DBActive):
                 )
             else:
                 key = ALIASES_TABLE_ELEMS.get(name, name)
-            if isinstance(values, (str, utils.REGEXP_T)):
+            if isinstance(values, (str, re.Pattern)):
                 req[key] = values
             else:
                 if len(values) >= 2 and f"ports.scripts.{key}" in cls.list_fields:
@@ -4689,7 +4689,7 @@ class MongoDBView(MongoDBActive, DBView):
         for key, value in tag.items():
             if isinstance(value, list) and len(value) == 1:
                 value = value[0]
-            if isinstance(value, utils.REGEXP_T):
+            if isinstance(value, re.Pattern):
                 if neg:
                     req[key] = {"$not": value}
                 else:
@@ -5843,7 +5843,7 @@ class MongoDBPassive(MongoDB, DBPassive):
     def searchsshkey(fingerprint=None, key=None, keytype=None, bits=None):
         res = {"recontype": "SSH_SERVER_HOSTKEY", "source": "SSHv2"}
         if fingerprint is not None:
-            if not isinstance(fingerprint, utils.REGEXP_T):
+            if not isinstance(fingerprint, re.Pattern):
                 fingerprint = fingerprint.replace(":", "").lower()
             res["infos.md5"] = fingerprint
         if key is not None:
@@ -5905,7 +5905,7 @@ def _coerce_asnum(asnum):
     ``aut-num`` integer field uses. Accepts int / ``"AS1234"`` /
     ``"1234"``, lists thereof, or a regex (passed through). Used by
     :meth:`MongoDBRir.searchasnum`."""
-    if isinstance(asnum, utils.REGEXP_T):
+    if isinstance(asnum, re.Pattern):
         return asnum
     if isinstance(asnum, list):
         return [_coerce_asnum(v) for v in asnum]

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -601,7 +601,7 @@ class SQLDB(DB):
 
     @staticmethod
     def _searchstring_re_inarray(idfield, field, value, neg=False):
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             operator = "~*" if (value.flags & re.IGNORECASE) else "~"
             value = value.pattern
             base1 = select(idfield.label("id"), func.unnest(field).label("field")).cte(
@@ -626,7 +626,7 @@ class SQLDB(DB):
 
     @staticmethod
     def _searchstring_re(field, value, neg=False):
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             flt = field.op("~*" if (value.flags & re.IGNORECASE) else "~")(
                 value.pattern
             )
@@ -665,7 +665,7 @@ class SQLDB(DB):
         regex-operator dispatch by overriding
         ``_searchstring_re`` without touching every caller.
         """
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             if map_ is not None:
                 raise TypeError(
                     "_search_field: map_ is incompatible with a regex value"
@@ -707,7 +707,7 @@ class SQLDB(DB):
             if hashval is None:
                 continue
             key = base.op("->>")(hashtype)
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 req &= key.op("~*")(hashval.pattern)
                 continue
             if isinstance(hashval, list):
@@ -725,7 +725,7 @@ class SQLDB(DB):
             if hashval is None:
                 continue
             key = base.op("->")("pubkey").op("->>")(hashtype)
-            if isinstance(hashval, utils.REGEXP_T):
+            if isinstance(hashval, re.Pattern):
                 req &= key.op("~*")(hashval.pattern)
                 continue
             if isinstance(hashval, list):
@@ -3518,7 +3518,7 @@ class SQLDBActive(SQLDB, DBActive):
                 )
             else:
                 basekey = ALIASES_TABLE_ELEMS.get(name, name)
-            if isinstance(values, (str, utils.REGEXP_T)):
+            if isinstance(values, (str, re.Pattern)):
                 needunwind = sorted(set(cls.needunwind_script(basekey)))
             else:
                 needunwind = sorted(
@@ -3557,7 +3557,7 @@ class SQLDBActive(SQLDB, DBActive):
                     result = {key.pop(): result}
                 return result
 
-            if isinstance(values, (str, utils.REGEXP_T)):
+            if isinstance(values, (str, re.Pattern)):
                 kv_generator = [(None, values)]
             else:
                 kv_generator = values.items()
@@ -3565,7 +3565,7 @@ class SQLDBActive(SQLDB, DBActive):
             for key, value in kv_generator:
                 subkey = _find_subkey(key)
                 if subkey is None:
-                    if isinstance(value, utils.REGEXP_T):
+                    if isinstance(value, re.Pattern):
                         base = cls.tables.script.data.op("->")(basekey)
                         key = key.split(".")
                         lastkey = key.pop()
@@ -3710,7 +3710,7 @@ class SQLDBActive(SQLDB, DBActive):
                 '{"ls": {"volumes": [{"files": []}]}}'
             )
         else:
-            if isinstance(fname, (utils.REGEXP_T, list)):
+            if isinstance(fname, (re.Pattern, list)):
                 base1 = (
                     select(
                         cls.tables.script.port,
@@ -4083,7 +4083,7 @@ class SQLDBActive(SQLDB, DBActive):
                 )
             else:
                 conds.append(port_t.screenwords.contains(lowered))
-        elif isinstance(words, utils.REGEXP_T):
+        elif isinstance(words, re.Pattern):
             # Match any array element against the regex.  Use
             # the table-valued-function ``AS __sw(v)`` form
             # (PostgreSQL and DuckDB both accept it) so the
@@ -4393,7 +4393,7 @@ class SQLDBActive(SQLDB, DBActive):
             .table_valued("v")
             .render_derived(name="__mac", with_types=False)
         )
-        if isinstance(mac, utils.REGEXP_T):
+        if isinstance(mac, re.Pattern):
             mac = re.compile(mac.pattern, mac.flags | re.IGNORECASE)
             elt_pred = cls._searchstring_re(mac_alias.c.v, mac)
         else:
@@ -5210,7 +5210,7 @@ class SQLDBPassive(SQLDB, DBPassive):
     def searchval(cls, key, val):
         if isinstance(key, str):
             key = cls.fields[key]
-        if isinstance(val, utils.REGEXP_T):
+        if isinstance(val, re.Pattern):
             return PassiveFilter(
                 main=key.op("~*" if (val.flags & re.IGNORECASE) else "~")(val.pattern)
             )
@@ -5381,7 +5381,7 @@ class SQLDBPassive(SQLDB, DBPassive):
                 return PassiveFilter(main=cls.tables.passive.recontype != "MAC_ADDRESS")
             return PassiveFilter(main=cls.tables.passive.recontype == "MAC_ADDRESS")
         value = cls.tables.passive.value
-        if isinstance(mac, utils.REGEXP_T):
+        if isinstance(mac, re.Pattern):
             cnd = value.op("~*")(mac.pattern)
             if neg:
                 cnd = not_(cnd)
@@ -5675,7 +5675,7 @@ class SQLDBPassive(SQLDB, DBPassive):
             cls.tables.passive.source == "SSHv2"
         )
         if fingerprint is not None:
-            if not isinstance(fingerprint, utils.REGEXP_T):
+            if not isinstance(fingerprint, re.Pattern):
                 fingerprint = fingerprint.replace(":", "").lower()
             cnd &= cls._searchstring_re(
                 cls.tables.passive.moreinfo.op("->>")("md5"), fingerprint

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -219,7 +219,7 @@ class DuckDBMixin:
         For non-regex values, the parent's scalar / list /
         equality dispatch shape is preserved verbatim.
         """
-        if isinstance(value, utils.REGEXP_T):
+        if isinstance(value, re.Pattern):
             options = "i" if (value.flags & re.IGNORECASE) else ""
             if options:
                 flt = func.regexp_matches(field, value.pattern, options)
@@ -844,7 +844,7 @@ class _DuckDBActiveSearchMixin:
             .table_valued("v")
             .render_derived(name="__mac", with_types=False)
         )
-        if isinstance(mac, utils.REGEXP_T):
+        if isinstance(mac, re.Pattern):
             mac = re.compile(mac.pattern, mac.flags | re.IGNORECASE)
             elt_pred = cls._searchstring_re(mac_alias.c.v, mac)
         else:

--- a/ivre/tools/mcp_server/__init__.py
+++ b/ivre/tools/mcp_server/__init__.py
@@ -40,7 +40,7 @@ from ivre.db import db
 from ivre.db.http import HttpDBNmap, HttpDBPassive, HttpDBView, serialize
 from ivre.plugins import load_plugins
 from ivre.tools import iprange as iprange_tool
-from ivre.utils import _NMAP_PROBES, REGEXP_T, get_nmap_svc_fp, str2regexp
+from ivre.utils import _NMAP_PROBES, get_nmap_svc_fp, str2regexp
 from ivre.web.utils import get_init_flt_for, parse_filter
 
 from .schemas import SCHEMAS
@@ -348,7 +348,7 @@ def _register_tools() -> None:
                         message="'name' must be set when 'values' is used",
                     )
                 )
-            if isinstance(kwargs["name"], REGEXP_T):
+            if isinstance(kwargs["name"], re.Pattern):
                 raise McpError(
                     ErrorData(
                         code=INVALID_PARAMS,

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -95,7 +95,6 @@ LOGGER = logging.getLogger("ivre")
 LOGGER.setLevel(logging.DEBUG if config.DEBUG or config.DEBUG_DB else logging.INFO)
 
 
-REGEXP_T = type(re.compile(""))
 HEX = re.compile("^[a-f0-9]+$", re.IGNORECASE)
 
 
@@ -461,7 +460,7 @@ def regexp2pattern(string: str | bytes | re.Pattern) -> tuple[str | bytes, int]:
     value are regexp.
 
     """
-    if isinstance(string, REGEXP_T):
+    if isinstance(string, re.Pattern):
         flags = string.flags
         data = string.pattern
         patterns = ("^", "$", ".*") if isinstance(data, str) else (b"^", b"$", b".*")
@@ -610,7 +609,7 @@ def isfinal(elt: Any) -> bool:
     that does not contain other elements)
 
     """
-    return isinstance(elt, (str, int, float, datetime.datetime, REGEXP_T))
+    return isinstance(elt, (str, int, float, datetime.datetime, re.Pattern))
 
 
 def diff(doc1: dict[str, Any], doc2: dict[str, Any]) -> dict[str, Any]:
@@ -862,7 +861,7 @@ def recursive_filelisting(
 
 def serialize(obj: Any) -> Any:
     """Return a JSON-compatible representation for `obj`"""
-    regexp_types = (REGEXP_T, BsonRegex) if USE_BSON else REGEXP_T
+    regexp_types = (re.Pattern, BsonRegex) if USE_BSON else re.Pattern
     if isinstance(obj, regexp_types):
         return f"/{obj.pattern}/{''.join((x.lower() for x in 'ILMSXU' if getattr(re, x) & obj.flags))}"
     if isinstance(obj, datetime.datetime):

--- a/ivre/xmlnmap.py
+++ b/ivre/xmlnmap.py
@@ -2329,7 +2329,7 @@ class NmapHandler(ContentHandler):
                 self._curtable = {}
             elif infokey in ADD_TABLE_ELEMS:
                 infos = ADD_TABLE_ELEMS[infokey]
-                if isinstance(infos, utils.REGEXP_T):
+                if isinstance(infos, re.Pattern):
                     infos = infos.search(self._curscript.get("output", ""))
                     if infos is not None:
                         infosdict = infos.groupdict()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -660,7 +660,7 @@ class IvreTests(unittest.TestCase):
                             if value_or_hash is None
                             else (
                                 "_regexp"
-                                if isinstance(value_or_hash, ivre.utils.REGEXP_T)
+                                if isinstance(value_or_hash, re.Pattern)
                                 else (
                                     "_fullstring"
                                     if value_or_hash.startswith("diffie-hellman-")
@@ -678,7 +678,7 @@ class IvreTests(unittest.TestCase):
                     "--hassh%s"
                     % ("-server" if server else "" if server is None else "-client"),
                 ]
-                if isinstance(value_or_hash, ivre.utils.REGEXP_T):
+                if isinstance(value_or_hash, re.Pattern):
                     cmdline.append("/%s/" % value_or_hash.pattern)
                 elif value_or_hash is not None:
                     cmdline.append(value_or_hash)


### PR DESCRIPTION
``REGEXP_T = type(re.compile(""))`` predated Python's public ``re.Pattern`` type and was the only portable way to get the compiled-regex class on the Python versions IVRE used to support. With Python 3.12+ as the floor (see ``pyproject.toml``), ``re.Pattern`` is the canonical, documented, stub-friendly type for the same thing.

Replace every ``utils.REGEXP_T`` (and the bare ``REGEXP_T`` inside ``ivre/utils.py``) with ``re.Pattern``; remove the alias from ``ivre/utils.py``. The ``re`` module is already imported in every file that referenced ``REGEXP_T``, so no extra imports are needed.

No behaviour change: ``type(re.compile(""))`` and ``re.Pattern`` are the same class.