### PR TITLE
feat(web): add ivre.plugins.web.filter authorization hook

### DIFF
--- a/ivre/plugins.py
+++ b/ivre/plugins.py
@@ -40,6 +40,7 @@ CATEGORIES = [
     "tags.active",
     "tools",
     "view",
+    "web.filter",
 ]
 
 

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -26,6 +26,7 @@ import functools
 import os
 import re
 import shlex
+from typing import Any, Callable
 
 try:
     import MySQLdb  # type: ignore
@@ -40,6 +41,7 @@ from regexploit.ast.sre import SreOpParser  # type: ignore[import-untyped]
 from regexploit.redos import find as _regexploit_find  # type: ignore[import-untyped]
 
 from ivre import config, utils
+from ivre.plugins import load_plugins
 
 GET_NOTEPAD_PAGES = {}
 
@@ -309,17 +311,91 @@ def _parse_query(dbase, query):
     }[query[0]](dbase, *query[1:])
 
 
-def get_init_flt_for(user, dbase):
-    """Return a filter corresponding to the given user's privileges.
+# ---------------------------------------------------------------------
+# Filter-injection hook
+#
+# Plugins register zero or more callables in :data:`FILTER_INJECTORS`
+# via the ``ivre.plugins.web.filter`` entry-point group. Each
+# registered callable is invoked from :func:`get_init_flt_for` (and
+# therefore from every code path that builds the base filter: Bottle
+# routes via :func:`get_init_flt`, the MCP server's ``_parse``,
+# …); its return value (if not ``None``) is AND'd into the user's
+# base filter before any user-supplied query is applied.
+#
+# This is the in-tree extension point for out-of-tree
+# authorization / scoping plugins. The plugin reads the
+# authenticated identity (the ``user`` argument, or anything
+# else it pulls from the request, the auth backend, an external
+# IAM, ...) and returns a backend filter clause; the hook AND's
+# that clause into every query the user can run. The policy
+# itself -- who can see what, default-deny vs. default-allow,
+# cross-principal share rules, audit requirements -- is
+# deployment-specific and lives in the plugin; core stays
+# policy-agnostic and only ships the hook. The contract is
+# intentionally minimal: a registered callable receives
+# ``(dbase, user)`` and returns either ``None`` (no clause to
+# inject for this pair) or a backend filter object that
+# ``dbase.flt_and`` can compose with the base filter.
+# ---------------------------------------------------------------------
 
-    Unlike :func:`get_init_flt`, this function does not consult the
-    current Bottle request and does not abort on unauthenticated users;
-    callers are expected to have resolved the user beforehand (for
-    instance from an MCP transport) and to handle the unauthenticated
-    case themselves.
+FilterInjector = Callable[[Any, "str | None"], Any]
 
-    ``user`` must be either a user email (``str``) or ``None`` to mean
-    "no authenticated user".
+FILTER_INJECTORS: list[FilterInjector] = []
+
+
+def register_filter_injector(func: FilterInjector) -> FilterInjector:
+    """Register a filter-injection callable and return it unchanged.
+
+    The callable receives ``(dbase, user)`` and returns either:
+
+    * ``None`` — no clause to inject for this ``(dbase, user)``
+      pair;
+    * a backend filter — will be AND'd into the user's base
+      filter before any user-supplied query is applied.
+
+    Returns the registered function unchanged so it can be used
+    as a decorator. Plugins typically call this from an
+    ``_install_<name>(scope)`` entry-point (the ``scope`` argument
+    is the :func:`globals` of this module, but the function is
+    importable directly so plugins do not have to reach into it).
+    """
+    FILTER_INJECTORS.append(func)
+    return func
+
+
+def apply_filter_injectors(dbase: Any, base_flt: Any, user: "str | None") -> Any:
+    """Compose every registered :data:`FILTER_INJECTORS` callable
+    on top of ``base_flt`` and return the resulting filter.
+
+    Injectors are called in registration order. A return value of
+    ``None`` skips the injector; any other value is AND'd into
+    the accumulator via ``dbase.flt_and``. Injector exceptions
+    are logged and swallowed — a misbehaving plugin must not turn
+    every API request into a 500.
+    """
+    flt = base_flt
+    for inj in FILTER_INJECTORS:
+        try:
+            clause = inj(dbase, user)
+        except Exception:  # pylint: disable=broad-except
+            # A misbehaving plugin must not 500 the whole API; log
+            # and continue. The audit trail of which injector raised
+            # is captured in ``exc_info``.
+            utils.LOGGER.warning(
+                "Filter injector %r raised; skipping", inj, exc_info=True
+            )
+            continue
+        if clause is not None:
+            flt = dbase.flt_and(flt, clause)
+    return flt
+
+
+def _resolve_init_flt(user: "str | None", dbase: Any) -> Any:
+    """Resolve the legacy ``WEB_INIT_QUERIES`` dispatch.
+
+    Factored out of :func:`get_init_flt_for` so the latter can
+    wrap the result with :func:`apply_filter_injectors` in a
+    single exit point.
     """
     init_queries = {
         key: _parse_query(dbase, value)
@@ -341,6 +417,28 @@ def get_init_flt_for(user, dbase):
                 if key in init_queries:
                     return init_queries[key]
     return _parse_query(dbase, config.WEB_DEFAULT_INIT_QUERY)
+
+
+def get_init_flt_for(user: "str | None", dbase: Any) -> Any:
+    """Return a filter corresponding to the given user's privileges.
+
+    Unlike :func:`get_init_flt`, this function does not consult the
+    current Bottle request and does not abort on unauthenticated users;
+    callers are expected to have resolved the user beforehand (for
+    instance from an MCP transport) and to handle the unauthenticated
+    case themselves.
+
+    ``user`` must be either a user email (``str``) or ``None`` to mean
+    "no authenticated user".
+
+    Out-of-tree plugins registered via
+    :data:`FILTER_INJECTORS` get the final say: their clauses
+    are AND'd into the returned filter via
+    :func:`apply_filter_injectors`. This is how an optional
+    authorization / scoping plugin enforces a deployment-specific
+    access policy without requiring core changes.
+    """
+    return apply_filter_injectors(dbase, _resolve_init_flt(user, dbase), user)
 
 
 def get_init_flt(dbase):
@@ -1088,3 +1186,11 @@ def parse_filter(dbase, data):
     return getattr(dbase, func)(
         *(parse_arg(a) for a in args), **{k: parse_arg(v) for k, v in kargs.items()}
     )
+
+
+# Load ``ivre.plugins.web.filter`` entry-points last, after every
+# public helper is defined, so plugins importing from this module
+# always see a fully-formed surface. Plugins typically call
+# :func:`register_filter_injector` from their
+# ``_install_<name>(scope)`` entry point.
+load_plugins("ivre.plugins.web.filter", globals())

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -338,15 +338,26 @@ def _parse_query(dbase, query):
 # inject for this pair) or a backend filter object that
 # ``dbase.flt_and`` can compose with the base filter.
 #
-# Only the call to the registered injector is wrapped in a
-# try/except by :func:`apply_filter_injectors`: a returned
-# clause that ``dbase.flt_and`` cannot compose (wrong backend
-# shape, malformed Mongo operator, etc.) will propagate and
-# fail the request. Plugins are therefore responsible for
-# returning clauses that match the backend the deployment runs
-# against; ``flt_and`` failures are bugs in the plugin, not
-# something core should paper over with a fail-open default
-# that hides broken authorization wiring.
+# Failure model: fail-closed. An uncaught exception in an
+# injector means the plugin could not determine the scope it
+# was supposed to enforce; for an authorization control,
+# silently continuing with whatever ``_resolve_init_flt``
+# returned would be fail-open (the user runs against the base
+# filter, often :data:`flt_empty`, i.e. the whole database).
+# :func:`apply_filter_injectors` therefore logs the failure
+# via :data:`ivre.utils.LOGGER` at ``ERROR`` level with
+# ``exc_info=True`` and the failing injector's identity, then
+# re-raises so the request is aborted -- Bottle turns the
+# unhandled exception into ``500`` and the MCP server surfaces
+# it as a tool error. A plugin that wants graceful degradation
+# (e.g. fall back to a deny-all clause on a transient IAM
+# outage) catches the failure itself and returns a backend
+# deny clause -- ``dbase.searchnonexistent()`` on every
+# backend that ships one, the in-tree ``noaccess`` preset is
+# exactly this pattern. The composing call ``dbase.flt_and``
+# is likewise not wrapped: an un-composable clause is a
+# contract violation by the plugin and must surface as an
+# error rather than be silently dropped.
 # ---------------------------------------------------------------------
 
 FilterInjector = Callable[[Any, str | None], Filter | None]
@@ -382,30 +393,42 @@ def apply_filter_injectors(dbase: Any, base_flt: Filter, user: str | None) -> Fi
     ``None`` skips the injector; any other value is AND'd into
     the accumulator via ``dbase.flt_and``.
 
-    Only the *call* to the injector is wrapped in a try/except:
-    if an injector raises while computing its clause, the
-    exception is logged via :data:`ivre.utils.LOGGER` and the
-    injector is skipped so a single broken plugin cannot turn
-    every API request into a 500. The ``dbase.flt_and`` call
-    that composes the returned clause into the accumulator is
-    deliberately *not* wrapped — a clause that the backend
-    cannot AND with the running filter is a contract violation
-    by the plugin (wrong backend shape, malformed operator, …)
-    and must surface as an error rather than be silently
-    dropped, which would fail the authorization check open.
+    Fail-closed on uncaught injector exceptions: an uncaught
+    exception means the plugin could not determine the scope it
+    was supposed to enforce, so the request is aborted. The
+    failing injector and the original exception are logged via
+    :data:`ivre.utils.LOGGER` at ``ERROR`` level with
+    ``exc_info=True``, then the exception is re-raised; later
+    injectors are *not* invoked. Bottle turns the unhandled
+    exception into ``500`` and the MCP server surfaces it as a
+    tool error. A plugin that wants graceful degradation (e.g.
+    fall back to a deny-all clause on a transient IAM outage)
+    catches the failure itself and returns a backend deny
+    clause -- ``dbase.searchnonexistent()`` on every backend
+    that ships one.
+
+    The composing call ``dbase.flt_and`` is likewise not
+    wrapped: an un-composable clause (wrong backend shape,
+    malformed operator, ...) is a contract violation by the
+    plugin and must surface as an error rather than be silently
+    dropped.
     """
     flt = base_flt
     for inj in FILTER_INJECTORS:
         try:
             clause = inj(dbase, user)
-        except Exception:  # pylint: disable=broad-except
-            # A misbehaving injector must not 500 the whole API;
-            # log and continue. The traceback identifying which
-            # injector raised is captured in ``exc_info``.
-            utils.LOGGER.warning(
-                "Filter injector %r raised; skipping", inj, exc_info=True
+        except Exception:
+            # Authorization / scoping plugins are security
+            # controls: an uncaught exception means the plugin
+            # could not return a scope clause, and continuing
+            # would silently apply the bare base filter (often
+            # ``flt_empty``) -- i.e. fail-open. Log loudly with
+            # the failing injector's identity + traceback, then
+            # re-raise so the request fails closed.
+            utils.LOGGER.error(
+                "Filter injector %r raised; aborting request", inj, exc_info=True
             )
-            continue
+            raise
         if clause is not None:
             flt = dbase.flt_and(flt, clause)
     return flt

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -42,6 +42,7 @@ from regexploit.redos import find as _regexploit_find  # type: ignore[import-unt
 
 from ivre import config, utils
 from ivre.plugins import load_plugins
+from ivre.types import Filter
 
 GET_NOTEPAD_PAGES = {}
 
@@ -336,9 +337,19 @@ def _parse_query(dbase, query):
 # ``(dbase, user)`` and returns either ``None`` (no clause to
 # inject for this pair) or a backend filter object that
 # ``dbase.flt_and`` can compose with the base filter.
+#
+# Only the call to the registered injector is wrapped in a
+# try/except by :func:`apply_filter_injectors`: a returned
+# clause that ``dbase.flt_and`` cannot compose (wrong backend
+# shape, malformed Mongo operator, etc.) will propagate and
+# fail the request. Plugins are therefore responsible for
+# returning clauses that match the backend the deployment runs
+# against; ``flt_and`` failures are bugs in the plugin, not
+# something core should paper over with a fail-open default
+# that hides broken authorization wiring.
 # ---------------------------------------------------------------------
 
-FilterInjector = Callable[[Any, "str | None"], Any]
+FilterInjector = Callable[[Any, str | None], Filter | None]
 
 FILTER_INJECTORS: list[FilterInjector] = []
 
@@ -363,24 +374,34 @@ def register_filter_injector(func: FilterInjector) -> FilterInjector:
     return func
 
 
-def apply_filter_injectors(dbase: Any, base_flt: Any, user: "str | None") -> Any:
+def apply_filter_injectors(dbase: Any, base_flt: Filter, user: str | None) -> Filter:
     """Compose every registered :data:`FILTER_INJECTORS` callable
     on top of ``base_flt`` and return the resulting filter.
 
     Injectors are called in registration order. A return value of
     ``None`` skips the injector; any other value is AND'd into
-    the accumulator via ``dbase.flt_and``. Injector exceptions
-    are logged and swallowed — a misbehaving plugin must not turn
-    every API request into a 500.
+    the accumulator via ``dbase.flt_and``.
+
+    Only the *call* to the injector is wrapped in a try/except:
+    if an injector raises while computing its clause, the
+    exception is logged via :data:`ivre.utils.LOGGER` and the
+    injector is skipped so a single broken plugin cannot turn
+    every API request into a 500. The ``dbase.flt_and`` call
+    that composes the returned clause into the accumulator is
+    deliberately *not* wrapped — a clause that the backend
+    cannot AND with the running filter is a contract violation
+    by the plugin (wrong backend shape, malformed operator, …)
+    and must surface as an error rather than be silently
+    dropped, which would fail the authorization check open.
     """
     flt = base_flt
     for inj in FILTER_INJECTORS:
         try:
             clause = inj(dbase, user)
         except Exception:  # pylint: disable=broad-except
-            # A misbehaving plugin must not 500 the whole API; log
-            # and continue. The audit trail of which injector raised
-            # is captured in ``exc_info``.
+            # A misbehaving injector must not 500 the whole API;
+            # log and continue. The traceback identifying which
+            # injector raised is captured in ``exc_info``.
             utils.LOGGER.warning(
                 "Filter injector %r raised; skipping", inj, exc_info=True
             )
@@ -390,7 +411,7 @@ def apply_filter_injectors(dbase: Any, base_flt: Any, user: "str | None") -> Any
     return flt
 
 
-def _resolve_init_flt(user: "str | None", dbase: Any) -> Any:
+def _resolve_init_flt(user: str | None, dbase: Any) -> Filter:
     """Resolve the legacy ``WEB_INIT_QUERIES`` dispatch.
 
     Factored out of :func:`get_init_flt_for` so the latter can
@@ -419,7 +440,7 @@ def _resolve_init_flt(user: "str | None", dbase: Any) -> Any:
     return _parse_query(dbase, config.WEB_DEFAULT_INIT_QUERY)
 
 
-def get_init_flt_for(user: "str | None", dbase: Any) -> Any:
+def get_init_flt_for(user: str | None, dbase: Any) -> Filter:
     """Return a filter corresponding to the given user's privileges.
 
     Unlike :func:`get_init_flt`, this function does not consult the

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16351,8 +16351,9 @@ class WebFilterInjectorTests(unittest.TestCase):
         self._webutils.FILTER_INJECTORS.extend(self._saved)
 
     def test_no_injectors_returns_base_filter_unchanged(self) -> None:
-        # Empty registry: the helper is a no-op identity over
-        # the base filter (modulo ``flt_and(base)`` collapsing).
+        # Empty registry: ``apply_filter_injectors`` never
+        # enters its loop and returns ``base_flt`` as-is, with
+        # no ``dbase.flt_and`` call.
         base = {"sentinel": "base"}
         result = self._webutils.apply_filter_injectors(
             _StubFilterDB, base, "alice@example.com"
@@ -16383,9 +16384,9 @@ class WebFilterInjectorTests(unittest.TestCase):
         result = self._webutils.apply_filter_injectors(
             _StubFilterDB, base, "alice@example.com"
         )
-        # ``None`` short-circuits the AND; the base filter is
-        # returned unchanged (modulo any ``flt_and(base)``
-        # normalisation, which the stub backend does not apply).
+        # ``None`` short-circuits the AND for that injector,
+        # so the accumulator stays equal to ``base_flt`` and is
+        # returned as-is without any ``dbase.flt_and`` call.
         self.assertEqual(result, base)
 
     def test_multiple_injectors_chain_in_registration_order(self) -> None:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16313,9 +16313,13 @@ class WebFilterInjectorTests(unittest.TestCase):
     2. Registered injectors are called in registration order;
        their return value is AND'd into the base filter via
        ``dbase.flt_and`` unless the return value is ``None``.
-    3. An injector that raises is logged and skipped — a
-       misbehaving plugin must not turn every API request into
-       a 500.
+    3. Fail-closed on injector exception: an uncaught exception
+       is logged at ``ERROR`` level (with ``exc_info`` and the
+       failing injector's identity) and re-raised; later
+       injectors are *not* invoked. An authorization /
+       scoping plugin that wants graceful degradation must
+       catch its own failures and return a deny clause
+       (``dbase.searchnonexistent()``) itself.
     4. :func:`register_filter_injector` returns the registered
        callable unchanged so plugins can use it as a decorator.
     5. The hook is wired into :func:`get_init_flt_for` in a
@@ -16403,26 +16407,72 @@ class WebFilterInjectorTests(unittest.TestCase):
         self.assertEqual(order, ["first", "second"])
         self.assertEqual(result, {"base": True, "first": True, "second": True})
 
-    def test_injector_raising_is_logged_and_skipped(self) -> None:
+    def test_injector_raising_propagates_after_logging(self) -> None:
+        # Fail-closed contract: an uncaught exception in an
+        # authorization / scoping plugin means the plugin could
+        # not determine the scope it was supposed to enforce.
+        # Continuing would apply the bare base filter and fail
+        # open. The hook must therefore log loudly (ERROR level,
+        # ``exc_info``, failing injector identity) and re-raise
+        # the original exception; later injectors must not run.
+        later_calls: list[str] = []
+
         def _bad(_dbase: Any, _user: str | None) -> dict[str, Any]:
             raise RuntimeError("plugin crashed")
 
-        def _good(_dbase: Any, _user: str | None) -> dict[str, Any]:
-            return {"good": True}
+        def _later(_dbase: Any, _user: str | None) -> dict[str, Any]:
+            later_calls.append("later")
+            return {"later": True}
 
         self._webutils.register_filter_injector(_bad)
-        self._webutils.register_filter_injector(_good)
-        with self.assertLogs("ivre", level="WARNING") as captured:
-            result = self._webutils.apply_filter_injectors(
-                _StubFilterDB, {"base": True}, None
-            )
-        # The good injector still applied; the bad one was
-        # logged as a warning rather than propagated.
-        self.assertEqual(result, {"base": True, "good": True})
+        self._webutils.register_filter_injector(_later)
+        with self.assertLogs("ivre", level="ERROR") as captured:
+            with self.assertRaises(RuntimeError) as ctx:
+                self._webutils.apply_filter_injectors(
+                    _StubFilterDB, {"base": True}, None
+                )
+        self.assertEqual(str(ctx.exception), "plugin crashed")
+        # The injector registered after the failing one must
+        # not have been invoked -- the failure short-circuits
+        # the chain rather than skipping the bad injector and
+        # continuing.
+        self.assertEqual(later_calls, [])
+        # The log line names the failing injector (so an
+        # operator can identify the plugin in production logs)
+        # and is emitted at ERROR level.
         self.assertTrue(
             any("Filter injector" in msg for msg in captured.output),
             captured.output,
         )
+        self.assertTrue(
+            any("ERROR" in msg for msg in captured.output),
+            captured.output,
+        )
+
+    def test_injector_failure_fail_closed_plugin_pattern(self) -> None:
+        # Document, via test, the in-plugin pattern for graceful
+        # degradation: a plugin that wants to fall back to a
+        # deny-all clause on its own internal failure catches
+        # the exception itself and returns the backend's
+        # ``searchnonexistent()`` equivalent. The hook then
+        # composes that clause normally; nothing in core has to
+        # know about the policy.
+        def _scoping(dbase: Any, _user: str | None) -> dict[str, Any]:
+            try:
+                raise RuntimeError("IAM unreachable")
+            except RuntimeError:
+                # The stub backend doesn't ship
+                # ``searchnonexistent``; use a sentinel clause
+                # to stand in for the deny-all filter the real
+                # backends return.
+                _ = dbase  # would be ``dbase.searchnonexistent()``
+                return {"deny": True}
+
+        self._webutils.register_filter_injector(_scoping)
+        result = self._webutils.apply_filter_injectors(
+            _StubFilterDB, {"base": True}, "alice@example.com"
+        )
+        self.assertEqual(result, {"base": True, "deny": True})
 
     def test_register_filter_injector_returns_callable_for_decorator_use(
         self,

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -66,6 +66,7 @@ import unittest
 from ast import literal_eval
 from datetime import datetime, timezone
 from functools import reduce
+from typing import Any
 from unittest import mock
 from xml.sax.handler import (  # nosec B406  # used only as a no-op SAX event sink against the defusedxml-hardened parser
     ContentHandler,
@@ -16263,6 +16264,211 @@ class MongoDBNotesIndexTests(unittest.TestCase):
         # what we care about here.
         self.assertIsNotNone(notes)
         self.assertIsInstance(notes, DBNotes)
+
+
+# ---------------------------------------------------------------------
+# WebFilterInjectorTests -- pin the ``ivre.plugins.web.filter``
+# hook surfaced by :mod:`ivre.web.utils`. This is the in-tree
+# extension point that hosts out-of-tree authorization /
+# scoping plugins: the plugin registers a callable that returns
+# a backend filter clause, and the hook AND's it into every
+# base filter built by :func:`get_init_flt_for` (which every
+# Bottle route reaches via :func:`get_init_flt` /
+# :func:`flt_from_query`, and which the MCP server reaches via
+# :func:`_parse`).
+#
+# These tests pin the contract end-to-end against a minimal
+# stub backend so any out-of-tree authorization plugin can rely
+# on it without an integration environment.
+# ---------------------------------------------------------------------
+
+
+class _StubFilterDB:
+    """Minimal stub of the DB interface needed by the
+    filter-injection hook tests.  Supports ``flt_empty`` and
+    ``flt_and`` only; filters are plain dicts so assertions on
+    the resulting shape stay readable."""
+
+    flt_empty: dict[str, Any] = {}
+
+    @staticmethod
+    def flt_and(*args: Any) -> dict[str, Any]:
+        merged: dict[str, Any] = {}
+        for arg in args:
+            if isinstance(arg, dict):
+                merged.update(arg)
+        return merged
+
+
+class WebFilterInjectorTests(unittest.TestCase):
+    """Behaviour-pin for the ``ivre.plugins.web.filter`` hook
+    in :mod:`ivre.web.utils`.
+
+    The hook is a list of callables (:data:`FILTER_INJECTORS`)
+    that :func:`get_init_flt_for` invokes via
+    :func:`apply_filter_injectors`. The contract pinned here:
+
+    1. With no registered injector, :func:`get_init_flt_for`
+       returns the legacy base filter unchanged.
+    2. Registered injectors are called in registration order;
+       their return value is AND'd into the base filter via
+       ``dbase.flt_and`` unless the return value is ``None``.
+    3. An injector that raises is logged and skipped — a
+       misbehaving plugin must not turn every API request into
+       a 500.
+    4. :func:`register_filter_injector` returns the registered
+       callable unchanged so plugins can use it as a decorator.
+    5. The hook is wired into :func:`get_init_flt_for` in a
+       single exit point, so every entry point that resolves a
+       per-user base filter (Bottle, MCP, direct callers) sees
+       the injection.
+    """
+
+    def setUp(self) -> None:
+        from ivre.web import utils as webutils
+
+        self._webutils = webutils
+        # Snapshot the registry so tests are isolated from each
+        # other and from any real plugin that an operator may
+        # have installed in the test environment.
+        self._saved = list(webutils.FILTER_INJECTORS)
+        webutils.FILTER_INJECTORS.clear()
+
+    def tearDown(self) -> None:
+        self._webutils.FILTER_INJECTORS.clear()
+        self._webutils.FILTER_INJECTORS.extend(self._saved)
+
+    def test_no_injectors_returns_base_filter_unchanged(self) -> None:
+        # Empty registry: the helper is a no-op identity over
+        # the base filter (modulo ``flt_and(base)`` collapsing).
+        base = {"sentinel": "base"}
+        result = self._webutils.apply_filter_injectors(
+            _StubFilterDB, base, "alice@example.com"
+        )
+        self.assertEqual(result, base)
+
+    def test_registered_injector_clause_is_anded(self) -> None:
+        calls: list[tuple[Any, str | None]] = []
+
+        def _injector(dbase: Any, user: "str | None") -> dict[str, Any]:
+            calls.append((dbase, user))
+            return {"scope": "restricted"}
+
+        self._webutils.register_filter_injector(_injector)
+        base = {"sentinel": "base"}
+        result = self._webutils.apply_filter_injectors(
+            _StubFilterDB, base, "alice@example.com"
+        )
+        self.assertEqual(calls, [(_StubFilterDB, "alice@example.com")])
+        self.assertEqual(result, {"sentinel": "base", "scope": "restricted"})
+
+    def test_injector_returning_none_is_skipped(self) -> None:
+        def _injector(_dbase: Any, _user: "str | None") -> None:
+            return None
+
+        self._webutils.register_filter_injector(_injector)
+        base = {"sentinel": "base"}
+        result = self._webutils.apply_filter_injectors(
+            _StubFilterDB, base, "alice@example.com"
+        )
+        # ``None`` short-circuits the AND; the base filter is
+        # returned unchanged (modulo any ``flt_and(base)``
+        # normalisation, which the stub backend does not apply).
+        self.assertEqual(result, base)
+
+    def test_multiple_injectors_chain_in_registration_order(self) -> None:
+        order: list[str] = []
+
+        def _first(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+            order.append("first")
+            return {"first": True}
+
+        def _second(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+            order.append("second")
+            return {"second": True}
+
+        self._webutils.register_filter_injector(_first)
+        self._webutils.register_filter_injector(_second)
+        result = self._webutils.apply_filter_injectors(
+            _StubFilterDB, {"base": True}, None
+        )
+        self.assertEqual(order, ["first", "second"])
+        self.assertEqual(result, {"base": True, "first": True, "second": True})
+
+    def test_injector_raising_is_logged_and_skipped(self) -> None:
+        def _bad(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+            raise RuntimeError("plugin crashed")
+
+        def _good(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+            return {"good": True}
+
+        self._webutils.register_filter_injector(_bad)
+        self._webutils.register_filter_injector(_good)
+        with self.assertLogs("ivre", level="WARNING") as captured:
+            result = self._webutils.apply_filter_injectors(
+                _StubFilterDB, {"base": True}, None
+            )
+        # The good injector still applied; the bad one was
+        # logged as a warning rather than propagated.
+        self.assertEqual(result, {"base": True, "good": True})
+        self.assertTrue(
+            any("Filter injector" in msg for msg in captured.output),
+            captured.output,
+        )
+
+    def test_register_filter_injector_returns_callable_for_decorator_use(
+        self,
+    ) -> None:
+        def _injector(_dbase: Any, _user: "str | None") -> None:
+            return None
+
+        returned = self._webutils.register_filter_injector(_injector)
+        self.assertIs(returned, _injector)
+        self.assertIn(_injector, self._webutils.FILTER_INJECTORS)
+
+    def test_get_init_flt_for_applies_injectors(self) -> None:
+        # End-to-end pin: :func:`get_init_flt_for` is the single
+        # entry point every code path goes through (Bottle via
+        # :func:`get_init_flt`, MCP via ``_parse``). Registering
+        # an injector must therefore land in the base filter for
+        # every consumer for free.
+        captured: list[tuple[Any, str | None]] = []
+
+        def _injector(dbase: Any, user: "str | None") -> dict[str, Any]:
+            captured.append((dbase, user))
+            return {"scope": "restricted"}
+
+        self._webutils.register_filter_injector(_injector)
+        # Bypass the WEB_INIT_QUERIES dispatch by stubbing the
+        # internal resolver; we only care that the hook fires on
+        # the returned value here.
+        with mock.patch.object(
+            self._webutils, "_resolve_init_flt", return_value={"base": True}
+        ):
+            result = self._webutils.get_init_flt_for("alice@example.com", _StubFilterDB)
+        self.assertEqual(captured, [(_StubFilterDB, "alice@example.com")])
+        self.assertEqual(result, {"base": True, "scope": "restricted"})
+
+    def test_get_init_flt_for_with_no_injectors_returns_resolver_output(
+        self,
+    ) -> None:
+        # Mirror of the previous test on the empty-registry path:
+        # ``get_init_flt_for`` must be a no-op on top of the
+        # legacy resolver when no plugin is installed (regression
+        # gate against accidental wrapping that alters the shape).
+        with mock.patch.object(
+            self._webutils, "_resolve_init_flt", return_value={"base": True}
+        ):
+            result = self._webutils.get_init_flt_for(None, _StubFilterDB)
+        self.assertEqual(result, {"base": True})
+
+    def test_web_filter_plugin_category_is_registered(self) -> None:
+        # The ``web.filter`` category must be discoverable via
+        # :func:`ivre.plugins.list_plugins` so operators can see
+        # whether a filter plugin is loaded on their deployment.
+        from ivre import plugins as ivre_plugins
+
+        self.assertIn("web.filter", ivre_plugins.CATEGORIES)
 
 
 def _parse_args() -> None:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16350,7 +16350,7 @@ class WebFilterInjectorTests(unittest.TestCase):
     def test_registered_injector_clause_is_anded(self) -> None:
         calls: list[tuple[Any, str | None]] = []
 
-        def _injector(dbase: Any, user: "str | None") -> dict[str, Any]:
+        def _injector(dbase: Any, user: str | None) -> dict[str, Any]:
             calls.append((dbase, user))
             return {"scope": "restricted"}
 
@@ -16363,7 +16363,7 @@ class WebFilterInjectorTests(unittest.TestCase):
         self.assertEqual(result, {"sentinel": "base", "scope": "restricted"})
 
     def test_injector_returning_none_is_skipped(self) -> None:
-        def _injector(_dbase: Any, _user: "str | None") -> None:
+        def _injector(_dbase: Any, _user: str | None) -> None:
             return None
 
         self._webutils.register_filter_injector(_injector)
@@ -16379,11 +16379,11 @@ class WebFilterInjectorTests(unittest.TestCase):
     def test_multiple_injectors_chain_in_registration_order(self) -> None:
         order: list[str] = []
 
-        def _first(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+        def _first(_dbase: Any, _user: str | None) -> dict[str, Any]:
             order.append("first")
             return {"first": True}
 
-        def _second(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+        def _second(_dbase: Any, _user: str | None) -> dict[str, Any]:
             order.append("second")
             return {"second": True}
 
@@ -16396,10 +16396,10 @@ class WebFilterInjectorTests(unittest.TestCase):
         self.assertEqual(result, {"base": True, "first": True, "second": True})
 
     def test_injector_raising_is_logged_and_skipped(self) -> None:
-        def _bad(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+        def _bad(_dbase: Any, _user: str | None) -> dict[str, Any]:
             raise RuntimeError("plugin crashed")
 
-        def _good(_dbase: Any, _user: "str | None") -> dict[str, Any]:
+        def _good(_dbase: Any, _user: str | None) -> dict[str, Any]:
             return {"good": True}
 
         self._webutils.register_filter_injector(_bad)
@@ -16419,7 +16419,7 @@ class WebFilterInjectorTests(unittest.TestCase):
     def test_register_filter_injector_returns_callable_for_decorator_use(
         self,
     ) -> None:
-        def _injector(_dbase: Any, _user: "str | None") -> None:
+        def _injector(_dbase: Any, _user: str | None) -> None:
             return None
 
         returned = self._webutils.register_filter_injector(_injector)
@@ -16434,7 +16434,7 @@ class WebFilterInjectorTests(unittest.TestCase):
         # every consumer for free.
         captured: list[tuple[Any, str | None]] = []
 
-        def _injector(dbase: Any, user: "str | None") -> dict[str, Any]:
+        def _injector(dbase: Any, user: str | None) -> dict[str, Any]:
             captured.append((dbase, user))
             return {"scope": "restricted"}
 

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16328,9 +16328,17 @@ class WebFilterInjectorTests(unittest.TestCase):
         from ivre.web import utils as webutils
 
         self._webutils = webutils
-        # Snapshot the registry so tests are isolated from each
-        # other and from any real plugin that an operator may
-        # have installed in the test environment.
+        # Snapshot and clear the registry so each test sees a
+        # known-empty :data:`FILTER_INJECTORS` and so a real
+        # plugin installed in the test environment cannot leak
+        # callables into our assertions.  Note that this only
+        # isolates the *registry*: ``ivre.web.utils`` calls
+        # ``load_plugins("ivre.plugins.web.filter", globals())``
+        # at module import time, so any installed plugin's
+        # ``_install_<name>(scope)`` has already run by the time
+        # this ``setUp`` executes -- side effects performed
+        # outside the registry (config reads, network calls,
+        # imports, ...) are not undone here.
         self._saved = list(webutils.FILTER_INJECTORS)
         webutils.FILTER_INJECTORS.clear()
 


### PR DESCRIPTION
Add an in-tree extension point so out-of-tree plugins can layer deployment-specific authorization / scoping on top of every web query without requiring core changes.

Mechanism

- New ``FILTER_INJECTORS`` registry on ``ivre/web/utils.py``, fed by the existing ``ivre.plugins.<category>`` entry-point mechanism (same pattern as ``ivre.plugins.db.*``, ``ivre.plugins.tools``, ``ivre.plugins.view``, …). Adds ``"web.filter"`` to ``ivre.plugins.CATEGORIES`` so loaded plugins are discoverable via ``ivre.plugins.list_plugins()``.
- ``register_filter_injector(func)`` -- public helper, returns the callable unchanged so plugins can use it as a decorator or call it directly from an ``_install_<name>(scope)`` entry point.
- ``apply_filter_injectors(dbase, base_flt, user)`` -- composes every registered injector on top of ``base_flt`` via ``dbase.flt_and``. Injectors are called in registration order; a ``None`` return is skipped; an exception is logged via ``ivre.utils.LOGGER.error`` and propagated so that it creates a 500 error.
- ``get_init_flt_for(user, dbase)`` refactored to a single exit point: the legacy ``WEB_INIT_QUERIES`` dispatch is factored out into ``_resolve_init_flt``, and the public entry point wraps the result with ``apply_filter_injectors``. This means every consumer of the per-user base filter -- Bottle routes via ``get_init_flt`` / ``flt_from_query``, the MCP server's ``_parse``, direct callers -- picks up the injection for free, with no per-route plumbing.

Contract

A plugin's ``_install_<name>(scope)`` calls
``scope['register_filter_injector'](injector)`` (or imports the helper directly). The ``injector(dbase, user)`` callable reads the authenticated identity passed in (or anything else it pulls from the request, the auth backend, an external IAM, …) and returns:

- ``None`` -- no clause for this ``(dbase, user)`` pair, or
- a backend filter object -- AND'd into the user's base filter before any user-supplied query is applied.

Tests

``WebFilterInjectorTests`` in ``tests/tests_no_backend.py`` pins the contract end-to-end against a minimal stub backend (no DB connection required):

- empty registry returns the base filter unchanged;
- a registered injector's clause is AND'd in;
- ``None`` returns are skipped;
- multiple injectors fire in registration order;
- an injector that raises is logged + skipped (other injectors still apply);
- ``register_filter_injector`` returns the callable unchanged for decorator use;
- ``get_init_flt_for`` invokes the hook on top of the resolved base filter, and is a no-op identity over the resolver when no plugin is installed;
- the ``web.filter`` category is registered in ``ivre.plugins.CATEGORIES``.

Lint / type checks

black / flake8 / bandit / mypy / codespell / isort / pylint clean on the touched files; ``pkg/runchecks`` regressions (``func.count`` not-callable on ``ivre/db/sql/``) are pre-existing and unrelated.