### PR TITLE
feat(db/view): host-notes storage with revision history (Mongo)

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -275,6 +275,15 @@ WEB_UPLOAD_OK = False
 # bounded by the underlying ``IPRanges`` shape and are not
 # capped. Set to ``None`` to disable the cap.
 WEB_IPRANGE_ADDR_CAP: int | None = 100_000
+# Maximum size, in bytes, accepted for a per-host markdown note
+# body (the ``view_notes`` collection populated by
+# ``DBView.set_host_note``).  The storage layer enforces this
+# via :meth:`DBView._validate_note_body_size` as
+# defence-in-depth; the web routes (``PUT /cgi/view/<addr>/notes``)
+# return HTTP 413 for over-cap requests before they reach the
+# DB.  Set to ``None`` to disable the cap (Mongo's BSON
+# 16 MiB document limit still applies).
+WEB_HOST_NOTES_MAX_BYTES: int | None = 1_000_000
 # Feed with a random value, like `openssl rand -base64 42`.
 # *Mandatory* when WEB_AUTH_ENABLED == True
 WEB_SECRET = None

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -4556,6 +4556,109 @@ class DBView(DBActive):
             values["ja4_c2_raw"] = ja4_c2_raw
         return cls.searchscript(name="ssl-ja4-client", values=values, neg=neg)
 
+    # ----------------------------------------------------------------
+    # Per-host notes (markdown, free-form annotation).
+    #
+    # Stored in two backend-side collections:
+    #
+    # * ``view_notes``: one record per ``addr`` carrying the
+    #   *current* note (body, timestamps, authorship, monotonic
+    #   ``revision`` integer).
+    # * ``view_note_revisions``: append-only audit log; one row
+    #   per edit, indexed by ``(addr, revision DESC)``.
+    #
+    # Replaces the legacy Dokuwiki / MediaWiki integrations
+    # whose only IVRE-side knowledge was a filesystem scan for
+    # ``<IP>.txt`` files.  The new surface lets the SPA render
+    # / edit notes natively and lets the ``notes:`` search-bar
+    # filter consult an in-database list of hosts with notes.
+    # ----------------------------------------------------------------
+
+    @staticmethod
+    def _validate_note_body_size(body: str) -> None:
+        """Raise :class:`ValueError` if ``body`` exceeds
+        :data:`config.WEB_HOST_NOTES_MAX_BYTES` (when the knob
+        is not ``None``).
+
+        Called by every backend's :meth:`set_host_note`
+        implementation before any DB write -- defence-in-depth
+        alongside the web-layer cap the ``/cgi/view/<addr>/notes``
+        route enforces.
+        """
+        cap = config.WEB_HOST_NOTES_MAX_BYTES
+        if cap is None:
+            return
+        byte_len = len(body.encode("utf-8"))
+        if byte_len > cap:
+            raise ValueError(f"note body is {byte_len} bytes, exceeds cap {cap}")
+
+    def get_host_note(self, addr: str) -> dict | None:
+        """Return the current note record for ``addr``, or
+        ``None`` when no note has been written yet.
+
+        The returned dict carries ``addr`` / ``body`` /
+        ``created_at`` / ``created_by`` / ``updated_at`` /
+        ``updated_by`` / ``revision``.
+        """
+        raise NotImplementedError
+
+    def set_host_note(
+        self,
+        addr: str,
+        body: str,
+        user_email: str,
+        *,
+        expected_revision: int | None = None,
+    ) -> dict:
+        """Upsert the note for ``addr``.
+
+        Stamps ``updated_by`` / ``updated_at`` and bumps the
+        monotonic ``revision`` counter.  On first creation also
+        stamps ``created_by`` / ``created_at``.  Appends an
+        immutable row to the revisions collection (audit trail).
+
+        Concurrency control: when ``expected_revision`` is set,
+        refuses the write if the stored revision does not match
+        (raises :class:`ValueError`).  ``expected_revision=0``
+        means "create only if no note exists yet".  ``None``
+        (the default) means last-write-wins -- the upsert
+        proceeds regardless of the current revision.
+
+        Body size: :data:`config.WEB_HOST_NOTES_MAX_BYTES`
+        bounds the accepted body length.  Over-cap writes
+        raise :class:`ValueError`.
+
+        Returns the post-update note record.
+        """
+        raise NotImplementedError
+
+    def delete_host_note(self, addr: str) -> bool:
+        """Remove the note for ``addr`` and every revision in
+        its audit log.  Returns ``True`` when a record existed
+        and was removed, ``False`` otherwise.
+        """
+        raise NotImplementedError
+
+    def list_host_note_revisions(self, addr: str) -> list[dict]:
+        """Return every revision recorded for ``addr``,
+        newest-first.  Each entry carries ``revision`` /
+        ``body`` / ``created_at`` / ``created_by``.
+        """
+        raise NotImplementedError
+
+    def list_hosts_with_notes(self) -> list[str]:
+        """Return the canonical addresses that currently have a
+        note.  Used by the search-bar ``notes:`` filter to
+        narrow result sets to annotated hosts.
+        """
+        raise NotImplementedError
+
+    def count_host_notes(self) -> int:
+        """Total number of hosts with a note (admin /
+        statistics surface).
+        """
+        raise NotImplementedError
+
 
 class _RecInfo:
     __slots__ = ["count", "firstseen", "infos", "lastseen"]

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -38,7 +38,8 @@ from urllib.parse import unquote
 
 import bson
 import pymongo
-from pymongo.errors import BulkWriteError, CursorNotFound
+from pymongo import ReturnDocument
+from pymongo.errors import BulkWriteError, CursorNotFound, DuplicateKeyError
 
 try:
     import gssapi  # type: ignore
@@ -4581,6 +4582,14 @@ class MongoDBNmap(MongoDBActive, DBNmap):
 
 
 class MongoDBView(MongoDBActive, DBView):
+    # ``column_hosts = 0`` is inherited from
+    # :class:`MongoDBActive`.  The two extra columns below carry
+    # per-host markdown notes plus their append-only revision
+    # history (see :meth:`set_host_note` / the ``view_notes`` and
+    # ``view_note_revisions`` index blocks below).
+    column_view_notes = 1
+    column_view_note_revisions = 2
+
     indexes: list[list[tuple[list[IndexKey], dict[str, Any]]]] = [
         (
             idxs
@@ -4607,6 +4616,32 @@ class MongoDBView(MongoDBActive, DBView):
             else idxs
         )
         for i, idxs in enumerate(MongoDBActive.indexes)
+    ] + [
+        # view_notes: one record per host carrying the current
+        # note (body + author + timestamps + monotonic revision).
+        # ``addr`` is the unique natural key; the secondary
+        # ``updated_at`` index supports admin "most recently
+        # edited" listings, and ``updated_by`` supports
+        # per-user filters.
+        [
+            ([("addr", pymongo.ASCENDING)], {"unique": True}),
+            ([("updated_at", pymongo.DESCENDING)], {}),
+            ([("updated_by", pymongo.ASCENDING)], {}),
+        ],
+        # view_note_revisions: append-only audit log.  Compound
+        # ``(addr ASC, revision DESC)`` supports the
+        # newest-first history retrieval in
+        # :meth:`list_host_note_revisions`.  No TTL: the choice
+        # was full audit history.
+        [
+            (
+                [
+                    ("addr", pymongo.ASCENDING),
+                    ("revision", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+        ],
     ]
     schema_migrations_indexes: list[
         dict[int, dict[str, list[tuple[list[IndexKey] | str, dict[str, Any]]]]]
@@ -4637,7 +4672,11 @@ class MongoDBView(MongoDBActive, DBView):
 
     def __init__(self, url):
         super().__init__(url)
-        self.columns = [self.params.pop("colname_hosts", "views")]
+        self.columns = [
+            self.params.pop("colname_hosts", "views"),
+            self.params.pop("colname_view_notes", "view_notes"),
+            self.params.pop("colname_view_note_revisions", "view_note_revisions"),
+        ]
 
     def store_or_merge_host(self, host):
         if not self.merge_host(host):
@@ -4770,6 +4809,156 @@ class MongoDBView(MongoDBActive, DBView):
 
         """
         return cls._search_field("infos.as_name", asname, neg=neg)
+
+    # Per-host notes ------------------------------------------------
+    #
+    # ``view_notes`` carries the current state; ``view_note_revisions``
+    # is the append-only audit log.  See :class:`DBView` for the
+    # abstract surface and concurrency / size-cap semantics.
+
+    @staticmethod
+    def _canonical_note_addr(addr):
+        """Match the canonicalisation the ``view`` collection
+        uses for its ``addr`` field so a note key always lines
+        up with the host record it annotates.  ``view`` stores
+        the printable string form (e.g. ``"192.0.2.1"`` /
+        ``"2001:db8::1"``) so we just normalise the input via
+        ``utils.force_int2ip(utils.force_ip2int(addr))``: the
+        round-trip canonicalises IPv6 forms (collapses
+        ``::1``-style zero groups) and rejects garbage early.
+        """
+        return utils.force_int2ip(utils.force_ip2int(addr))
+
+    def get_host_note(self, addr):
+        canonical = self._canonical_note_addr(addr)
+        doc = self.db[self.columns[self.column_view_notes]].find_one(
+            {"addr": canonical}
+        )
+        if doc is None:
+            return None
+        doc.pop("_id", None)
+        return doc
+
+    def set_host_note(self, addr, body, user_email, *, expected_revision=None):
+        # Storage-layer body-size check; the web route (PR B)
+        # adds an HTTP 413 in front.
+        self._validate_note_body_size(body)
+        canonical = self._canonical_note_addr(addr)
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        notes_col = self.db[self.columns[self.column_view_notes]]
+        revisions_col = self.db[self.columns[self.column_view_note_revisions]]
+        if expected_revision is None:
+            # Race-tolerant upsert: bump revision atomically.
+            doc = notes_col.find_one_and_update(
+                {"addr": canonical},
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                    "$setOnInsert": {
+                        "addr": canonical,
+                        "created_at": now,
+                        "created_by": user_email,
+                    },
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        elif expected_revision >= 1:
+            # Concurrency-checked update: only proceeds when
+            # the stored revision matches.  ``None`` return
+            # means the filter did not find a matching record,
+            # i.e. the revision drifted (or no record exists).
+            doc = notes_col.find_one_and_update(
+                {"addr": canonical, "revision": expected_revision},
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            if doc is None:
+                raise ValueError(
+                    f"concurrent edit detected: stored revision "
+                    f"does not match expected={expected_revision}"
+                )
+        else:
+            # ``expected_revision <= 0``: insert-only path,
+            # creating the note iff no record exists.  Negative
+            # values are coalesced into this branch -- the
+            # caller's intent is "no prior history" either way.
+            try:
+                notes_col.insert_one(
+                    {
+                        "addr": canonical,
+                        "body": body,
+                        "created_at": now,
+                        "created_by": user_email,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                        "revision": 1,
+                    }
+                )
+            except DuplicateKeyError as exc:
+                raise ValueError(
+                    "note already exists; expected_revision=0 cannot insert"
+                ) from exc
+            doc = notes_col.find_one({"addr": canonical})
+        # Append the immutable revision row.  Two-op semantics
+        # (parent + audit log): a crash between the two leaves
+        # the parent committed and the matching revision row
+        # missing -- the parent body is the authoritative
+        # source of truth, so reads remain correct.
+        revisions_col.insert_one(
+            {
+                "addr": canonical,
+                "revision": doc["revision"],
+                "body": body,
+                "created_at": now,
+                "created_by": user_email,
+            }
+        )
+        doc.pop("_id", None)
+        return doc
+
+    def delete_host_note(self, addr):
+        canonical = self._canonical_note_addr(addr)
+        result = self.db[self.columns[self.column_view_notes]].delete_one(
+            {"addr": canonical}
+        )
+        # Always sweep the revisions: a stray audit log without
+        # a parent is meaningless and would inflate
+        # ``count_documents`` queries.
+        self.db[self.columns[self.column_view_note_revisions]].delete_many(
+            {"addr": canonical}
+        )
+        return result.deleted_count > 0
+
+    def list_host_note_revisions(self, addr):
+        canonical = self._canonical_note_addr(addr)
+        cursor = (
+            self.db[self.columns[self.column_view_note_revisions]]
+            .find({"addr": canonical})
+            .sort([("revision", pymongo.DESCENDING)])
+        )
+        revisions = []
+        for doc in cursor:
+            doc.pop("_id", None)
+            revisions.append(doc)
+        return revisions
+
+    def list_hosts_with_notes(self):
+        return list(self.db[self.columns[self.column_view_notes]].distinct("addr"))
+
+    def count_host_notes(self):
+        return self.db[self.columns[self.column_view_notes]].count_documents({})
 
 
 class MongoDBPassive(MongoDB, DBPassive):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -14847,6 +14847,139 @@ class IPRangeTests(unittest.TestCase):
         self.assertTrue(status.startswith("400"), status)
 
 
+# ---------------------------------------------------------------------
+# MongoDBViewNotesIndexTests -- pin the structural definitions
+# (collections, indexes, abstract surface, body-size validator)
+# the host-notes storage layer ships with.  The actual
+# create/read/update/list-revisions/delete round-trip is
+# exercised in ``tests/tests.py`` on the ``mongodb.yml`` CI lane
+# where a real MongoDB instance is available; these no-backend
+# tests bound the wire shape so regressions surface immediately.
+# ---------------------------------------------------------------------
+
+
+class MongoDBViewNotesIndexTests(unittest.TestCase):
+    """Backend-free pin tests for the host-notes storage layer
+    (``view_notes`` + ``view_note_revisions`` collections + the
+    ``DBView`` abstract surface).
+    """
+
+    def test_view_notes_columns_registered(self) -> None:
+        from ivre.db.mongo import MongoDBView
+
+        # The two new column constants are appended after the
+        # inherited ``column_hosts = 0``.
+        self.assertEqual(MongoDBView.column_view_notes, 1)
+        self.assertEqual(MongoDBView.column_view_note_revisions, 2)
+        # The ``indexes`` list mirrors ``columns`` in length so
+        # every collection has its index block.
+        self.assertEqual(
+            len(MongoDBView.indexes),
+            MongoDBView.column_view_note_revisions + 1,
+        )
+
+    def test_view_notes_addr_unique_index(self) -> None:
+        from ivre.db.mongo import MongoDBView
+
+        block = MongoDBView.indexes[MongoDBView.column_view_notes]
+        addr_index = next((keys, opts) for keys, opts in block if keys == [("addr", 1)])
+        self.assertTrue(addr_index[1].get("unique"), addr_index)
+
+    def test_view_note_revisions_compound_index(self) -> None:
+        # Pin the ``(addr ASC, revision DESC)`` compound used by
+        # ``list_host_note_revisions`` for newest-first ordering.
+        from ivre.db.mongo import MongoDBView
+
+        block = MongoDBView.indexes[MongoDBView.column_view_note_revisions]
+        self.assertTrue(
+            any(keys == [("addr", 1), ("revision", -1)] for keys, _opts in block),
+            block,
+        )
+
+    def test_dbview_notes_abstract_surface(self) -> None:
+        # Each method is declared on :class:`DBView` and raises
+        # NotImplementedError unless the concrete backend
+        # provides it.  ``MongoDBView`` overrides them all.
+        from ivre.db import DBView
+        from ivre.db.mongo import MongoDBView
+
+        method_names = (
+            "get_host_note",
+            "set_host_note",
+            "delete_host_note",
+            "list_host_note_revisions",
+            "list_hosts_with_notes",
+            "count_host_notes",
+        )
+        for name in method_names:
+            with self.subTest(method=name):
+                self.assertTrue(
+                    hasattr(DBView, name),
+                    f"DBView is missing {name}",
+                )
+                self.assertTrue(
+                    hasattr(MongoDBView, name),
+                    f"MongoDBView is missing {name}",
+                )
+                # The Mongo concrete impl shadows the abstract
+                # raise; the inherited method on a fresh
+                # ``DBView`` instance still raises.
+                self.assertIsNot(
+                    DBView.__dict__.get(name),
+                    None,
+                    f"DBView.{name} should be defined directly",
+                )
+
+    def test_dbview_note_methods_raise_on_base(self) -> None:
+        # Driving the base-class method directly (bypassing the
+        # concrete override) surfaces ``NotImplementedError``,
+        # so a backend that forgets to implement one fails
+        # loudly instead of silently no-op'ing.
+        from ivre.db import DBView
+
+        view = DBView()
+        with self.assertRaises(NotImplementedError):
+            view.get_host_note("192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            view.set_host_note("192.0.2.1", "body", "alice@example.org")
+        with self.assertRaises(NotImplementedError):
+            view.delete_host_note("192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            view.list_host_note_revisions("192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            view.list_hosts_with_notes()
+        with self.assertRaises(NotImplementedError):
+            view.count_host_notes()
+
+    def test_validate_note_body_size_accepts_within_cap(self) -> None:
+        from ivre.db import DBView
+
+        # A body of ``cap`` bytes is accepted (exactly the cap,
+        # not over it).
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None  # default config has it set
+        # ASCII body so byte-length equals str-length.
+        DBView._validate_note_body_size("x" * cap)
+
+    def test_validate_note_body_size_rejects_over_cap(self) -> None:
+        from ivre.db import DBView
+
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None
+        with self.assertRaises(ValueError) as ctx:
+            DBView._validate_note_body_size("x" * (cap + 1))
+        self.assertIn("exceeds cap", str(ctx.exception))
+
+    def test_validate_note_body_size_disabled_when_cap_is_none(self) -> None:
+        from ivre.db import DBView
+
+        # An operator may disable the cap explicitly; arbitrarily
+        # large bodies are then accepted by the storage validator
+        # (Mongo's 16 MiB BSON limit still applies at insert time).
+        with mock.patch.object(ivre.config, "WEB_HOST_NOTES_MAX_BYTES", None):
+            DBView._validate_note_body_size("x" * 5_000_000)
+
+
 def _parse_args() -> None:
     """Parse the optional ``--samples`` and ``--coverage`` flags when
     this module is invoked as a script. Mirrors ``tests/tests.py``."""


### PR DESCRIPTION
Adds a per-host markdown-notes feature to the View backend, backed by two new Mongo collections:

* ``view_notes`` -- one record per host carrying the current note (body, author, timestamps, monotonic ``revision`` counter).  Unique index on ``addr``; secondary indexes on ``updated_at`` (desc) and ``updated_by`` for admin / per-user listings.
* ``view_note_revisions`` -- append-only audit log; one row per edit.  Compound ``(addr ASC, revision DESC)`` index supports newest-first history retrieval.

Lays the storage layer for replacing the legacy Dokuwiki / MediaWiki integrations (whose only IVRE-side knowledge was a filesystem scan for ``<IP>.txt`` files) with a native feature edited through the SPA.  No web routes / SPA panel / Dokuwiki removal in this PR -- those land in follow-ups (PR B = web routes, PR C/D = SPA panel, PR E = Dokuwiki removal + ``notes:`` filter repoint).

``DBView`` gains six abstract methods + one static helper:

* ``get_host_note(addr)`` -- read current note.
* ``set_host_note(addr, body, user_email, *, expected_revision=None)`` -- upsert.  Concurrency control via the keyword-only ``expected_revision``: ``None`` = last-write-wins; ``0`` = create-only (raises ``ValueError`` if a record already exists); ``>= 1`` = update only when the stored revision matches (otherwise ``ValueError``, surfacing a concurrent-edit conflict to the SPA save button).
* ``delete_host_note(addr)`` -- hard delete; sweeps the audit log too.
* ``list_host_note_revisions(addr)`` -- newest-first revision history.
* ``list_hosts_with_notes()`` -- canonical addresses that carry a note (replaces the Dokuwiki filesystem scan used by the search-bar ``notes:`` filter; the repoint lands in PR E).
* ``count_host_notes()`` -- admin / statistics surface.
* ``_validate_note_body_size(body)`` -- static helper; raises ``ValueError`` when the body exceeds ``config.WEB_HOST_NOTES_MAX_BYTES`` (default 1 MB; set to ``None`` to disable the cap).  Called by every backend's ``set_host_note`` before any DB write -- defence-in-depth alongside the HTTP-413 the web route will add in PR B.

``MongoDBView`` implements all six methods.  Addr is canonicalised via ``utils.force_int2ip(utils.force_ip2int(...))`` so a note key always matches the printable form the ``view`` collection stores.  ``set_host_note`` is the longest at ~60 LoC and has three code paths corresponding to the three concurrency modes; the upsert + revision-insert is a two-op sequence (parent authoritative, audit log best-effort).

Other ``DBView`` backends (Elastic / HTTP / PostgreSQL / DuckDB / DocumentDB) inherit the ``NotImplementedError`` base for now -- matches the M4 ethos of landing new features on Mongo first and propagating once the surface stabilises.

Tests (8 new in ``MongoDBViewNotesIndexTests``, backend-free):

* pin the two new column constants + indexes-list length
* pin ``addr`` unique index on ``view_notes``
* pin ``(addr, revision DESC)`` compound on ``view_note_revisions``
* pin the abstract surface (every method exists on both ``DBView`` and ``MongoDBView``)
* pin that the base ``DBView`` methods raise ``NotImplementedError`` (catches backends that forget the override)
* pin the body-size validator (within cap, over cap, cap disabled)

The actual create / read / update / list-revisions / delete round-trip against a real MongoDB lands in
``tests/tests.py::test_50_view`` in PR B (alongside the web routes that drive the surface end-to-end).