### PR TITLE
feat(db): DBNotes purpose for entity-keyed markdown annotations (Mongo)

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -37,6 +37,11 @@ DEBUG = False
 DEBUG_DB = False
 DB = "mongodb:///ivre"
 DB_DATA = None  # specific: maxmind:///<ivre_share_path>/geoip
+# DB URL for the ``notes`` purpose (per-entity markdown
+# annotations).  Falls back to ``DB`` when unset.  The ``notes``
+# purpose is independent of every data purpose: ``view --init``,
+# ``nmap --init`` etc. do not touch notes.
+DB_NOTES = None
 # Begin batch sizes
 LOCAL_BATCH_SIZE = 10000  # used with --local-bulk
 MONGODB_BATCH_SIZE = 100
@@ -301,6 +306,14 @@ WEB_UPLOAD_OK = False
 # bounded by the underlying ``IPRanges`` shape and are not
 # capped. Set to ``None`` to disable the cap.
 WEB_IPRANGE_ADDR_CAP: int | None = 100_000
+# Maximum size, in bytes, accepted for a single note body
+# (per-entity markdown annotation stored in the ``notes``
+# purpose).  The storage layer enforces this via
+# :meth:`DBNotes._validate_note_body_size` as defence-in-depth;
+# web routes return HTTP 413 for over-cap requests before they
+# reach the DB.  Set to ``None`` to disable the cap (Mongo's
+# BSON 16 MiB document limit still applies).
+WEB_HOST_NOTES_MAX_BYTES: int | None = 1_000_000
 # Feed with a random value, like `openssl rand -base64 42`.
 # *Mandatory* when WEB_AUTH_ENABLED == True
 WEB_SECRET = None
@@ -490,6 +503,13 @@ if RIR_PATH is None:
 
 if DB_DATA is None and GEOIP_PATH is not None:
     DB_DATA = f"maxmind:///{GEOIP_PATH}"
+
+
+# Per-entity notes default to the same store as everything else
+# (operators get a working ``db.notes`` out of the box).  Override
+# DB_NOTES explicitly to move notes to a separate store.
+if DB_NOTES is None:
+    DB_NOTES = DB
 
 
 if DATA_PATH is None:

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -35,6 +35,7 @@ import sys
 import time
 from argparse import ArgumentParser
 from collections import OrderedDict
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
 from functools import reduce
 from importlib import import_module
@@ -5822,6 +5823,216 @@ class DBFlow(DB):
         raise NotImplementedError
 
 
+# ---------------------------------------------------------------------
+# Per-entity notes (per-host, eventually per-domain / per-ASN / ...).
+# Independent purpose so the storage lifecycle is decoupled from any
+# data purpose: ``view --init``, ``nmap --init``, ``passive --init``
+# never touch notes.  Operators wipe annotations explicitly via the
+# new (to-be-added) ``ivre notes --init`` CLI.
+#
+# Entities are referenced by an opaque ``(entity_type, entity_key)``
+# pair.  ``entity_type`` is a short string drawn from a closed
+# vocabulary (``"host"`` only at v1; ``"domain"`` / ``"asn"`` /
+# ``"cve"`` / ... slot in as additive PRs).  ``entity_key`` is the
+# canonical form for that type -- e.g. for ``"host"`` it is the
+# ``[addr_0, addr_1]`` int128 split that :class:`MongoDB` already
+# uses for the ``view`` collection's ``addr`` field, so the two
+# stores align byte-for-byte and a future ``$lookup`` join works
+# without per-side conversion.
+# ---------------------------------------------------------------------
+
+
+def _canonicalize_host_key(key: Any) -> list[int]:
+    """Canonical entity_key for the ``host`` entity type.
+
+    Accepts a printable IP string (``"192.0.2.1"`` /
+    ``"2001:db8::1"``) or an already-canonical
+    ``[addr_0, addr_1]`` int pair.  Returns the int128 split
+    form :class:`MongoDB` uses for its ``addr_0`` / ``addr_1``
+    fields, so a note keyed by host aligns byte-for-byte with
+    the matching ``view`` record (enables future ``$lookup``
+    joins and correct IP-range queries).
+
+    The split logic is reproduced here (rather than delegating
+    to :meth:`MongoDB.ip2internal`) so the canonicalisation
+    registry does not pull the Mongo backend into the import
+    graph from the base :mod:`ivre.db` module.
+    """
+    if isinstance(key, list):
+        return key
+    return [val - 0x8000000000000000 for val in struct.unpack("!QQ", utils.ip2bin(key))]
+
+
+# Registry of canonicalisation helpers keyed by entity_type.
+# Adding a new entity type means:
+#   1. registering its helper here,
+#   2. extending the storage layer's BSON-shape handling if the
+#      canonical form is something other than ``str`` / ``list``,
+#   3. wiring the matching MCP tool + web route in PR B.
+_ENTITY_CANONICALIZERS: dict[str, Callable[[Any], Any]] = {
+    "host": _canonicalize_host_key,
+}
+
+
+def canonicalize_entity_key(entity_type: str, key: Any) -> Any:
+    """Return the canonical form for ``key`` under
+    ``entity_type``.  Raises :class:`ValueError` on an unknown
+    ``entity_type`` so a backend, a web route or an MCP tool
+    that received a garbled type surfaces the error cleanly
+    instead of silently storing nonsense.
+    """
+    try:
+        canonicalizer = _ENTITY_CANONICALIZERS[entity_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown entity_type {entity_type!r}; expected one of "
+            f"{sorted(_ENTITY_CANONICALIZERS)}"
+        ) from exc
+    return canonicalizer(key)
+
+
+class DBNotes(DB):
+    """Per-entity markdown annotations (notes).
+
+    Replaces the legacy Dokuwiki / MediaWiki integrations whose
+    only IVRE-side knowledge was a filesystem scan for
+    ``<IP>.txt`` files.  Notes are stored in IVRE's own DB,
+    keyed by ``(entity_type, entity_key)``, with an append-only
+    revision history.
+
+    Lifecycle independence is the whole point of carving this
+    out as its own purpose: ``view --init``, ``nmap --init``,
+    ``passive --init`` never touch notes.  Operators wipe
+    annotations explicitly via ``ivre notes --init`` (CLI
+    subcommand wired in a follow-up PR).
+    """
+
+    backends = {
+        "mongodb": ("mongo", "MongoDBNotes"),
+        # Other backends inherit ``NotImplementedError`` from
+        # this base for v1.  Filled in alongside their
+        # respective M4 follow-ups.
+    }
+
+    @staticmethod
+    def _validate_note_body_size(body: str) -> None:
+        """Raise :class:`ValueError` if ``body`` exceeds
+        :data:`config.WEB_HOST_NOTES_MAX_BYTES` (when the knob
+        is not ``None``).
+
+        Called by every backend's :meth:`set_note`
+        implementation before any DB write -- defence-in-depth
+        alongside the HTTP-413 the ``/cgi/notes/...`` routes
+        return in PR B.
+        """
+        cap = config.WEB_HOST_NOTES_MAX_BYTES
+        if cap is None:
+            return
+        byte_len = len(body.encode("utf-8"))
+        if byte_len > cap:
+            raise ValueError(f"note body is {byte_len} bytes, exceeds cap {cap}")
+
+    def get_note(self, entity_type: str, entity_key: Any) -> dict | None:
+        """Return the current note for ``(entity_type, entity_key)``,
+        or ``None`` when no annotation has been written yet.
+
+        The returned dict carries ``entity_type`` /
+        ``entity_key`` (canonical form) / ``body`` /
+        ``created_at`` / ``created_by`` / ``updated_at`` /
+        ``updated_by`` / ``revision``.  ``entity_key`` is
+        canonical (e.g. printable IP string for ``host``) --
+        backends are responsible for converting from the
+        on-disk form back to the caller-facing form.
+        """
+        raise NotImplementedError
+
+    def set_note(
+        self,
+        entity_type: str,
+        entity_key: Any,
+        body: str,
+        user_email: str,
+        *,
+        expected_revision: int | None = None,
+    ) -> dict:
+        """Upsert the note for ``(entity_type, entity_key)``.
+
+        Stamps ``updated_by`` / ``updated_at`` and bumps the
+        monotonic ``revision`` counter.  On first creation
+        also stamps ``created_by`` / ``created_at``.  Appends
+        an immutable row to the revisions collection (audit
+        trail).
+
+        Concurrency control via ``expected_revision``:
+
+        * ``None`` (default): last-write-wins; upsert proceeds
+          regardless of the current revision.
+        * ``0``: create-only; raises :class:`ValueError` if a
+          note already exists.
+        * ``>= 1``: update only when the stored revision
+          matches.  Mismatch raises :class:`ValueError`,
+          surfacing a concurrent edit to the SPA save button.
+
+        Body-size cap: :data:`config.WEB_HOST_NOTES_MAX_BYTES`
+        bounds the accepted body length.  Over-cap writes
+        raise :class:`ValueError`.
+        """
+        raise NotImplementedError
+
+    def delete_note(self, entity_type: str, entity_key: Any) -> bool:
+        """Remove the note for ``(entity_type, entity_key)``
+        and every revision in its audit log.  Returns ``True``
+        when a record existed and was removed.
+        """
+        raise NotImplementedError
+
+    def list_note_revisions(self, entity_type: str, entity_key: Any) -> list[dict]:
+        """Return every revision recorded for the entity,
+        newest-first.  Each entry carries ``revision`` /
+        ``body`` / ``created_at`` / ``created_by``.
+        """
+        raise NotImplementedError
+
+    def list_entities(self, entity_type: str | None = None) -> list[dict]:
+        """Return the entities that currently have a note,
+        optionally narrowed by ``entity_type``.
+
+        Each entry carries ``entity_type`` / ``entity_key`` /
+        ``updated_at`` / ``updated_by`` / ``revision`` so the
+        search-bar ``notes:`` filter (PR E) can build a host
+        narrow without an extra round-trip per entity.
+        """
+        raise NotImplementedError
+
+    def count_notes(self, entity_type: str | None = None) -> int:
+        """Number of entities with a note, optionally narrowed
+        by ``entity_type``.  Admin / statistics surface.
+        """
+        raise NotImplementedError
+
+    def get(self, spec: Any, **kargs: Any) -> Iterable[dict]:
+        """Iterate note documents matching the backend-native
+        filter ``spec``.
+
+        Filters are composed via :meth:`searchtext` (free-text
+        search over note bodies, inherited from the backend's
+        base class -- e.g. :meth:`MongoDB.searchtext`) and the
+        standard backend combinators (:meth:`flt_and` /
+        :meth:`flt_or` / direct filter literals).  Returned
+        documents carry the storage-layer ``entity_key_*``
+        fields verbatim; callers that need the caller-facing
+        ``entity_key`` form go through :meth:`get_note` /
+        :meth:`list_entities` instead.
+        """
+        raise NotImplementedError
+
+    def count(self, spec: Any) -> int:
+        """Number of note documents matching ``spec``.  Same
+        filter shape as :meth:`get`.
+        """
+        raise NotImplementedError
+
+
 class DBAuth(DB):
     """Backend-independent code to handle authentication"""
 
@@ -6077,6 +6288,7 @@ class MetaDB:
         "rir": DBRir,
         "flow": DBFlow,
         "auth": DBAuth,
+        "notes": DBNotes,
     }
 
     def __init__(self, url=None, urls=None):
@@ -6084,7 +6296,7 @@ class MetaDB:
         self.urls = urls or {}
 
     def close(self):
-        for attr in ["nmap", "passive", "data", "flow", "view"]:
+        for attr in ["nmap", "passive", "data", "flow", "view", "notes"]:
             try:
                 getattr(self, f"_{attr}").close()
             except AttributeError:
@@ -6167,6 +6379,16 @@ class MetaDB:
             )
         self._auth = self.get_class("auth")
         return self._auth
+
+    @property
+    def notes(self):
+        try:
+            # pylint: disable=access-member-before-definition
+            return self._notes
+        except AttributeError:
+            pass
+        self._notes = self.get_class("notes")
+        return self._notes
 
     def get_class(self, purpose):
         url = self.urls.get(purpose, self.url)

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -38,7 +38,8 @@ from urllib.parse import unquote
 
 import bson
 import pymongo
-from pymongo.errors import BulkWriteError, CursorNotFound
+from pymongo import ReturnDocument
+from pymongo.errors import BulkWriteError, CursorNotFound, DuplicateKeyError
 
 try:
     import gssapi  # type: ignore
@@ -57,9 +58,11 @@ from ivre.db import (
     DBFlow,
     DBFlowMeta,
     DBNmap,
+    DBNotes,
     DBPassive,
     DBRir,
     DBView,
+    canonicalize_entity_key,
 )
 from ivre.plugins import load_plugins
 from ivre.tags.active import is_synack_honeypot, set_auto_tags
@@ -7879,6 +7882,355 @@ class MongoDBAuth(MongoDB, DBAuth):
             {"$set": {"revoked_at": now}},
         )
         return result.modified_count
+
+
+class MongoDBNotes(MongoDB, DBNotes):
+    """MongoDB backend for the ``notes`` purpose.
+
+    Stores entity-keyed markdown annotations in two collections:
+
+    * ``notes`` -- one record per ``(entity_type, entity_key)``
+      carrying the current body, monotonic ``revision``,
+      authorship and timestamp metadata.  Unique compound
+      index on ``(entity_type, entity_key)``.
+    * ``note_revisions`` -- append-only audit log.  Compound
+      ``(entity_type, entity_key, revision DESC)`` supports
+      newest-first history retrieval.
+
+    The ``entity_key`` is stored in its canonical on-disk form
+    (e.g. ``[addr_0, addr_1]`` int128 split for the ``host``
+    type, matching :meth:`MongoDB.ip2internal` so the ``view``
+    collection and the ``notes`` collection align byte-for-byte
+    and a future ``$lookup`` join works without per-side
+    conversion).  Reads strip the canonical form back to the
+    caller-facing shape (e.g. printable IP string for
+    ``host``).
+    """
+
+    column_notes = 0
+    column_note_revisions = 1
+
+    indexes: list[list[tuple[list[IndexKey], dict[str, Any]]]] = [
+        # notes
+        #
+        # The canonical ``entity_key`` for an entity type may be
+        # a 1-or-2-element list of scalars (e.g. ``[addr_0,
+        # addr_1]`` for the ``host`` type, matching
+        # :meth:`MongoDB.ip2internal`'s int128 split).  Storing
+        # each half in its own scalar BSON field
+        # (``entity_key_0`` / ``entity_key_1``) keeps the unique
+        # compound a plain single-key compound -- a BSON-array
+        # ``entity_key`` would make the compound *multikey*, in
+        # which case Mongo enforces uniqueness element-wise: for
+        # any two IPv4 notes ``addr_0`` is the same (the bias
+        # constant ``-0x8000000000000000``), the second insert
+        # then collides with the first on a per-element basis.
+        # Single-scalar types (``domain``, ``cve``, ...) store
+        # the value in ``entity_key_0`` and ``None`` in
+        # ``entity_key_1``.
+        [
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("entity_key_0", pymongo.ASCENDING),
+                    ("entity_key_1", pymongo.ASCENDING),
+                ],
+                {"unique": True},
+            ),
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("updated_at", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+            ([("updated_by", pymongo.ASCENDING)], {}),
+            # Free-text search over note bodies.  Inherited
+            # :meth:`MongoDB.searchtext` returns
+            # ``{"$text": {"$search": ...}}`` filters that
+            # compose with :meth:`flt_and` and feed
+            # :meth:`get` / :meth:`count` on the storage
+            # layer.  Mongo allows at most one text index
+            # per collection.
+            ([("body", "text")], {"name": "notes_body_text"}),
+        ],
+        # note_revisions
+        [
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("entity_key_0", pymongo.ASCENDING),
+                    ("entity_key_1", pymongo.ASCENDING),
+                    ("revision", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+        ],
+    ]
+
+    def __init__(self, url):
+        super().__init__(url)
+        self.columns = [
+            self.params.pop("colname_notes", "notes"),
+            self.params.pop("colname_note_revisions", "note_revisions"),
+        ]
+
+    @staticmethod
+    def _entity_key_to_storage(canonical):
+        """Pack the canonical entity_key into the two storage
+        scalars ``(entity_key_0, entity_key_1)``.
+
+        Accepts either a scalar (1-element canonical form -- the
+        future ``domain`` / ``cve`` / ``asn`` types) or a
+        2-element list (the current ``host`` type's int128
+        split).  1-element lists are accepted too for callers
+        that uniformise the canonicalisation contract.
+        """
+        if isinstance(canonical, list):
+            if len(canonical) == 2:
+                return canonical[0], canonical[1]
+            if len(canonical) == 1:
+                return canonical[0], None
+            raise ValueError(
+                f"canonical entity_key list must have 1 or 2 "
+                f"elements, got {len(canonical)}"
+            )
+        return canonical, None
+
+    @classmethod
+    def _entity_key_filter(cls, entity_type, entity_key):
+        """Build a single-record find filter for the
+        ``(entity_type, entity_key_0, entity_key_1)`` compound
+        from a caller-facing ``entity_key``.
+        """
+        key_0, key_1 = cls._entity_key_to_storage(
+            canonicalize_entity_key(entity_type, entity_key)
+        )
+        return {
+            "entity_type": entity_type,
+            "entity_key_0": key_0,
+            "entity_key_1": key_1,
+        }
+
+    @staticmethod
+    def _present_entity_key(entity_type, entity_key_0, entity_key_1):
+        """Reassemble the caller-facing ``entity_key`` from the
+        two storage scalars.  Inverse of
+        :meth:`_entity_key_to_storage` composed with
+        :func:`canonicalize_entity_key`.
+
+        At v1 only the ``host`` type needs back-conversion
+        (printable IP string from the int128 split); future
+        single-scalar types round-trip the value in
+        ``entity_key_0`` as-is and ignore ``entity_key_1``.
+        """
+        if entity_type == "host":
+            return MongoDB.internal2ip([entity_key_0, entity_key_1])
+        return entity_key_0
+
+    def _present_note(self, doc):
+        """Common projection helper: drop ``_id`` and the two
+        storage scalars, replacing them with a single
+        caller-facing ``entity_key`` field.
+        """
+        doc.pop("_id", None)
+        doc["entity_key"] = self._present_entity_key(
+            doc["entity_type"],
+            doc.pop("entity_key_0"),
+            doc.pop("entity_key_1"),
+        )
+        return doc
+
+    def get(self, spec, **kargs):
+        """Iterate raw note documents matching ``spec``.
+
+        ``spec`` is composed via :meth:`searchtext` (inherited
+        from :class:`MongoDB`) and the standard combinators
+        (:meth:`flt_and` / :meth:`flt_or` / direct dict
+        literals).  Returned documents carry the storage-layer
+        ``entity_key_0`` / ``entity_key_1`` fields verbatim --
+        free-text search routes and listing pages that want the
+        caller-facing ``entity_key`` form post-process with
+        :meth:`_present_note` / :meth:`_present_entity_key`.
+        ``**kargs`` is accepted for forward-compatibility with
+        the base :meth:`DB.get` signature; v1 ignores it.
+        """
+        return self.db[self.columns[self.column_notes]].find(spec, **kargs)
+
+    def count(self, spec):
+        return self.db[self.columns[self.column_notes]].count_documents(spec)
+
+    def get_note(self, entity_type, entity_key):
+        doc = self.db[self.columns[self.column_notes]].find_one(
+            self._entity_key_filter(entity_type, entity_key)
+        )
+        if doc is None:
+            return None
+        return self._present_note(doc)
+
+    def set_note(
+        self,
+        entity_type,
+        entity_key,
+        body,
+        user_email,
+        *,
+        expected_revision=None,
+    ):
+        # Storage-layer body-size check; the web routes (PR B)
+        # add an HTTP 413 in front for the friendlier client
+        # error.
+        self._validate_note_body_size(body)
+        key_0, key_1 = self._entity_key_to_storage(
+            canonicalize_entity_key(entity_type, entity_key)
+        )
+        key_filter = {
+            "entity_type": entity_type,
+            "entity_key_0": key_0,
+            "entity_key_1": key_1,
+        }
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        notes_col = self.db[self.columns[self.column_notes]]
+        revisions_col = self.db[self.columns[self.column_note_revisions]]
+        if expected_revision is None:
+            # Race-tolerant upsert: bump revision atomically.
+            doc = notes_col.find_one_and_update(
+                key_filter,
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                    "$setOnInsert": {
+                        "entity_type": entity_type,
+                        "entity_key_0": key_0,
+                        "entity_key_1": key_1,
+                        "created_at": now,
+                        "created_by": user_email,
+                    },
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        elif expected_revision >= 1:
+            # Concurrency-checked update: only proceeds when
+            # the stored revision matches.  ``None`` return
+            # means the filter did not find a matching record,
+            # i.e. the revision drifted (or no record exists).
+            doc = notes_col.find_one_and_update(
+                {**key_filter, "revision": expected_revision},
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            if doc is None:
+                raise ValueError(
+                    f"concurrent edit detected: stored revision "
+                    f"does not match expected={expected_revision}"
+                )
+        else:
+            # ``expected_revision <= 0``: insert-only path,
+            # creating the note iff no record exists.  Negative
+            # values are coalesced into this branch -- the
+            # caller's intent is "no prior history" either way.
+            try:
+                notes_col.insert_one(
+                    {
+                        "entity_type": entity_type,
+                        "entity_key_0": key_0,
+                        "entity_key_1": key_1,
+                        "body": body,
+                        "created_at": now,
+                        "created_by": user_email,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                        "revision": 1,
+                    }
+                )
+            except DuplicateKeyError as exc:
+                raise ValueError(
+                    "note already exists; expected_revision=0 cannot insert"
+                ) from exc
+            doc = notes_col.find_one(key_filter)
+        # Append the immutable revision row.  Two-op semantics
+        # (parent + audit log): a crash between the two leaves
+        # the parent committed and the matching revision row
+        # missing -- the parent body is the authoritative
+        # source of truth, so reads remain correct.
+        revisions_col.insert_one(
+            {
+                "entity_type": entity_type,
+                "entity_key_0": key_0,
+                "entity_key_1": key_1,
+                "revision": doc["revision"],
+                "body": body,
+                "created_at": now,
+                "created_by": user_email,
+            }
+        )
+        return self._present_note(doc)
+
+    def delete_note(self, entity_type, entity_key):
+        key_filter = self._entity_key_filter(entity_type, entity_key)
+        result = self.db[self.columns[self.column_notes]].delete_one(key_filter)
+        # Always sweep the audit log: orphan revisions without
+        # a parent are meaningless and would inflate
+        # ``count_documents`` queries.
+        self.db[self.columns[self.column_note_revisions]].delete_many(key_filter)
+        return result.deleted_count > 0
+
+    def list_note_revisions(self, entity_type, entity_key):
+        cursor = (
+            self.db[self.columns[self.column_note_revisions]]
+            .find(self._entity_key_filter(entity_type, entity_key))
+            .sort([("revision", pymongo.DESCENDING)])
+        )
+        revisions = []
+        for doc in cursor:
+            doc.pop("_id", None)
+            # Strip the redundant ``entity_*`` keys: callers
+            # passed them in and already know.  Keep ``revision``
+            # / ``body`` / ``created_at`` / ``created_by``.
+            doc.pop("entity_type", None)
+            doc.pop("entity_key_0", None)
+            doc.pop("entity_key_1", None)
+            revisions.append(doc)
+        return revisions
+
+    def list_entities(self, entity_type=None):
+        flt = {} if entity_type is None else {"entity_type": entity_type}
+        cursor = self.db[self.columns[self.column_notes]].find(
+            flt,
+            projection={
+                "_id": 0,
+                "entity_type": 1,
+                "entity_key_0": 1,
+                "entity_key_1": 1,
+                "updated_at": 1,
+                "updated_by": 1,
+                "revision": 1,
+            },
+        )
+        entries = []
+        for doc in cursor:
+            doc["entity_key"] = self._present_entity_key(
+                doc["entity_type"],
+                doc.pop("entity_key_0"),
+                doc.pop("entity_key_1"),
+            )
+            entries.append(doc)
+        return entries
+
+    def count_notes(self, entity_type=None):
+        return self.count({} if entity_type is None else {"entity_type": entity_type})
 
 
 load_plugins("ivre.plugins.db.mongo", globals())

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -14847,6 +14847,232 @@ class IPRangeTests(unittest.TestCase):
         self.assertTrue(status.startswith("400"), status)
 
 
+# ---------------------------------------------------------------------
+# MongoDBNotesIndexTests -- pin the structural definitions
+# (collections, indexes, abstract surface, canonicalisation
+# registry, body-size validator) the per-entity notes purpose
+# ships with.  The actual create / read / update / list-revisions
+# / delete round-trip is exercised in ``tests/tests.py`` on the
+# ``mongodb.yml`` CI lane where a real MongoDB instance is
+# available; these no-backend tests bound the wire shape so
+# regressions surface immediately.
+# ---------------------------------------------------------------------
+
+
+class MongoDBNotesIndexTests(unittest.TestCase):
+    """Backend-free pin tests for the per-entity notes storage
+    layer (``notes`` + ``note_revisions`` collections + the
+    ``DBNotes`` abstract surface + entity-key canonicalisation
+    registry).
+    """
+
+    def test_notes_columns_registered(self) -> None:
+        from ivre.db.mongo import MongoDBNotes
+
+        # Two columns at indexes 0 and 1 -- ``notes`` + audit log.
+        self.assertEqual(MongoDBNotes.column_notes, 0)
+        self.assertEqual(MongoDBNotes.column_note_revisions, 1)
+        # ``indexes`` mirrors ``columns`` in length so every
+        # collection has its index block.
+        self.assertEqual(len(MongoDBNotes.indexes), 2)
+
+    def test_notes_compound_unique_index(self) -> None:
+        # Pin ``(entity_type, entity_key_0, entity_key_1)`` as
+        # the unique compound.  Storing the canonical key as
+        # two scalar fields keeps the index a plain single-key
+        # compound -- a BSON-array ``entity_key`` would turn it
+        # into a *multikey* index where Mongo enforces
+        # uniqueness element-wise, in which case two IPv4 notes
+        # (whose ``addr_0`` is the same bias constant) collide
+        # at the second insert.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_notes]
+        unique_index = next(
+            (keys, opts)
+            for keys, opts in block
+            if keys
+            == [
+                ("entity_type", 1),
+                ("entity_key_0", 1),
+                ("entity_key_1", 1),
+            ]
+        )
+        self.assertTrue(
+            unique_index[1].get("unique"),
+            f"expected unique=True, got {unique_index[1]!r}",
+        )
+
+    def test_notes_body_text_index(self) -> None:
+        # Free-text search over note bodies relies on a text
+        # index; Mongo allows at most one per collection.
+        # ``MongoDB.searchtext`` (inherited by
+        # :class:`MongoDBNotes`) produces ``$text`` queries
+        # that target this index.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_notes]
+        text_index = next(
+            (keys, opts) for keys, opts in block if keys == [("body", "text")]
+        )
+        self.assertEqual(text_index[1].get("name"), "notes_body_text")
+
+    def test_note_revisions_compound_index(self) -> None:
+        # Pin ``(entity_type ASC, entity_key_0 ASC,
+        # entity_key_1 ASC, revision DESC)`` -- the compound
+        # used by ``list_note_revisions`` for newest-first
+        # ordering with the storage shape matching the unique
+        # compound on the parent collection.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_note_revisions]
+        self.assertTrue(
+            any(
+                keys
+                == [
+                    ("entity_type", 1),
+                    ("entity_key_0", 1),
+                    ("entity_key_1", 1),
+                    ("revision", -1),
+                ]
+                for keys, _opts in block
+            ),
+            block,
+        )
+
+    def test_dbnotes_abstract_surface(self) -> None:
+        # Each method is declared on :class:`DBNotes` and is
+        # overridden by :class:`MongoDBNotes`.  The generic
+        # ``get`` / ``count`` primitives + the convenience
+        # methods make up the full purpose surface.
+        from ivre.db import DBNotes
+        from ivre.db.mongo import MongoDBNotes
+
+        method_names = (
+            "get",
+            "count",
+            "get_note",
+            "set_note",
+            "delete_note",
+            "list_note_revisions",
+            "list_entities",
+            "count_notes",
+        )
+        for name in method_names:
+            with self.subTest(method=name):
+                self.assertIn(
+                    name,
+                    DBNotes.__dict__,
+                    f"DBNotes is missing {name}",
+                )
+                self.assertIn(
+                    name,
+                    MongoDBNotes.__dict__,
+                    f"MongoDBNotes is missing {name}",
+                )
+
+    def test_dbnotes_methods_raise_on_base(self) -> None:
+        # Driving the base-class methods directly (bypassing the
+        # concrete override) surfaces ``NotImplementedError``,
+        # so a backend that forgets to implement one fails
+        # loudly instead of silently no-op'ing.
+        from ivre.db import DBNotes
+
+        notes = DBNotes()
+        with self.assertRaises(NotImplementedError):
+            notes.get_note("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.set_note("host", "192.0.2.1", "body", "alice@example.org")
+        with self.assertRaises(NotImplementedError):
+            notes.delete_note("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.list_note_revisions("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.list_entities()
+        with self.assertRaises(NotImplementedError):
+            notes.count_notes()
+        with self.assertRaises(NotImplementedError):
+            notes.get({})
+        with self.assertRaises(NotImplementedError):
+            notes.count({})
+
+    def test_canonicalize_host_key_matches_ip2internal(self) -> None:
+        # Notes for the ``host`` entity type are keyed by the
+        # same int128 split MongoDBView uses for its ``addr_0``
+        # / ``addr_1`` fields, so the two collections align
+        # byte-for-byte (enables future ``$lookup`` joins +
+        # correct IP-range queries).
+        from ivre.db import canonicalize_entity_key
+        from ivre.db.mongo import MongoDB
+
+        for addr in ["192.0.2.1", "10.0.0.1", "2001:db8::1", "::1"]:
+            with self.subTest(addr=addr):
+                self.assertEqual(
+                    canonicalize_entity_key("host", addr),
+                    MongoDB.ip2internal(addr),
+                )
+
+    def test_canonicalize_entity_key_unknown_type_raises(self) -> None:
+        from ivre.db import canonicalize_entity_key
+
+        with self.assertRaises(ValueError) as ctx:
+            canonicalize_entity_key("garbage", "anything")
+        # The error names the unknown type and lists what is
+        # registered, so operators adding a new type via a plugin
+        # see exactly which side to fix.
+        self.assertIn("garbage", str(ctx.exception))
+        self.assertIn("host", str(ctx.exception))
+
+    def test_validate_note_body_size_accepts_within_cap(self) -> None:
+        from ivre.db import DBNotes
+
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None  # default config has it set
+        # ASCII body so byte-length equals str-length.
+        DBNotes._validate_note_body_size("x" * cap)
+
+    def test_validate_note_body_size_rejects_over_cap(self) -> None:
+        from ivre.db import DBNotes
+
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None
+        with self.assertRaises(ValueError) as ctx:
+            DBNotes._validate_note_body_size("x" * (cap + 1))
+        self.assertIn("exceeds cap", str(ctx.exception))
+
+    def test_validate_note_body_size_disabled_when_cap_is_none(self) -> None:
+        from ivre.db import DBNotes
+
+        # An operator may disable the cap explicitly; arbitrarily
+        # large bodies are then accepted by the storage
+        # validator (Mongo's 16 MiB BSON limit still applies at
+        # insert time).
+        with mock.patch.object(ivre.config, "WEB_HOST_NOTES_MAX_BYTES", None):
+            DBNotes._validate_note_body_size("x" * 5_000_000)
+
+    def test_metadb_has_notes_property(self) -> None:
+        # ``db.notes`` resolves to a ``DBNotes`` instance when
+        # ``DB_NOTES`` / ``DB`` is configured to a backend that
+        # implements the purpose.  We patch ``DB_NOTES`` to a
+        # synthetic mongodb URL so the property doesn't try to
+        # talk to a real backend.
+        from ivre.db import DBNotes, MetaDB
+
+        # Build a fresh MetaDB so we don't poison the module-level
+        # ``db`` singleton's cached ``_notes`` attribute.
+        m = MetaDB(
+            url="mongodb:///x",
+            urls={"notes": "mongodb:///x"},
+        )
+        notes = m.notes
+        # The class lookup succeeded -- ``MongoDBNotes`` is the
+        # registered backend for ``"mongodb"``.  We can't talk to
+        # the real server in this test, but the class wiring is
+        # what we care about here.
+        self.assertIsNotNone(notes)
+        self.assertIsInstance(notes, DBNotes)
+
+
 def _parse_args() -> None:
     """Parse the optional ``--samples`` and ``--coverage`` flags when
     this module is invoked as a script. Mirrors ``tests/tests.py``."""


### PR DESCRIPTION
Introduces a new ``notes`` purpose -- per-entity markdown annotations stored in IVRE's own DB, keyed by an
``(entity_type, entity_key)`` pair -- as the storage layer underneath the eventual Dokuwiki replacement.  Independent of every data purpose: ``view --init``, ``nmap --init``, ``passive --init`` never touch notes; operators wipe annotations explicitly via ``ivre notes --init`` (CLI lands in a follow-up PR).

The entity-typed model lets the same surface annotate hosts today and domains / ASNs / CVE IDs / cert
fingerprints / classifier labels tomorrow -- additive PRs register new entity-type canonicalisers; no
storage-shape changes needed.

V1 ships the ``host`` entity type only.  ``entity_key`` for hosts is stored as the same ``[addr_0, addr_1]`` int128 split :class:`MongoDB.ip2internal` produces for the ``view`` collection's ``addr`` field, so notes and view records align byte-for-byte (enables future ``$lookup`` joins and correct IP-range queries; lexicographic string sort would give the wrong order across IPv4 / IPv6).

Storage layer (MongoDB):

* ``notes``: one record per ``(entity_type, entity_key)``. Unique compound index on the pair; secondary indexes on ``(entity_type, updated_at DESC)`` and ``updated_by`` support admin "recently edited" listings and per-user filters.
* ``note_revisions``: append-only audit log.  Compound ``(entity_type, entity_key, revision DESC)`` supports newest-first history retrieval.  No TTL: the choice is full audit history.

``DBNotes`` abstract surface in :mod:`ivre.db` ships six methods + one static helper:

* ``get_note(entity_type, entity_key)`` -- read current note.
* ``set_note(entity_type, entity_key, body, user_email, *, expected_revision=None)`` -- upsert.  Three modes via the keyword-only ``expected_revision``: ``None`` = last-write-wins; ``0`` = create-only (raises ``ValueError`` if a record already exists); ``>= 1`` = update only when the stored revision matches (raises ``ValueError`` on drift, surfacing concurrent edits to the SPA save button).
* ``delete_note(entity_type, entity_key)`` -- hard delete; sweeps the audit log too.
* ``list_note_revisions(entity_type, entity_key)`` -- newest-first revision history.
* ``list_entities(entity_type=None)`` -- entities that carry a note, optionally narrowed by type.  Used by the search-bar ``notes:`` filter (PR E) to build a ``searchhosts`` narrow without an extra round-trip per entity.
* ``count_notes(entity_type=None)`` -- admin / statistics surface.
* ``_validate_note_body_size(body)`` -- static helper; raises ``ValueError`` when ``body`` exceeds ``config.WEB_HOST_NOTES_MAX_BYTES`` (default 1 MB; ``None`` disables).  Called by every backend's ``set_note`` before any DB write as defence-in-depth alongside the HTTP-413 the web routes (PR B) will add.

Entity-key canonicalisation is centralised in a small registry of helper functions: ``_ENTITY_CANONICALIZERS`` maps an ``entity_type`` string to a normaliser.  V1 registers ``"host"`` only.  The host normaliser reproduces the :meth:`MongoDB.ip2internal` int128 split as pure-Python to keep the canonicalisation module independent of the Mongo backend's import graph.  ``canonicalize_entity_key`` is the public entry point; raises ``ValueError`` on unknown types so a backend / web route / MCP tool that received a garbled type surfaces the error cleanly.

``MongoDBNotes(MongoDB, DBNotes)`` implements all six methods plus a ``_present_entity_key`` helper that converts the canonical on-disk form back to the
caller-facing shape on the way out (printable IP string for ``host``).  The ``set_note`` body is the longest at ~70 LoC and has three code paths for the three
concurrency modes; the upsert + revision-insert is a two-op sequence (parent authoritative, audit log
best-effort).

``MetaDB`` gains a ``notes`` property that lazy-loads the purpose from ``config.DB_NOTES`` (falling back to
``config.DB`` when unset so operators get a working ``db.notes`` out of the box).  Other backends (Postgres, DuckDB, Elastic, DocumentDB, HTTP) inherit
``NotImplementedError`` from the base for v1 -- matches the M4 ethos of landing new features on Mongo first.

Tests: 11 new in ``MongoDBNotesIndexTests``, backend-free. Pin the column constants + indexes-list length, the unique compound index on ``(entity_type, entity_key)``, the compound on ``(entity_type, entity_key, revision DESC)``, the abstract surface on both ``DBNotes`` and ``MongoDBNotes``, the base-class ``NotImplementedError`` raises, the host canonicaliser's parity with
``MongoDB.ip2internal``, the unknown-type rejection, the body-size validator (within cap / over cap / cap
disabled), and the ``MetaDB.notes`` property wiring.

The actual create / read / update / list-revisions / delete round-trip against a real MongoDB lands in
``tests/tests.py`` in PR B (alongside the
``/cgi/notes/<type>/<key>`` web routes that drive the surface end-to-end).