### PR TITLE
feat(db): DBNotes purpose for entity-keyed markdown annotations (Mongo)

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -37,6 +37,11 @@ DEBUG = False
 DEBUG_DB = False
 DB = "mongodb:///ivre"
 DB_DATA = None  # specific: maxmind:///<ivre_share_path>/geoip
+# DB URL for the ``notes`` purpose (per-entity markdown
+# annotations).  Falls back to ``DB`` when unset.  The ``notes``
+# purpose is independent of every data purpose: ``view --init``,
+# ``nmap --init`` etc. do not touch notes.
+DB_NOTES = None
 # Begin batch sizes
 LOCAL_BATCH_SIZE = 10000  # used with --local-bulk
 MONGODB_BATCH_SIZE = 100
@@ -301,6 +306,14 @@ WEB_UPLOAD_OK = False
 # bounded by the underlying ``IPRanges`` shape and are not
 # capped. Set to ``None`` to disable the cap.
 WEB_IPRANGE_ADDR_CAP: int | None = 100_000
+# Maximum size, in bytes, accepted for a single note body
+# (per-entity markdown annotation stored in the ``notes``
+# purpose).  The storage layer enforces this via
+# :meth:`DBNotes._validate_note_body_size` as defence-in-depth;
+# web routes return HTTP 413 for over-cap requests before they
+# reach the DB.  Set to ``None`` to disable the cap (Mongo's
+# BSON 16 MiB document limit still applies).
+WEB_HOST_NOTES_MAX_BYTES: int | None = 1_000_000
 # Feed with a random value, like `openssl rand -base64 42`.
 # *Mandatory* when WEB_AUTH_ENABLED == True
 WEB_SECRET = None
@@ -490,6 +503,13 @@ if RIR_PATH is None:
 
 if DB_DATA is None and GEOIP_PATH is not None:
     DB_DATA = f"maxmind:///{GEOIP_PATH}"
+
+
+# Per-entity notes default to the same store as everything else
+# (operators get a working ``db.notes`` out of the box).  Override
+# DB_NOTES explicitly to move notes to a separate store.
+if DB_NOTES is None:
+    DB_NOTES = DB
 
 
 if DATA_PATH is None:

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -35,6 +35,7 @@ import sys
 import time
 from argparse import ArgumentParser
 from collections import OrderedDict
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
 from functools import reduce
 from importlib import import_module
@@ -5822,6 +5823,323 @@ class DBFlow(DB):
         raise NotImplementedError
 
 
+# ---------------------------------------------------------------------
+# Per-entity notes (per-host, eventually per-domain / per-ASN / ...).
+# Independent purpose so the storage lifecycle is decoupled from any
+# data purpose: ``view --init``, ``nmap --init``, ``passive --init``
+# never touch notes.  Operators wipe annotations explicitly via the
+# new (to-be-added) ``ivre notes --init`` CLI.
+#
+# Entities are referenced by an opaque ``(entity_type, entity_key)``
+# pair.  ``entity_type`` is a short string drawn from a closed
+# vocabulary (``"host"`` only at v1; ``"domain"`` / ``"asn"`` /
+# ``"cve"`` / ... slot in as additive PRs).  ``entity_key`` is the
+# canonical form for that type -- e.g. for ``"host"`` it is the
+# ``[addr_0, addr_1]`` int128 split that :class:`MongoDB` already
+# uses for the ``view`` collection's ``addr`` field, so the two
+# stores align byte-for-byte and a future ``$lookup`` join works
+# without per-side conversion.
+# ---------------------------------------------------------------------
+
+
+def _canonicalize_host_key(key: Any) -> list[int]:
+    """Canonical entity_key for the ``host`` entity type.
+
+    Accepts a printable IP string (``"192.0.2.1"`` /
+    ``"2001:db8::1"``) or an already-canonical
+    ``[addr_0, addr_1]`` int pair.  Returns the int128 split
+    form :class:`MongoDB` uses for its ``addr_0`` / ``addr_1``
+    fields, so a note keyed by host aligns byte-for-byte with
+    the matching ``view`` record (enables future ``$lookup``
+    joins and correct IP-range queries).
+
+    The split logic is reproduced here (rather than delegating
+    to :meth:`MongoDB.ip2internal`) so the canonicalisation
+    registry does not pull the Mongo backend into the import
+    graph from the base :mod:`ivre.db` module.
+
+    Validates shape and ranges up-front so malformed keys are
+    rejected on the write path with a clear ``ValueError``,
+    rather than crashing later on read inside
+    :meth:`MongoDB.internal2ip` (which would surface as a
+    ``TypeError`` for ``None`` / ``str`` halves or as an
+    ``OverflowError`` for out-of-range halves -- both
+    far-from-the-bug error sites).  The host canonical form is
+    always two int64-range integers; future single-scalar
+    entity types own their own validation in their own
+    canonicalisers.
+    """
+    if isinstance(key, list):
+        if len(key) != 2:
+            raise ValueError(
+                f"host entity_key list must have exactly 2 "
+                f"elements (addr_0, addr_1), got {len(key)}"
+            )
+        for idx, val in enumerate(key):
+            if not isinstance(val, int) or isinstance(val, bool):
+                raise ValueError(
+                    f"host entity_key element {idx} must be int, "
+                    f"got {type(val).__name__}: {val!r}"
+                )
+            if not -(1 << 63) <= val < (1 << 63):
+                raise ValueError(
+                    f"host entity_key element {idx} out of signed "
+                    f"int64 range: {val!r}"
+                )
+        return key
+    if not isinstance(key, str):
+        raise ValueError(
+            f"host entity_key must be a printable IP string or a "
+            f"2-element [addr_0, addr_1] int list, got "
+            f"{type(key).__name__}: {key!r}"
+        )
+    return [val - 0x8000000000000000 for val in struct.unpack("!QQ", utils.ip2bin(key))]
+
+
+# Registry of canonicalisation helpers keyed by entity_type.
+# Adding a new entity type means:
+#   1. registering its helper here,
+#   2. extending the storage layer's BSON-shape handling if the
+#      canonical form is something other than ``str`` / ``list``,
+#   3. wiring the matching MCP tool + web route in PR B.
+_ENTITY_CANONICALIZERS: dict[str, Callable[[Any], Any]] = {
+    "host": _canonicalize_host_key,
+}
+
+
+def canonicalize_entity_key(entity_type: str, key: Any) -> Any:
+    """Return the canonical form for ``key`` under
+    ``entity_type``.  Raises :class:`ValueError` on an unknown
+    ``entity_type`` so a backend, a web route or an MCP tool
+    that received a garbled type surfaces the error cleanly
+    instead of silently storing nonsense.
+    """
+    try:
+        canonicalizer = _ENTITY_CANONICALIZERS[entity_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown entity_type {entity_type!r}; expected one of "
+            f"{sorted(_ENTITY_CANONICALIZERS)}"
+        ) from exc
+    return canonicalizer(key)
+
+
+class NoteNotFound(ValueError):
+    """Raised by :meth:`DBNotes.set_note` (with
+    ``expected_revision >= 1``) when no note exists for the
+    ``(entity_type, entity_key)`` target.  The caller's edit
+    target was deleted between load and save, or was never
+    created.  Web routes should map to HTTP 404.
+
+    Inherits from :class:`ValueError` so callers that catch the
+    coarser type keep working; PR-B web routes catch the
+    specific class to dispatch the right status code.
+    """
+
+
+class NoteConcurrencyError(ValueError):
+    """Raised by :meth:`DBNotes.set_note` (with
+    ``expected_revision >= 1``) when a note exists for the
+    ``(entity_type, entity_key)`` target but its stored
+    revision does not match the caller-provided
+    ``expected_revision``.  Another caller modified the note
+    between load and save.  Web routes should map to HTTP 409
+    (with ``If-Match``-style semantics).
+
+    Inherits from :class:`ValueError` so callers that catch the
+    coarser type keep working.
+    """
+
+
+class NoteAlreadyExists(ValueError):
+    """Raised by :meth:`DBNotes.set_note` (with
+    ``expected_revision=0``, the create-only mode) when a note
+    already exists for the ``(entity_type, entity_key)``
+    target.  Web routes should map to HTTP 409 (or 412
+    Precondition Failed).
+
+    Inherits from :class:`ValueError` so callers that catch the
+    coarser type keep working.
+    """
+
+
+class DBNotes(DB):
+    """Per-entity markdown annotations (notes).
+
+    Replaces the legacy Dokuwiki / MediaWiki integrations whose
+    only IVRE-side knowledge was a filesystem scan for
+    ``<IP>.txt`` files.  Notes are stored in IVRE's own DB,
+    keyed by ``(entity_type, entity_key)``, with an append-only
+    revision history.
+
+    Lifecycle independence is the whole point of carving this
+    out as its own purpose: ``view --init``, ``nmap --init``,
+    ``passive --init`` never touch notes.  Operators wipe
+    annotations explicitly via ``ivre notes --init`` (CLI
+    subcommand wired in a follow-up PR).
+
+    Two ``entity_key`` forms appear in this API.  Methods that
+    take an ``entity_key`` argument and methods that surface an
+    ``entity_key`` value in their return dict always speak the
+    **caller-facing** form -- for ``host`` that is the
+    printable IP string (``"192.0.2.1"`` /
+    ``"2001:db8::1"``).  The **canonical** form (produced by
+    :func:`canonicalize_entity_key` -- e.g.  the
+    ``[addr_0, addr_1]`` int128 split for ``host``) is the
+    on-disk representation that backends store and index
+    against, and only escapes the storage layer through the
+    low-level :meth:`get` / :meth:`count` primitives whose
+    documents carry the backend-specific storage fields
+    verbatim.  Convenience methods (:meth:`get_note` /
+    :meth:`set_note` / :meth:`delete_note` /
+    :meth:`list_note_revisions` / :meth:`list_entities`)
+    convert in both directions so callers never need to deal
+    with the canonical form.
+    """
+
+    backends = {
+        "mongodb": ("mongo", "MongoDBNotes"),
+        # Other backends inherit ``NotImplementedError`` from
+        # this base for v1.  Filled in alongside their
+        # respective M4 follow-ups.
+    }
+
+    @staticmethod
+    def _validate_note_body_size(body: str) -> None:
+        """Raise :class:`ValueError` if ``body`` exceeds
+        :data:`config.WEB_HOST_NOTES_MAX_BYTES` (when the knob
+        is not ``None``).
+
+        Called by every backend's :meth:`set_note`
+        implementation before any DB write -- defence-in-depth
+        alongside the HTTP-413 the ``/cgi/notes/...`` routes
+        return in PR B.
+        """
+        cap = config.WEB_HOST_NOTES_MAX_BYTES
+        if cap is None:
+            return
+        byte_len = len(body.encode("utf-8"))
+        if byte_len > cap:
+            raise ValueError(f"note body is {byte_len} bytes, exceeds cap {cap}")
+
+    def get_note(self, entity_type: str, entity_key: Any) -> dict | None:
+        """Return the current note for ``(entity_type, entity_key)``,
+        or ``None`` when no annotation has been written yet.
+
+        The returned dict carries ``entity_type`` /
+        ``entity_key`` / ``body`` / ``created_at`` /
+        ``created_by`` / ``updated_at`` / ``updated_by`` /
+        ``revision``.  The ``entity_key`` value is in the
+        caller-facing form (e.g. printable IP string for
+        ``host``); backends round-trip from the canonical
+        on-disk form (e.g. ``[addr_0, addr_1]`` int128 split
+        for ``host``) back to the caller-facing form on the way
+        out.  Callers that need the storage-layer fields
+        verbatim go through :meth:`get` instead.
+        """
+        raise NotImplementedError
+
+    def set_note(
+        self,
+        entity_type: str,
+        entity_key: Any,
+        body: str,
+        user_email: str,
+        *,
+        expected_revision: int | None = None,
+    ) -> dict:
+        """Upsert the note for ``(entity_type, entity_key)``.
+
+        Stamps ``updated_by`` / ``updated_at`` and bumps the
+        monotonic ``revision`` counter.  On first creation
+        also stamps ``created_by`` / ``created_at``.  Appends
+        an immutable row to the revisions collection (audit
+        trail).
+
+        Concurrency control via ``expected_revision``:
+
+        * ``None`` (default): last-write-wins; upsert proceeds
+          regardless of the current revision.
+        * ``0``: create-only; raises
+          :class:`NoteAlreadyExists` if a note already exists.
+        * ``>= 1``: update only when the stored revision
+          matches.  Raises :class:`NoteNotFound` when no note
+          exists for the target (deleted between load and
+          save -- web layer maps to HTTP 404); raises
+          :class:`NoteConcurrencyError` when a note exists but
+          its stored revision drifted from
+          ``expected_revision`` (concurrent edit -- web layer
+          maps to HTTP 409).  Both subclass :class:`ValueError`
+          for callers that prefer the coarser exception.
+
+        Body-size cap: :data:`config.WEB_HOST_NOTES_MAX_BYTES`
+        bounds the accepted body length.  Over-cap writes
+        raise :class:`ValueError`.
+
+        Returns the persisted note as a dict with the same
+        shape :meth:`get_note` produces (``entity_key`` in
+        caller-facing form).
+        """
+        raise NotImplementedError
+
+    def delete_note(self, entity_type: str, entity_key: Any) -> bool:
+        """Remove the note for ``(entity_type, entity_key)``
+        and every revision in its audit log.  Returns ``True``
+        when a record existed and was removed.
+        """
+        raise NotImplementedError
+
+    def list_note_revisions(self, entity_type: str, entity_key: Any) -> list[dict]:
+        """Return every revision recorded for the entity,
+        newest-first.  Each entry carries ``revision`` /
+        ``body`` / ``created_at`` / ``created_by``.
+        """
+        raise NotImplementedError
+
+    def list_entities(self, entity_type: str | None = None) -> list[dict]:
+        """Return the entities that currently have a note,
+        optionally narrowed by ``entity_type``.
+
+        Each entry carries ``entity_type`` / ``entity_key``
+        (in the caller-facing form -- e.g. printable IP string
+        for ``host``) / ``updated_at`` / ``updated_by`` /
+        ``revision`` so the search-bar ``notes:`` filter can
+        build a host narrow without an extra round-trip per
+        entity.  ``body`` is omitted from the listing
+        projection to keep the payload small; callers that
+        need bodies fetch them via :meth:`get_note`.
+        """
+        raise NotImplementedError
+
+    def count_notes(self, entity_type: str | None = None) -> int:
+        """Number of entities with a note, optionally narrowed
+        by ``entity_type``.  Admin / statistics surface.
+        """
+        raise NotImplementedError
+
+    def get(self, spec: Any, **kargs: Any) -> Iterable[dict]:
+        """Iterate note documents matching the backend-native
+        filter ``spec``.
+
+        Filters are composed via :meth:`searchtext` (free-text
+        search over note bodies, inherited from the backend's
+        base class -- e.g. :meth:`MongoDB.searchtext`) and the
+        standard backend combinators (:meth:`flt_and` /
+        :meth:`flt_or` / direct filter literals).  Returned
+        documents carry the storage-layer ``entity_key_*``
+        fields verbatim; callers that need the caller-facing
+        ``entity_key`` form go through :meth:`get_note` /
+        :meth:`list_entities` instead.
+        """
+        raise NotImplementedError
+
+    def count(self, spec: Any) -> int:
+        """Number of note documents matching ``spec``.  Same
+        filter shape as :meth:`get`.
+        """
+        raise NotImplementedError
+
+
 class DBAuth(DB):
     """Backend-independent code to handle authentication"""
 
@@ -6077,6 +6395,7 @@ class MetaDB:
         "rir": DBRir,
         "flow": DBFlow,
         "auth": DBAuth,
+        "notes": DBNotes,
     }
 
     def __init__(self, url=None, urls=None):
@@ -6084,7 +6403,7 @@ class MetaDB:
         self.urls = urls or {}
 
     def close(self):
-        for attr in ["nmap", "passive", "data", "flow", "view"]:
+        for attr in ["nmap", "passive", "data", "flow", "view", "notes"]:
             try:
                 getattr(self, f"_{attr}").close()
             except AttributeError:
@@ -6167,6 +6486,16 @@ class MetaDB:
             )
         self._auth = self.get_class("auth")
         return self._auth
+
+    @property
+    def notes(self):
+        try:
+            # pylint: disable=access-member-before-definition
+            return self._notes
+        except AttributeError:
+            pass
+        self._notes = self.get_class("notes")
+        return self._notes
 
     def get_class(self, purpose):
         url = self.urls.get(purpose, self.url)

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -38,7 +38,13 @@ from urllib.parse import unquote
 
 import bson
 import pymongo
-from pymongo.errors import BulkWriteError, CursorNotFound
+from pymongo import ReadPreference, ReturnDocument
+from pymongo.errors import (
+    BulkWriteError,
+    CursorNotFound,
+    DuplicateKeyError,
+    PyMongoError,
+)
 
 try:
     import gssapi  # type: ignore
@@ -57,9 +63,14 @@ from ivre.db import (
     DBFlow,
     DBFlowMeta,
     DBNmap,
+    DBNotes,
     DBPassive,
     DBRir,
     DBView,
+    NoteAlreadyExists,
+    NoteConcurrencyError,
+    NoteNotFound,
+    canonicalize_entity_key,
 )
 from ivre.plugins import load_plugins
 from ivre.tags.active import is_synack_honeypot, set_auto_tags
@@ -7879,6 +7890,476 @@ class MongoDBAuth(MongoDB, DBAuth):
             {"$set": {"revoked_at": now}},
         )
         return result.modified_count
+
+
+class MongoDBNotes(MongoDB, DBNotes):
+    """MongoDB backend for the ``notes`` purpose.
+
+    Stores entity-keyed markdown annotations in two collections:
+
+    * ``notes`` -- one record per
+      ``(entity_type, entity_key_0, entity_key_1)`` triple
+      carrying the current body, monotonic ``revision``,
+      authorship and timestamp metadata.  Unique compound
+      index on the triple; secondary indexes on
+      ``(entity_type, updated_at DESC)`` and ``updated_by``;
+      a text index on ``body`` (named ``notes_body_text``)
+      backs free-text search via the inherited
+      :meth:`MongoDB.searchtext`.
+    * ``note_revisions`` -- append-only audit log.  Compound
+      ``(entity_type, entity_key_0, entity_key_1,
+      revision DESC)`` supports newest-first history
+      retrieval at the same key shape as the parent
+      collection.
+
+    The canonical entity_key is *split* across two scalar
+    BSON fields ``entity_key_0`` / ``entity_key_1`` rather
+    than stored as a single ``entity_key`` BSON array.  For
+    the ``host`` type the canonical form is the
+    ``[addr_0, addr_1]`` int128 split
+    :meth:`MongoDB.ip2internal` produces for the ``view``
+    collection's ``addr`` field, so the two collections
+    align byte-for-byte (enables future ``$lookup`` joins
+    and correct IP-range queries).  Storing the canonical
+    list verbatim in a single field would make the unique
+    compound a *multikey* index with element-wise uniqueness
+    semantics -- every IPv4 host's high half is the same
+    bias constant, so the second IPv4 note insert would
+    collide on a per-element basis; see the
+    :attr:`indexes` block for the canonical rationale.
+    Single-scalar entity types (future ``domain`` / ``cve``
+    / ``asn``) store the value in ``entity_key_0`` and
+    ``None`` in ``entity_key_1``.
+
+    Reads reassemble the two storage scalars and strip the
+    canonical form back to the caller-facing shape via
+    :meth:`_present_entity_key` (printable IP string for
+    ``host``; ``entity_key_0`` as-is for single-scalar
+    types).
+    """
+
+    column_notes = 0
+    column_note_revisions = 1
+
+    indexes: list[list[tuple[list[IndexKey], dict[str, Any]]]] = [
+        # notes
+        #
+        # The canonical ``entity_key`` for an entity type may be
+        # a 1-or-2-element list of scalars (e.g. ``[addr_0,
+        # addr_1]`` for the ``host`` type, matching
+        # :meth:`MongoDB.ip2internal`'s int128 split).  Storing
+        # each half in its own scalar BSON field
+        # (``entity_key_0`` / ``entity_key_1``) keeps the unique
+        # compound a plain single-key compound -- a BSON-array
+        # ``entity_key`` would make the compound *multikey*, in
+        # which case Mongo enforces uniqueness element-wise: for
+        # any two IPv4 notes ``addr_0`` is the same (the bias
+        # constant ``-0x8000000000000000``), the second insert
+        # then collides with the first on a per-element basis.
+        # Single-scalar types (``domain``, ``cve``, ...) store
+        # the value in ``entity_key_0`` and ``None`` in
+        # ``entity_key_1``.
+        [
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("entity_key_0", pymongo.ASCENDING),
+                    ("entity_key_1", pymongo.ASCENDING),
+                ],
+                {"unique": True},
+            ),
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("updated_at", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+            ([("updated_by", pymongo.ASCENDING)], {}),
+            # Free-text search over note bodies.  Inherited
+            # :meth:`MongoDB.searchtext` returns
+            # ``{"$text": {"$search": ...}}`` filters that
+            # compose with :meth:`flt_and` and feed
+            # :meth:`get` / :meth:`count` on the storage
+            # layer.  Mongo allows at most one text index
+            # per collection.
+            ([("body", "text")], {"name": "notes_body_text"}),
+        ],
+        # note_revisions
+        [
+            (
+                [
+                    ("entity_type", pymongo.ASCENDING),
+                    ("entity_key_0", pymongo.ASCENDING),
+                    ("entity_key_1", pymongo.ASCENDING),
+                    ("revision", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+        ],
+    ]
+
+    def __init__(self, url):
+        super().__init__(url)
+        self.columns = [
+            self.params.pop("colname_notes", "notes"),
+            self.params.pop("colname_note_revisions", "note_revisions"),
+        ]
+
+    @staticmethod
+    def _entity_key_to_storage(canonical):
+        """Pack the canonical entity_key into the two storage
+        scalars ``(entity_key_0, entity_key_1)``.
+
+        Accepts either a scalar (1-element canonical form -- the
+        future ``domain`` / ``cve`` / ``asn`` types) or a
+        2-element list (the current ``host`` type's int128
+        split).  1-element lists are accepted too for callers
+        that uniformise the canonicalisation contract.
+        """
+        if isinstance(canonical, list):
+            if len(canonical) == 2:
+                return canonical[0], canonical[1]
+            if len(canonical) == 1:
+                return canonical[0], None
+            raise ValueError(
+                f"canonical entity_key list must have 1 or 2 "
+                f"elements, got {len(canonical)}"
+            )
+        return canonical, None
+
+    @classmethod
+    def _entity_key_filter(cls, entity_type, entity_key):
+        """Build a single-record find filter for the
+        ``(entity_type, entity_key_0, entity_key_1)`` compound
+        from a caller-facing ``entity_key``.
+        """
+        key_0, key_1 = cls._entity_key_to_storage(
+            canonicalize_entity_key(entity_type, entity_key)
+        )
+        return {
+            "entity_type": entity_type,
+            "entity_key_0": key_0,
+            "entity_key_1": key_1,
+        }
+
+    @staticmethod
+    def _present_entity_key(entity_type, entity_key_0, entity_key_1):
+        """Reassemble the caller-facing ``entity_key`` from the
+        two storage scalars.  Inverse of
+        :meth:`_entity_key_to_storage` composed with
+        :func:`canonicalize_entity_key`.
+
+        At v1 only the ``host`` type needs back-conversion
+        (printable IP string from the int128 split); future
+        single-scalar types round-trip the value in
+        ``entity_key_0`` as-is and ignore ``entity_key_1``.
+        """
+        if entity_type == "host":
+            return MongoDB.internal2ip([entity_key_0, entity_key_1])
+        return entity_key_0
+
+    def _present_note(self, doc):
+        """Common projection helper: drop ``_id`` and the two
+        storage scalars, replacing them with a single
+        caller-facing ``entity_key`` field.
+        """
+        doc.pop("_id", None)
+        doc["entity_key"] = self._present_entity_key(
+            doc["entity_type"],
+            doc.pop("entity_key_0"),
+            doc.pop("entity_key_1"),
+        )
+        return doc
+
+    def get(self, spec, **kargs):
+        """Iterate raw note documents matching ``spec``.
+
+        ``spec`` is composed via :meth:`searchtext` (inherited
+        from :class:`MongoDB`) and the standard combinators
+        (:meth:`flt_and` / :meth:`flt_or` / direct dict
+        literals).  Returned documents carry the storage-layer
+        ``entity_key_0`` / ``entity_key_1`` fields verbatim --
+        free-text search routes and listing pages that want
+        the caller-facing ``entity_key`` form post-process
+        with :meth:`_present_note` / :meth:`_present_entity_key`.
+
+        Routes through :meth:`MongoDB._get_cursor` for parity
+        with :meth:`MongoDBView.get` / :meth:`MongoDBPassive.get`
+        / :meth:`MongoDBRir.get`.  That gives notes queries:
+
+        * Query-timeout enforcement via :meth:`set_limits`
+          (``cursor.max_time_ms(self.maxtime)`` based on the
+          ``MONGODB_QUERY_TIMEOUT_MS`` config knob or the
+          per-URL ``?maxtime=`` parameter).  Free-text search
+          over a large notes collection under adversarial
+          input would otherwise be unbounded.
+        * The ``sort=[("text", direction)]`` shortcut: when
+          a caller asks for relevance-ranked text search,
+          :meth:`_get_cursor` auto-adds
+          ``projection["score"] = {"$meta": "textScore"}``
+          and replaces the sort with the matching
+          ``$meta``-driven order, so web routes can ask for
+          "best matches first" in one line instead of
+          hand-rolling the projection.
+        * Legacy ``fields=`` kwarg compat (converted to
+          ``projection=`` before forwarding to
+          :meth:`pymongo.collection.Collection.find`).
+
+        Other :class:`DBNotes` backends translate or ignore
+        these conveniences per their own storage primitives,
+        so backend-portable code sticks to ``spec`` only.
+        """
+        return self._get_cursor(self.columns[self.column_notes], spec, **kargs)
+
+    def count(self, spec):
+        # Empty-filter shortcut mirrors :meth:`MongoDBView.count`:
+        # ``estimated_document_count`` reads collection metadata
+        # in O(1) instead of scanning, which matters for
+        # ``count_notes(entity_type=None)`` on a heavily-used
+        # notes collection.
+        col = self.db[self.columns[self.column_notes]]
+        if not spec:
+            return col.estimated_document_count()
+        return col.count_documents(spec)
+
+    def get_note(self, entity_type, entity_key):
+        doc = self.db[self.columns[self.column_notes]].find_one(
+            self._entity_key_filter(entity_type, entity_key)
+        )
+        if doc is None:
+            return None
+        return self._present_note(doc)
+
+    def set_note(
+        self,
+        entity_type,
+        entity_key,
+        body,
+        user_email,
+        *,
+        expected_revision=None,
+    ):
+        # Storage-layer body-size check; the web routes (PR B)
+        # add an HTTP 413 in front for the friendlier client
+        # error.
+        self._validate_note_body_size(body)
+        key_0, key_1 = self._entity_key_to_storage(
+            canonicalize_entity_key(entity_type, entity_key)
+        )
+        key_filter = {
+            "entity_type": entity_type,
+            "entity_key_0": key_0,
+            "entity_key_1": key_1,
+        }
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        notes_col = self.db[self.columns[self.column_notes]]
+        revisions_col = self.db[self.columns[self.column_note_revisions]]
+        if expected_revision is None:
+            # Race-tolerant upsert: bump revision atomically.
+            doc = notes_col.find_one_and_update(
+                key_filter,
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                    "$setOnInsert": {
+                        "entity_type": entity_type,
+                        "entity_key_0": key_0,
+                        "entity_key_1": key_1,
+                        "created_at": now,
+                        "created_by": user_email,
+                    },
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        elif expected_revision >= 1:
+            # Concurrency-checked update: only proceeds when
+            # the stored revision matches.  ``None`` return
+            # means the filter did not find a matching record;
+            # that conflates two failure modes -- the note
+            # does not exist, or it exists at a different
+            # revision.  A second ``find_one`` on the bare
+            # entity-key filter distinguishes them so the web
+            # layer can map to HTTP 404 vs 409 without sniffing
+            # error strings.  The race window between the two
+            # ops is tiny; a concurrent create / delete in that
+            # window at worst surfaces a slightly misleading
+            # exception class, not corruption.
+            doc = notes_col.find_one_and_update(
+                {**key_filter, "revision": expected_revision},
+                {
+                    "$set": {
+                        "body": body,
+                        "updated_at": now,
+                        "updated_by": user_email,
+                    },
+                    "$inc": {"revision": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            if doc is None:
+                # The existence check must see authoritative
+                # state; ``find_one_and_update`` is a write
+                # that always hits primary, but a follow-up
+                # read on a client configured with a
+                # non-PRIMARY ``read_preference`` could be
+                # served from a stale secondary and
+                # misclassify a concurrency drift as
+                # :class:`NoteNotFound` (or report a stale
+                # ``stored revision``).  Pin the read to
+                # PRIMARY explicitly so the error class and
+                # message reflect the primary's view.  Other
+                # read-only methods on this backend still
+                # honour the client-level preference -- only
+                # this read-after-write needs the override.
+                existing = notes_col.with_options(
+                    read_preference=ReadPreference.PRIMARY
+                ).find_one(key_filter, projection={"revision": 1, "_id": 0})
+                if existing is None:
+                    raise NoteNotFound(
+                        f"no note exists for {entity_type}/" f"{entity_key!r}"
+                    )
+                raise NoteConcurrencyError(
+                    f"stored revision {existing['revision']} does "
+                    f"not match expected={expected_revision} for "
+                    f"{entity_type}/{entity_key!r}"
+                )
+        else:
+            # ``expected_revision <= 0``: insert-only path,
+            # creating the note iff no record exists.  Negative
+            # values are coalesced into this branch -- the
+            # caller's intent is "no prior history" either way.
+            #
+            # The persisted document is constructed locally
+            # rather than read back via ``find_one`` after the
+            # insert: we know exactly what we just wrote
+            # (``revision=1``, the caller-supplied body /
+            # authorship / timestamps), so a follow-up read is
+            # both unnecessary (one extra round-trip per
+            # create) and unsafe under a non-PRIMARY
+            # ``read_preference`` -- a stale secondary that
+            # has not yet replicated the insert would return
+            # ``None`` and the audit-log step downstream would
+            # crash on ``doc["revision"]``.  Pymongo also
+            # mutates ``doc`` in-place to add the generated
+            # ``_id`` after a successful ``insert_one``, so
+            # ``_present_note``'s ``doc.pop("_id", None)``
+            # later still produces the correct caller-facing
+            # shape.
+            doc = {
+                "entity_type": entity_type,
+                "entity_key_0": key_0,
+                "entity_key_1": key_1,
+                "body": body,
+                "created_at": now,
+                "created_by": user_email,
+                "updated_at": now,
+                "updated_by": user_email,
+                "revision": 1,
+            }
+            try:
+                notes_col.insert_one(doc)
+            except DuplicateKeyError as exc:
+                raise NoteAlreadyExists(
+                    f"note already exists for {entity_type}/"
+                    f"{entity_key!r}; expected_revision=0 cannot "
+                    f"insert"
+                ) from exc
+        # Append the immutable revision row.  The parent commit
+        # above is authoritative; the audit row is best-effort.
+        # Catching :class:`PyMongoError` here keeps the
+        # user-facing write successful when the audit insert
+        # fails on a transient backend issue (network blip,
+        # secondary unreachable under ``w=majority``,
+        # over-BSON-size metadata, ...).  Letting the exception
+        # propagate would poison the next caller operation:
+        # under ``expected_revision=None`` the LWW retry bumps
+        # the revision counter again (audit gap + same body at
+        # rev N and N+2); under ``expected_revision>=1`` the
+        # retry raises a false "concurrent edit" because the
+        # parent already moved.  Operators see the failure via
+        # :data:`utils.LOGGER` and can audit-replay manually if
+        # needed.
+        try:
+            revisions_col.insert_one(
+                {
+                    "entity_type": entity_type,
+                    "entity_key_0": key_0,
+                    "entity_key_1": key_1,
+                    "revision": doc["revision"],
+                    "body": body,
+                    "created_at": now,
+                    "created_by": user_email,
+                }
+            )
+        except PyMongoError as exc:
+            utils.LOGGER.warning(
+                "audit log insert failed for note %s/%r revision %d: %s",
+                entity_type,
+                entity_key,
+                doc["revision"],
+                exc,
+            )
+        return self._present_note(doc)
+
+    def delete_note(self, entity_type, entity_key):
+        key_filter = self._entity_key_filter(entity_type, entity_key)
+        result = self.db[self.columns[self.column_notes]].delete_one(key_filter)
+        # Always sweep the audit log: orphan revisions without
+        # a parent are meaningless and would inflate
+        # ``count_documents`` queries.
+        self.db[self.columns[self.column_note_revisions]].delete_many(key_filter)
+        return result.deleted_count > 0
+
+    def list_note_revisions(self, entity_type, entity_key):
+        cursor = (
+            self.db[self.columns[self.column_note_revisions]]
+            .find(self._entity_key_filter(entity_type, entity_key))
+            .sort([("revision", pymongo.DESCENDING)])
+        )
+        revisions = []
+        for doc in cursor:
+            doc.pop("_id", None)
+            # Strip the redundant ``entity_*`` keys: callers
+            # passed them in and already know.  Keep ``revision``
+            # / ``body`` / ``created_at`` / ``created_by``.
+            doc.pop("entity_type", None)
+            doc.pop("entity_key_0", None)
+            doc.pop("entity_key_1", None)
+            revisions.append(doc)
+        return revisions
+
+    def list_entities(self, entity_type=None):
+        flt = {} if entity_type is None else {"entity_type": entity_type}
+        cursor = self.db[self.columns[self.column_notes]].find(
+            flt,
+            projection={
+                "_id": 0,
+                "entity_type": 1,
+                "entity_key_0": 1,
+                "entity_key_1": 1,
+                "updated_at": 1,
+                "updated_by": 1,
+                "revision": 1,
+            },
+        )
+        entries = []
+        for doc in cursor:
+            doc["entity_key"] = self._present_entity_key(
+                doc["entity_type"],
+                doc.pop("entity_key_0"),
+                doc.pop("entity_key_1"),
+            )
+            entries.append(doc)
+        return entries
+
+    def count_notes(self, entity_type=None):
+        return self.count({} if entity_type is None else {"entity_type": entity_type})
 
 
 load_plugins("ivre.plugins.db.mongo", globals())

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -14847,6 +14847,688 @@ class IPRangeTests(unittest.TestCase):
         self.assertTrue(status.startswith("400"), status)
 
 
+# ---------------------------------------------------------------------
+# MongoDBNotesIndexTests -- pin the structural definitions
+# (collections, indexes, abstract surface, canonicalisation
+# registry, body-size validator) the per-entity notes purpose
+# ships with.  The actual create / read / update / list-revisions
+# / delete round-trip is exercised in ``tests/tests.py`` on the
+# ``mongodb.yml`` CI lane where a real MongoDB instance is
+# available; these no-backend tests bound the wire shape so
+# regressions surface immediately.
+# ---------------------------------------------------------------------
+
+
+class MongoDBNotesIndexTests(unittest.TestCase):
+    """Backend-free pin tests for the per-entity notes storage
+    layer (``notes`` + ``note_revisions`` collections + the
+    ``DBNotes`` abstract surface + entity-key canonicalisation
+    registry).
+    """
+
+    def test_notes_columns_registered(self) -> None:
+        from ivre.db.mongo import MongoDBNotes
+
+        # Two columns at indexes 0 and 1 -- ``notes`` + audit log.
+        self.assertEqual(MongoDBNotes.column_notes, 0)
+        self.assertEqual(MongoDBNotes.column_note_revisions, 1)
+        # ``indexes`` mirrors ``columns`` in length so every
+        # collection has its index block.
+        self.assertEqual(len(MongoDBNotes.indexes), 2)
+
+    def test_notes_compound_unique_index(self) -> None:
+        # Pin ``(entity_type, entity_key_0, entity_key_1)`` as
+        # the unique compound.  Storing the canonical key as
+        # two scalar fields keeps the index a plain single-key
+        # compound -- a BSON-array ``entity_key`` would turn it
+        # into a *multikey* index where Mongo enforces
+        # uniqueness element-wise, in which case two IPv4 notes
+        # (whose ``addr_0`` is the same bias constant) collide
+        # at the second insert.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_notes]
+        unique_index = next(
+            (keys, opts)
+            for keys, opts in block
+            if keys
+            == [
+                ("entity_type", 1),
+                ("entity_key_0", 1),
+                ("entity_key_1", 1),
+            ]
+        )
+        self.assertTrue(
+            unique_index[1].get("unique"),
+            f"expected unique=True, got {unique_index[1]!r}",
+        )
+
+    def test_notes_body_text_index(self) -> None:
+        # Free-text search over note bodies relies on a text
+        # index; Mongo allows at most one per collection.
+        # ``MongoDB.searchtext`` (inherited by
+        # :class:`MongoDBNotes`) produces ``$text`` queries
+        # that target this index.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_notes]
+        text_index = next(
+            (keys, opts) for keys, opts in block if keys == [("body", "text")]
+        )
+        self.assertEqual(text_index[1].get("name"), "notes_body_text")
+
+    def test_note_revisions_compound_index(self) -> None:
+        # Pin ``(entity_type ASC, entity_key_0 ASC,
+        # entity_key_1 ASC, revision DESC)`` -- the compound
+        # used by ``list_note_revisions`` for newest-first
+        # ordering with the storage shape matching the unique
+        # compound on the parent collection.
+        from ivre.db.mongo import MongoDBNotes
+
+        block = MongoDBNotes.indexes[MongoDBNotes.column_note_revisions]
+        self.assertTrue(
+            any(
+                keys
+                == [
+                    ("entity_type", 1),
+                    ("entity_key_0", 1),
+                    ("entity_key_1", 1),
+                    ("revision", -1),
+                ]
+                for keys, _opts in block
+            ),
+            block,
+        )
+
+    def test_dbnotes_abstract_surface(self) -> None:
+        # Each method is declared on :class:`DBNotes` and is
+        # overridden by :class:`MongoDBNotes`.  The generic
+        # ``get`` / ``count`` primitives + the convenience
+        # methods make up the full purpose surface.
+        from ivre.db import DBNotes
+        from ivre.db.mongo import MongoDBNotes
+
+        method_names = (
+            "get",
+            "count",
+            "get_note",
+            "set_note",
+            "delete_note",
+            "list_note_revisions",
+            "list_entities",
+            "count_notes",
+        )
+        for name in method_names:
+            with self.subTest(method=name):
+                self.assertIn(
+                    name,
+                    DBNotes.__dict__,
+                    f"DBNotes is missing {name}",
+                )
+                self.assertIn(
+                    name,
+                    MongoDBNotes.__dict__,
+                    f"MongoDBNotes is missing {name}",
+                )
+
+    def test_dbnotes_methods_raise_on_base(self) -> None:
+        # Driving the base-class methods directly (bypassing the
+        # concrete override) surfaces ``NotImplementedError``,
+        # so a backend that forgets to implement one fails
+        # loudly instead of silently no-op'ing.
+        from ivre.db import DBNotes
+
+        notes = DBNotes()
+        with self.assertRaises(NotImplementedError):
+            notes.get_note("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.set_note("host", "192.0.2.1", "body", "alice@example.org")
+        with self.assertRaises(NotImplementedError):
+            notes.delete_note("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.list_note_revisions("host", "192.0.2.1")
+        with self.assertRaises(NotImplementedError):
+            notes.list_entities()
+        with self.assertRaises(NotImplementedError):
+            notes.count_notes()
+        with self.assertRaises(NotImplementedError):
+            notes.get({})
+        with self.assertRaises(NotImplementedError):
+            notes.count({})
+
+    def test_canonicalize_host_key_matches_ip2internal(self) -> None:
+        # Notes for the ``host`` entity type are keyed by the
+        # same int128 split MongoDBView uses for its ``addr_0``
+        # / ``addr_1`` fields, so the two collections align
+        # byte-for-byte (enables future ``$lookup`` joins +
+        # correct IP-range queries).
+        from ivre.db import canonicalize_entity_key
+        from ivre.db.mongo import MongoDB
+
+        for addr in ["192.0.2.1", "10.0.0.1", "2001:db8::1", "::1"]:
+            with self.subTest(addr=addr):
+                self.assertEqual(
+                    canonicalize_entity_key("host", addr),
+                    MongoDB.ip2internal(addr),
+                )
+
+    def test_canonicalize_entity_key_unknown_type_raises(self) -> None:
+        from ivre.db import canonicalize_entity_key
+
+        with self.assertRaises(ValueError) as ctx:
+            canonicalize_entity_key("garbage", "anything")
+        # The error names the unknown type and lists what is
+        # registered, so operators adding a new type via a plugin
+        # see exactly which side to fix.
+        self.assertIn("garbage", str(ctx.exception))
+        self.assertIn("host", str(ctx.exception))
+
+    def test_canonicalize_host_key_rejects_wrong_length_list(self) -> None:
+        # A list input for the ``host`` type must have exactly
+        # two elements (``[addr_0, addr_1]``).  Anything else
+        # is rejected up-front to prevent malformed keys from
+        # reaching the storage layer and crashing far away on
+        # the next read inside ``MongoDB.internal2ip``.
+        from ivre.db import canonicalize_entity_key
+
+        for bad in ([], [0], [0, 0, 0]):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    canonicalize_entity_key("host", bad)
+                self.assertIn("exactly 2 elements", str(ctx.exception))
+
+    def test_canonicalize_host_key_rejects_non_int_elements(self) -> None:
+        # Both halves of the int128 split must be ints; a
+        # ``None`` half or a string half would silently corrupt
+        # the document and surface as a ``TypeError`` deep
+        # inside ``internal2ip`` on the read path.  ``bool``
+        # is a subclass of ``int`` in Python but is rejected
+        # explicitly: a caller passing ``[True, False]`` is
+        # clearly confused.
+        from ivre.db import canonicalize_entity_key
+
+        cases = [
+            [None, 0],
+            [0, None],
+            ["addr_0", 0],
+            [0, "addr_1"],
+            [1.5, 0],
+            [True, False],
+        ]
+        for bad in cases:
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    canonicalize_entity_key("host", bad)
+                self.assertIn("must be int", str(ctx.exception))
+
+    def test_canonicalize_host_key_rejects_out_of_range_int(self) -> None:
+        # Values outside the signed int64 range cannot be
+        # reassembled to a valid int128 by
+        # :meth:`MongoDB.internal2ip` (the bias-add would
+        # produce an out-of-range value for ``struct.pack``).
+        # Reject early.
+        from ivre.db import canonicalize_entity_key
+
+        cases = [
+            [1 << 63, 0],
+            [0, 1 << 63],
+            [-(1 << 63) - 1, 0],
+            [0, -(1 << 63) - 1],
+        ]
+        for bad in cases:
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    canonicalize_entity_key("host", bad)
+                self.assertIn("out of signed int64 range", str(ctx.exception))
+
+    def test_canonicalize_host_key_rejects_non_str_non_list_input(self) -> None:
+        # The host canonicaliser accepts only printable IP
+        # strings or 2-element ``[addr_0, addr_1]`` int
+        # lists.  Anything else (raw int, bytes, dict, ...)
+        # is rejected with a clear error that names the
+        # acceptable input forms instead of surfacing a
+        # downstream ``ip2bin`` error from a different
+        # module.
+        from ivre.db import canonicalize_entity_key
+
+        for bad in (12345, b"\xc0\x00\x02\x01", {"addr": "1.2.3.4"}, None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    canonicalize_entity_key("host", bad)
+                self.assertIn("printable IP string", str(ctx.exception))
+
+    def test_canonicalize_host_key_accepts_valid_canonical_list(self) -> None:
+        # Already-canonical 2-element lists with valid int64
+        # halves round-trip unchanged.  Verifies the
+        # validation guards do not regress the happy-path
+        # idempotence (e.g. when ``set_note`` is fed back a
+        # value previously returned by ``get_note``'s
+        # internal representation).
+        from ivre.db import canonicalize_entity_key
+        from ivre.db.mongo import MongoDB
+
+        for addr in ["192.0.2.1", "10.0.0.1", "2001:db8::1", "::1"]:
+            with self.subTest(addr=addr):
+                canonical = MongoDB.ip2internal(addr)
+                self.assertEqual(canonicalize_entity_key("host", canonical), canonical)
+
+    def test_validate_note_body_size_accepts_within_cap(self) -> None:
+        from ivre.db import DBNotes
+
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None  # default config has it set
+        # ASCII body so byte-length equals str-length.
+        DBNotes._validate_note_body_size("x" * cap)
+
+    def test_validate_note_body_size_rejects_over_cap(self) -> None:
+        from ivre.db import DBNotes
+
+        cap = ivre.config.WEB_HOST_NOTES_MAX_BYTES
+        assert cap is not None
+        with self.assertRaises(ValueError) as ctx:
+            DBNotes._validate_note_body_size("x" * (cap + 1))
+        self.assertIn("exceeds cap", str(ctx.exception))
+
+    def test_validate_note_body_size_disabled_when_cap_is_none(self) -> None:
+        from ivre.db import DBNotes
+
+        # An operator may disable the cap explicitly; arbitrarily
+        # large bodies are then accepted by the storage
+        # validator (Mongo's 16 MiB BSON limit still applies at
+        # insert time).
+        with mock.patch.object(ivre.config, "WEB_HOST_NOTES_MAX_BYTES", None):
+            DBNotes._validate_note_body_size("x" * 5_000_000)
+
+    def test_set_note_swallows_audit_insert_failure(self) -> None:
+        # Real bug surfaced by review: an unwrapped audit insert
+        # in ``set_note`` lets a transient failure on the
+        # ``note_revisions`` collection propagate to the caller
+        # after the parent note write already committed.  The
+        # caller's retry then bumps the parent revision a second
+        # time (under ``expected_revision=None`` LWW) or raises
+        # a false "concurrent edit" (under
+        # ``expected_revision>=1``).  Catching
+        # :class:`PyMongoError` on the audit insert keeps the
+        # user-facing write successful; the failure surfaces via
+        # :data:`utils.LOGGER` for operator inspection.
+        from pymongo.errors import PyMongoError
+
+        from ivre.db import canonicalize_entity_key
+        from ivre.db.mongo import MongoDBNotes
+
+        backend = MongoDBNotes.__new__(MongoDBNotes)
+        backend.columns = ["notes", "note_revisions"]
+
+        # Parent collection: ``find_one_and_update`` returns a
+        # plausible upserted doc with the same canonical
+        # ``entity_key_0`` / ``entity_key_1`` the real backend
+        # would produce for ``192.0.2.1``.  Audit collection:
+        # ``insert_one`` raises a transient backend error.
+        canonical = canonicalize_entity_key("host", "192.0.2.1")
+        now = datetime.now(tz=timezone.utc)
+        upserted_doc = {
+            "_id": "x",
+            "entity_type": "host",
+            "entity_key_0": canonical[0],
+            "entity_key_1": canonical[1],
+            "body": "hello",
+            "revision": 1,
+            "created_at": now,
+            "created_by": "alice@example.org",
+            "updated_at": now,
+            "updated_by": "alice@example.org",
+        }
+        notes_col = mock.Mock()
+        notes_col.find_one_and_update.return_value = upserted_doc
+        revisions_col = mock.Mock()
+        revisions_col.insert_one.side_effect = PyMongoError("simulated blip")
+
+        # ``MongoDBNotes.db`` is a property delegating to
+        # ``self._db.db``; stub the inner ``_db`` so the
+        # ``self.db[...]`` lookups return our mocked collections.
+        backend._db = mock.Mock()
+        backend._db.db = {
+            "notes": notes_col,
+            "note_revisions": revisions_col,
+        }
+        with mock.patch.object(ivre.utils.LOGGER, "warning") as warning_mock:
+            result = backend.set_note("host", "192.0.2.1", "hello", "alice@example.org")
+        # Parent write was committed; caller sees success.
+        self.assertEqual(result["body"], "hello")
+        self.assertEqual(result["revision"], 1)
+        self.assertEqual(result["entity_key"], "192.0.2.1")
+        # Audit insert was attempted exactly once.
+        revisions_col.insert_one.assert_called_once()
+        # And the failure was logged.
+        warning_mock.assert_called_once()
+        # The log message names the entity so an operator can
+        # audit-replay manually.
+        log_args = warning_mock.call_args
+        self.assertIn("host", log_args.args)
+        self.assertIn("192.0.2.1", log_args.args)
+
+    @staticmethod
+    def _build_set_note_backend(
+        notes_col: "mock.Mock", revisions_col: "mock.Mock"
+    ) -> "object":
+        """Helper: instantiate a :class:`MongoDBNotes` without
+        opening a real backend connection and stub its ``db``
+        property so ``self.db[...]`` returns the mocked
+        collections.  Returned object has both collections
+        wired and ready for :meth:`set_note` exercise.
+        """
+        from ivre.db.mongo import MongoDBNotes
+
+        backend = MongoDBNotes.__new__(MongoDBNotes)
+        backend.columns = ["notes", "note_revisions"]
+        backend._db = mock.Mock()
+        backend._db.db = {
+            "notes": notes_col,
+            "note_revisions": revisions_col,
+        }
+        return backend
+
+    def test_set_note_raises_note_not_found_when_missing(self) -> None:
+        # ``expected_revision >= 1`` + the target note does not
+        # exist -> ``NoteNotFound``.  Distinguishes from
+        # ``NoteConcurrencyError`` so web layers can map to
+        # HTTP 404 vs 409 without sniffing error strings.
+        from pymongo import ReadPreference
+
+        from ivre.db import NoteNotFound
+
+        notes_col = mock.Mock()
+        # find_one_and_update returns None (no doc at
+        # expected_revision).  The existence-check must hit
+        # PRIMARY explicitly via ``with_options``: stub the
+        # sub-collection it returns so its ``find_one``
+        # returns None (no doc at all).
+        notes_col.find_one_and_update.return_value = None
+        primary_view = mock.Mock()
+        primary_view.find_one.return_value = None
+        notes_col.with_options.return_value = primary_view
+        revisions_col = mock.Mock()
+        backend = self._build_set_note_backend(notes_col, revisions_col)
+        with self.assertRaises(NoteNotFound) as ctx:
+            backend.set_note(
+                "host",
+                "192.0.2.1",
+                "new body",
+                "alice@example.org",
+                expected_revision=5,
+            )
+        # Error message identifies the entity so operators /
+        # web logs see which target was missing.
+        self.assertIn("host", str(ctx.exception))
+        self.assertIn("192.0.2.1", str(ctx.exception))
+        # Existence check was pinned to PRIMARY -- non-PRIMARY
+        # client read preferences would otherwise let a stale
+        # secondary misclassify a concurrency drift as
+        # not-found (or vice versa).
+        notes_col.with_options.assert_called_once_with(
+            read_preference=ReadPreference.PRIMARY
+        )
+        primary_view.find_one.assert_called_once()
+        # Audit log is *not* touched on the failure path.
+        revisions_col.insert_one.assert_not_called()
+
+    def test_set_note_raises_concurrency_error_on_revision_drift(self) -> None:
+        # ``expected_revision >= 1`` + the target note exists
+        # but at a different revision -> ``NoteConcurrencyError``.
+        from pymongo import ReadPreference
+
+        from ivre.db import NoteConcurrencyError
+
+        notes_col = mock.Mock()
+        notes_col.find_one_and_update.return_value = None
+        # PRIMARY-pinned existence check finds the note at a
+        # different revision than the caller asked for.
+        primary_view = mock.Mock()
+        primary_view.find_one.return_value = {"revision": 7}
+        notes_col.with_options.return_value = primary_view
+        revisions_col = mock.Mock()
+        backend = self._build_set_note_backend(notes_col, revisions_col)
+        with self.assertRaises(NoteConcurrencyError) as ctx:
+            backend.set_note(
+                "host",
+                "192.0.2.1",
+                "new body",
+                "alice@example.org",
+                expected_revision=5,
+            )
+        # Error names the stored vs expected revisions so the
+        # SPA's conflict dialog can surface them.
+        msg = str(ctx.exception)
+        self.assertIn("7", msg)
+        self.assertIn("5", msg)
+        notes_col.with_options.assert_called_once_with(
+            read_preference=ReadPreference.PRIMARY
+        )
+        revisions_col.insert_one.assert_not_called()
+
+    def test_set_note_raises_already_exists_in_create_only_mode(self) -> None:
+        # ``expected_revision = 0`` (create-only) on a note
+        # that already exists -> ``NoteAlreadyExists``.
+        from pymongo.errors import DuplicateKeyError
+
+        from ivre.db import NoteAlreadyExists
+
+        notes_col = mock.Mock()
+        # insert_one raises DuplicateKeyError on the unique
+        # compound index.
+        notes_col.insert_one.side_effect = DuplicateKeyError("duplicate")
+        revisions_col = mock.Mock()
+        backend = self._build_set_note_backend(notes_col, revisions_col)
+        with self.assertRaises(NoteAlreadyExists) as ctx:
+            backend.set_note(
+                "host",
+                "192.0.2.1",
+                "new body",
+                "alice@example.org",
+                expected_revision=0,
+            )
+        self.assertIn("host", str(ctx.exception))
+        self.assertIn("192.0.2.1", str(ctx.exception))
+        revisions_col.insert_one.assert_not_called()
+
+    def test_set_note_create_only_does_not_read_after_insert(self) -> None:
+        # The ``expected_revision <= 0`` (create-only) success
+        # path constructs the persisted-doc dict locally
+        # rather than reading it back: we know exactly what
+        # we just wrote, and a follow-up ``find_one`` would
+        # be served from whatever the client-level
+        # ``read_preference`` selects -- a stale secondary
+        # could return ``None`` and crash the downstream
+        # audit-log step on ``doc["revision"]``.  Pin that
+        # the create path never issues a read (neither a
+        # direct ``find_one`` nor a ``with_options(...)``
+        # routed read).
+        notes_col = mock.Mock()
+        notes_col.insert_one.return_value = mock.Mock()
+        revisions_col = mock.Mock()
+        backend = self._build_set_note_backend(notes_col, revisions_col)
+        result = backend.set_note(
+            "host",
+            "192.0.2.1",
+            "first version",
+            "alice@example.org",
+            expected_revision=0,
+        )
+        # The created note round-trips back through
+        # ``_present_note`` and carries the values we just
+        # inserted -- not a fetched copy.
+        self.assertEqual(result["body"], "first version")
+        self.assertEqual(result["revision"], 1)
+        self.assertEqual(result["entity_key"], "192.0.2.1")
+        # Insert happened exactly once; no reads on the
+        # notes collection at all.
+        notes_col.insert_one.assert_called_once()
+        notes_col.find_one.assert_not_called()
+        notes_col.with_options.assert_not_called()
+        # Audit log still gets its row.
+        revisions_col.insert_one.assert_called_once()
+
+    def test_note_exception_types_are_value_errors(self) -> None:
+        # Subclassing ``ValueError`` keeps backwards
+        # compatibility with callers that catch the coarser
+        # type (legacy ``except ValueError:`` blocks still
+        # catch all three).
+        from ivre.db import (
+            NoteAlreadyExists,
+            NoteConcurrencyError,
+            NoteNotFound,
+        )
+
+        self.assertTrue(issubclass(NoteNotFound, ValueError))
+        self.assertTrue(issubclass(NoteConcurrencyError, ValueError))
+        self.assertTrue(issubclass(NoteAlreadyExists, ValueError))
+
+    @staticmethod
+    def _build_get_backend(
+        notes_col: "mock.Mock", maxtime: "int | None" = None
+    ) -> "object":
+        """Helper: build a :class:`MongoDBNotes` whose ``db``
+        property returns the mocked collection.  ``maxtime``
+        seeds the inherited :meth:`MongoDB.set_limits` so
+        tests can exercise the timeout-application path
+        without spinning up a real client.
+        """
+        from ivre.db.mongo import MongoDBNotes
+
+        backend = MongoDBNotes.__new__(MongoDBNotes)
+        backend.columns = ["notes", "note_revisions"]
+        backend.maxtime = maxtime
+        backend._db = mock.Mock()
+        backend._db.db = {"notes": notes_col, "note_revisions": mock.Mock()}
+        return backend
+
+    def test_mongodb_notes_get_routes_through_get_cursor(self) -> None:
+        # Pin that :meth:`MongoDBNotes.get` goes through
+        # :meth:`MongoDB._get_cursor` -- the shared cursor
+        # factory the rest of the Mongo backends use --
+        # rather than calling ``find`` directly.  Routing
+        # through ``_get_cursor`` gets the notes purpose
+        # parity with ``MongoDBView.get`` /
+        # ``MongoDBPassive.get`` for query timeouts, the
+        # ``("text", ...)`` sort shortcut, and the legacy
+        # ``fields=`` to ``projection=`` conversion.
+        notes_col = mock.Mock()
+        cursor = mock.Mock()
+        notes_col.find.return_value = cursor
+        backend = self._build_get_backend(notes_col)
+        result = backend.get(
+            {"entity_type": "host"},
+            projection={"body": 0},
+            sort=[("updated_at", -1)],
+            limit=10,
+            skip=5,
+        )
+        # ``_get_cursor`` pops ``sort`` before calling
+        # ``find`` and applies it via ``cursor.sort(...)``
+        # afterwards; everything else is forwarded to
+        # ``find`` unchanged.
+        notes_col.find.assert_called_once_with(
+            {"entity_type": "host"},
+            projection={"body": 0},
+            limit=10,
+            skip=5,
+        )
+        cursor.sort.assert_called_once_with([("updated_at", -1)])
+        # ``set_limits`` returns the cursor unchanged when
+        # ``maxtime`` is unset, which is what ``get`` returns.
+        self.assertIs(result, cursor)
+
+    def test_mongodb_notes_get_applies_query_timeout(self) -> None:
+        # When the client is configured with a query
+        # timeout (``MONGODB_QUERY_TIMEOUT_MS`` config knob
+        # or per-URL ``?maxtime=`` param,
+        # surfaced as ``backend.maxtime``), the cursor
+        # returned by :meth:`MongoDBNotes.get` must carry
+        # the bound -- otherwise a heavy ``$text`` query
+        # over a large notes collection under adversarial
+        # input would run unbounded.
+        notes_col = mock.Mock()
+        cursor = mock.Mock()
+        notes_col.find.return_value = cursor
+        backend = self._build_get_backend(notes_col, maxtime=5000)
+        backend.get({"entity_type": "host"})
+        cursor.max_time_ms.assert_called_once_with(5000)
+
+    def test_mongodb_notes_get_text_sort_adds_score_projection(self) -> None:
+        # The :meth:`_get_cursor` ``sort=[("text", ...)]``
+        # shortcut auto-adds the ``$meta: textScore``
+        # projection and sort, so web routes can ask for
+        # relevance-ranked free-text search results in one
+        # call rather than hand-rolling the meta projection.
+        # Pin that behaviour for the notes purpose --
+        # ``/cgi/notes/?q=...`` (added in a follow-up PR)
+        # relies on it.
+        notes_col = mock.Mock()
+        cursor = mock.Mock()
+        notes_col.find.return_value = cursor
+        backend = self._build_get_backend(notes_col)
+        backend.get(
+            {"$text": {"$search": "c2"}},
+            sort=[("text", 0)],
+        )
+        # ``find`` received the auto-added meta projection.
+        find_args = notes_col.find.call_args
+        self.assertEqual(find_args.args, ({"$text": {"$search": "c2"}},))
+        self.assertEqual(
+            find_args.kwargs.get("projection"),
+            {"score": {"$meta": "textScore"}},
+        )
+        # And the cursor was sorted by the same meta key.
+        cursor.sort.assert_called_once_with([("score", {"$meta": "textScore"})])
+
+    def test_mongodb_notes_count_empty_filter_uses_estimated(self) -> None:
+        # Mirrors :meth:`MongoDBView.count`: an empty filter
+        # reads collection metadata in O(1) via
+        # ``estimated_document_count`` instead of scanning
+        # every document.  The ``count_notes(entity_type=None)``
+        # path is the common case that benefits.
+        notes_col = mock.Mock()
+        notes_col.estimated_document_count.return_value = 42
+        backend = self._build_get_backend(notes_col)
+        self.assertEqual(backend.count({}), 42)
+        notes_col.estimated_document_count.assert_called_once_with()
+        notes_col.count_documents.assert_not_called()
+
+    def test_mongodb_notes_count_nonempty_filter_uses_count_documents(
+        self,
+    ) -> None:
+        # A non-empty filter goes through
+        # ``count_documents`` so the filter is honoured.
+        notes_col = mock.Mock()
+        notes_col.count_documents.return_value = 7
+        backend = self._build_get_backend(notes_col)
+        self.assertEqual(backend.count({"entity_type": "host"}), 7)
+        notes_col.count_documents.assert_called_once_with({"entity_type": "host"})
+        notes_col.estimated_document_count.assert_not_called()
+
+    def test_metadb_has_notes_property(self) -> None:
+        # ``db.notes`` resolves to a ``DBNotes`` instance when
+        # ``DB_NOTES`` / ``DB`` is configured to a backend that
+        # implements the purpose.  We patch ``DB_NOTES`` to a
+        # synthetic mongodb URL so the property doesn't try to
+        # talk to a real backend.
+        from ivre.db import DBNotes, MetaDB
+
+        # Build a fresh MetaDB so we don't poison the module-level
+        # ``db`` singleton's cached ``_notes`` attribute.
+        m = MetaDB(
+            url="mongodb:///x",
+            urls={"notes": "mongodb:///x"},
+        )
+        notes = m.notes
+        # The class lookup succeeded -- ``MongoDBNotes`` is the
+        # registered backend for ``"mongodb"``.  We can't talk to
+        # the real server in this test, but the class wiring is
+        # what we care about here.
+        self.assertIsNotNone(notes)
+        self.assertIsInstance(notes, DBNotes)
+
+
 def _parse_args() -> None:
     """Parse the optional ``--samples`` and ``--coverage`` flags when
     this module is invoked as a script. Mirrors ``tests/tests.py``."""


### PR DESCRIPTION
Introduces a new ``notes`` purpose -- per-entity markdown annotations stored in IVRE's own DB, keyed by an
``(entity_type, entity_key)`` pair -- as the storage layer underneath the eventual Dokuwiki replacement.  Independent of every data purpose: ``view --init``, ``nmap --init``, ``passive --init`` never touch notes; operators wipe annotations explicitly via ``ivre notes --init`` (CLI lands in a follow-up PR).

The entity-typed model lets the same surface annotate hosts today and domains / ASNs / CVE IDs / cert
fingerprints / classifier labels tomorrow -- additive PRs register new entity-type canonicalisers; no
storage-shape changes needed.

V1 ships the ``host`` entity type only.  The canonical form for ``host`` is the same ``[addr_0, addr_1]`` int128 split :meth:`MongoDB.ip2internal` produces for the ``view`` collection's ``addr`` field, so notes and view records align byte-for-byte (enables future ``$lookup`` joins and correct IP-range queries; lexicographic string sort would give the wrong order across IPv4 / IPv6).

Storage layer (MongoDB) carves the canonical key into two scalar BSON fields, ``entity_key_0`` and ``entity_key_1``, rather than storing the canonical list in a single ``entity_key`` field.  Storing the canonical form as a BSON array would make the unique compound a *multikey* index, in which case Mongo enforces uniqueness element-wise: every IPv4 host's ``addr_0`` is the same bias constant (``-0x8000000000000000``), so the second IPv4 note insert would collide with the first on a per-element basis.  The two-scalar shape keeps the compound a plain single-key compound and admits future single-scalar entity types (``domain`` / ``cve`` / ``asn``) that store the value in ``entity_key_0`` and ``None`` in ``entity_key_1``.

Two collections:

* ``notes``: one record per ``(entity_type, entity_key_0, entity_key_1)`` triple.  Unique compound index on the triple; secondary indexes on ``(entity_type, updated_at DESC)`` and ``updated_by`` support admin "recently edited" listings and per-user filters.  A text index on ``body`` named ``notes_body_text`` backs free-text search; the inherited :meth:`MongoDB.searchtext` produces ``$text`` queries that target this index.
* ``note_revisions``: append-only audit log.  Compound ``(entity_type, entity_key_0, entity_key_1, revision DESC)`` supports newest-first history retrieval.  No TTL: the choice is full audit history.

``DBNotes`` abstract surface in :mod:`ivre.db` ships eight methods + one static helper:

* ``get(spec, **kargs)`` -- iterate raw note documents. Filters are composed via :meth:`searchtext` (inherited from the backend's base class, e.g. :meth:`MongoDB.searchtext`) and the standard combinators (:meth:`flt_and` / :meth:`flt_or` / direct filter literals).  Returned documents carry the storage-layer ``entity_key_0`` / ``entity_key_1`` fields verbatim; the caller-facing convenience methods post-process to the ``entity_key`` form.
* ``count(spec)`` -- count documents matching ``spec``.
* ``get_note(entity_type, entity_key)`` -- read current note for one entity.
* ``set_note(entity_type, entity_key, body, user_email, *, expected_revision=None)`` -- upsert.  Three modes via the keyword-only ``expected_revision``: ``None`` = last-write-wins; ``0`` = create-only (raises ``ValueError`` if a record already exists); ``>= 1`` = update only when the stored revision matches (raises ``ValueError`` on drift, surfacing concurrent edits to the SPA save button).
* ``delete_note(entity_type, entity_key)`` -- hard delete; sweeps the audit log too.
* ``list_note_revisions(entity_type, entity_key)`` -- newest-first revision history.
* ``list_entities(entity_type=None)`` -- entities that carry a note, optionally narrowed by type.  Used by the search-bar ``notes:`` filter to build a host narrow without an extra round-trip per entity.
* ``count_notes(entity_type=None)`` -- admin / statistics surface.  Delegates to ``count``.
* ``_validate_note_body_size(body)`` -- static helper; raises ``ValueError`` when ``body`` exceeds ``config.WEB_HOST_NOTES_MAX_BYTES`` (default 1 MB; ``None`` disables).  Called by every backend's ``set_note`` before any DB write as defence-in-depth alongside the HTTP-413 the web routes will add.

Entity-key canonicalisation is centralised in a small registry of helper functions: ``_ENTITY_CANONICALIZERS`` maps an ``entity_type`` string to a normaliser.  V1 registers ``"host"`` only.  The host normaliser reproduces the :meth:`MongoDB.ip2internal` int128 split as pure-Python to keep the canonicalisation module independent of the Mongo backend's import graph.  ``canonicalize_entity_key`` is the public entry point; raises ``ValueError`` on unknown types so a backend / web route / MCP tool that received a garbled type surfaces the error cleanly.

``MongoDBNotes(MongoDB, DBNotes)`` implements every method plus three helpers: ``_entity_key_to_storage`` packs the canonical form (scalar or 1/2-element list) into the ``(entity_key_0, entity_key_1)`` pair;
``_entity_key_filter`` builds a single-record find filter from a caller-facing key; ``_present_entity_key`` converts the two storage scalars back to the caller-facing form (printable IP string for ``host``; ``entity_key_0`` as-is for future single-scalar types).  The ``set_note`` body is the longest at ~80 LoC and has three code paths for the three concurrency modes; the upsert + revision-insert is a two-op sequence (parent authoritative, audit log best-effort).  Free-text search inherits
:meth:`MongoDB.searchtext` verbatim and feeds the new ``get`` / ``count`` primitives.

``MetaDB`` gains a ``notes`` property that lazy-loads the purpose from ``config.DB_NOTES`` (falling back to
``config.DB`` when unset so operators get a working ``db.notes`` out of the box).  Other backends (Postgres, DuckDB, Elastic, DocumentDB, HTTP) inherit
``NotImplementedError`` from the base for v1 -- matches the convention of landing new features on Mongo first.

Tests: 12 new in ``MongoDBNotesIndexTests``, backend-free. Pin the column constants + indexes-list length, the unique compound index on
``(entity_type, entity_key_0, entity_key_1)``, the body text index named ``notes_body_text``, the
``(entity_type, entity_key_0, entity_key_1, revision DESC)`` compound on the audit log, the abstract surface on both ``DBNotes`` and ``MongoDBNotes`` (eight methods including ``get`` / ``count``), the base-class
``NotImplementedError`` raises on every method, the host canonicaliser's parity with ``MongoDB.ip2internal``, the unknown-type rejection, the body-size validator (within cap / over cap / cap disabled), and the ``MetaDB.notes`` property wiring.

The actual create / read / update / list-revisions / delete round-trip against a real MongoDB lands in
``tests/tests.py`` in a follow-up PR (alongside the ``/cgi/notes/<type>/<key>`` web routes that drive the surface end-to-end).