### PR TITLE
feat(db): DBAudit append-only audit log (Mongo + SQL)

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -42,6 +42,16 @@ DB_DATA = None  # specific: maxmind:///<ivre_share_path>/geoip
 # purpose is independent of every data purpose: ``view --init``,
 # ``nmap --init`` etc. do not touch notes.
 DB_NOTES = None
+# DB URL for the ``audit`` purpose (append-only audit log of
+# uploads, admin actions, and oversized queries).  Falls back to
+# ``DB`` when unset.  The ``audit`` purpose is independent of
+# every other purpose; ``view --init``, ``nmap --init`` etc. do
+# not touch audit events.  Retention is operator-driven (no TTL
+# by default); a dedicated CLI verb purges entries older than a
+# cutoff.  The web / CLI / MCP surfaces consuming this purpose
+# land in follow-up PRs; the storage layer ships first so the
+# ABC contract is reviewable in isolation.
+DB_AUDIT = None
 # Begin batch sizes
 LOCAL_BATCH_SIZE = 10000  # used with --local-bulk
 MONGODB_BATCH_SIZE = 100
@@ -536,6 +546,16 @@ if DB_DATA is None and GEOIP_PATH is not None:
 # DB_NOTES explicitly to move notes to a separate store.
 if DB_NOTES is None:
     DB_NOTES = DB
+
+
+# Audit log defaults to the same store as everything else
+# (operators get a working ``db.audit`` out of the box).
+# Override DB_AUDIT explicitly to direct the audit stream to a
+# dedicated store -- typical compliance setups point this at a
+# write-restricted PostgreSQL with WORM-style append controls
+# while keeping the rest of IVRE on Mongo.
+if DB_AUDIT is None:
+    DB_AUDIT = DB
 
 
 if DATA_PATH is None:

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -6337,9 +6337,20 @@ class DBAudit(DB):
         try:
             return uuid.UUID(event_id).hex
         except (AttributeError, TypeError, ValueError) as exc:
+            # The error message enumerates every textual form
+            # :class:`uuid.UUID` actually accepts so a caller
+            # who hits the reject path knows which spellings
+            # are legal (and which are not): the 32-char hex,
+            # the 36-char hex-with-dashes, the brace-wrapped
+            # ``{...}`` form, and the RFC 4122 ``urn:uuid:...``
+            # prefixed form.  Keeping the message in sync with
+            # the parser avoids the false impression that only
+            # the two "canonical" spellings work.
             raise ValueError(
-                f"event_id must be a UUID hex string (32-char no-dashes "
-                f"or 36-char with-dashes form); got {event_id!r}"
+                f"event_id must be a UUID textual form accepted by "
+                f"uuid.UUID() (32-char hex, 36-char hex-with-dashes, "
+                f"brace-wrapped ``{{...}}``, or ``urn:uuid:...``); "
+                f"got {event_id!r}"
             ) from exc
 
     def record(

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -6209,6 +6209,194 @@ class DBNotes(DB):
         raise NotImplementedError
 
 
+class AuditWriteError(Exception):
+    """Raised by :meth:`DBAudit.record` when the backend write
+    fails (Mongo ``PyMongoError``, SQLAlchemy ``SQLAlchemyError``,
+    ...).
+
+    Unlike :class:`NoteAlreadyExists` / :class:`NoteConcurrencyError`
+    et al. on :class:`DBNotes` (which subclass :class:`ValueError`
+    because notes' best-effort revisions log can survive a missed
+    audit row), this is a top-level :class:`Exception` so the
+    caller is forced to choose explicitly whether to swallow it.
+    The audit log's contract is fail-loud: an unrecorded event
+    is worse than a failed request, so the default web/handler
+    path lets this propagate to ``HTTP 500`` rather than masking
+    it.
+    """
+
+
+class DBAudit(DB):
+    """Append-only audit log.
+
+    Captures three event categories surfaced by the web layer:
+
+    * ``upload`` -- writes against ``post_nmap`` / ``post_flow`` /
+      ``post_flow_cleanup`` (``ivre/web/app.py``).
+    * ``admin_action`` -- mutations under ``/cgi/auth/admin/*``
+      (`admin_update_user`, `admin_delete_api_key`, ...).
+    * ``oversize_query`` -- reads whose underlying result count
+      exceeds the operator-set threshold (consumed by a future
+      decorator in PR 2; this storage layer only declares the
+      type).
+
+    The hook decorator / route plumbing / read API / CLI / MCP
+    surfaces all land in follow-up PRs; this purpose ships the
+    storage contract first so the schema is reviewable in
+    isolation.  Retention is operator-driven: there is no
+    default TTL, and :meth:`purge_older_than` is the explicit
+    sweep verb the future CLI invokes.
+
+    Insert-failure model: fail-loud.  See
+    :class:`AuditWriteError`.
+    """
+
+    EVENT_TYPES: tuple[str, ...] = (
+        "upload",
+        "admin_action",
+        "oversize_query",
+    )
+
+    backends = {
+        "mongodb": ("mongo", "MongoDBAudit"),
+        "postgresql": ("sql.postgres", "PostgresDBAudit"),
+        "duckdb": ("sql.duckdb", "DuckDBAudit"),
+        # Other backends inherit ``NotImplementedError`` from
+        # this base for v1.
+    }
+
+    @staticmethod
+    def _validate_event_type(event_type: str) -> None:
+        """Raise :class:`ValueError` if ``event_type`` is not a
+        member of :attr:`EVENT_TYPES`.
+
+        The enum is intentionally strict at the ABC level: a
+        new category requires an explicit
+        :attr:`EVENT_TYPES` extension, which surfaces as a
+        compile-time signal in code review and prevents typos
+        from silently creating a new category that no
+        downstream filter knows about.
+        """
+        if event_type not in DBAudit.EVENT_TYPES:
+            raise ValueError(
+                f"unknown event_type {event_type!r}; expected one of "
+                f"{list(DBAudit.EVENT_TYPES)}"
+            )
+
+    @staticmethod
+    def _validate_details(details: Any) -> None:
+        """Raise :class:`ValueError` if ``details`` is not
+        ``None`` and not JSON-serializable.
+
+        Caught at the ABC so a caller that passes a
+        ``datetime`` / ``set`` / custom object surfaces the
+        problem at insert time with a clear error rather than
+        at SQL JSON-serialization time (or worse, at later
+        read time on a Mongo backend that happily stored the
+        BSON-but-not-JSON value).  The default ``json.dumps``
+        encoder is sufficient: any value the rest of IVRE
+        emits to JSON via stdlib ``json`` will serialize here.
+        """
+        if details is None:
+            return
+        if not isinstance(details, dict):
+            raise ValueError(
+                f"details must be a dict (or None), got " f"{type(details).__name__}"
+            )
+        try:
+            json.dumps(details)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"details is not JSON-serializable: {exc}") from exc
+
+    def record(
+        self,
+        event_type: str,
+        *,
+        actor: dict[str, Any] | None = None,
+        resource: dict[str, Any] | None = None,
+        details: dict[str, Any] | None = None,
+        outcome: int | None = None,
+        event_id: str | None = None,
+    ) -> str:
+        """Append one event to the audit log.
+
+        ``event_type`` must be a member of :attr:`EVENT_TYPES`
+        (validated via :meth:`_validate_event_type`).
+        ``actor`` / ``resource`` / ``details`` are dicts whose
+        shape is event-type-specific; ``details`` is validated
+        as JSON-serializable via :meth:`_validate_details`.
+        ``outcome`` is the HTTP status code (or ``None`` for
+        non-HTTP callers).
+
+        ``event_id``: 32-char UUID hex (no dashes).  Auto-
+        generated via ``uuid.uuid4().hex`` when not supplied;
+        callers (e.g. cross-system correlation) may supply
+        their own.  The returned value is the event_id of the
+        persisted row.
+
+        Fail-loud on backend write failure: raises
+        :class:`AuditWriteError` chained to the underlying
+        backend exception.  The caller (typically a Bottle
+        route) lets the exception propagate to ``HTTP 500``;
+        silently swallowing it would defeat the purpose of an
+        audit trail.
+        """
+        raise NotImplementedError
+
+    def query(
+        self,
+        *,
+        event_type: str | None = None,
+        user_email: str | None = None,
+        since: Any | None = None,
+        until: Any | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List audit events matching the filter.
+
+        All filter kwargs are AND'd.  Results are returned
+        newest-first (descending ``created_at``).  ``limit`` /
+        ``skip`` are applied at the backend layer.  Returns a
+        list of dicts in the same shape :meth:`record`
+        persisted.
+        """
+        raise NotImplementedError
+
+    def count(
+        self,
+        *,
+        event_type: str | None = None,
+        user_email: str | None = None,
+        since: Any | None = None,
+        until: Any | None = None,
+    ) -> int:
+        """Count audit events matching the filter.  Same
+        kwargs as :meth:`query` minus pagination.
+        """
+        raise NotImplementedError
+
+    def purge_older_than(self, cutoff: Any) -> int:
+        """Remove every audit event with ``created_at < cutoff``.
+
+        Returns the number of rows deleted.  The operator-
+        driven retention verb invoked by the future
+        ``ivre auditcli --purge-older-than`` CLI; no
+        automatic TTL runs on the table.
+        """
+        raise NotImplementedError
+
+    def get(self, spec: Any, **kargs: Any) -> Iterable[dict[str, Any]]:
+        """Low-level: iterate raw storage-layer documents
+        matching ``spec`` (a backend-native filter).  Mirrors
+        :meth:`DBNotes.get`'s contract -- the convenience
+        :meth:`query` / :meth:`count` methods are the public
+        API; this escape hatch surfaces the storage-layer
+        fields verbatim for tooling that needs them.
+        """
+        raise NotImplementedError
+
+
 class DBAuth(DB):
     """Backend-independent code to handle authentication"""
 
@@ -6464,6 +6652,7 @@ class MetaDB:
         "rir": DBRir,
         "flow": DBFlow,
         "auth": DBAuth,
+        "audit": DBAudit,
         "notes": DBNotes,
     }
 
@@ -6472,7 +6661,7 @@ class MetaDB:
         self.urls = urls or {}
 
     def close(self):
-        for attr in ["nmap", "passive", "data", "flow", "view", "notes"]:
+        for attr in ["nmap", "passive", "data", "flow", "view", "notes", "audit"]:
             try:
                 getattr(self, f"_{attr}").close()
             except AttributeError:
@@ -6555,6 +6744,16 @@ class MetaDB:
             )
         self._auth = self.get_class("auth")
         return self._auth
+
+    @property
+    def audit(self):
+        try:
+            # pylint: disable=access-member-before-definition
+            return self._audit
+        except AttributeError:
+            pass
+        self._audit = self.get_class("audit")
+        return self._audit
 
     @property
     def notes(self):

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -33,6 +33,7 @@ import socket
 import struct
 import sys
 import time
+import uuid
 from argparse import ArgumentParser
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
@@ -6307,6 +6308,39 @@ class DBAudit(DB):
             json.dumps(details)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"details is not JSON-serializable: {exc}") from exc
+
+    @staticmethod
+    def _normalize_event_id(event_id: str | None) -> str:
+        """Return the canonical 32-char hex ``event_id``.
+
+        Generates a fresh UUID v4 when ``event_id`` is
+        ``None``.  Otherwise validates the caller-supplied
+        value via :class:`uuid.UUID`, which accepts every
+        standard textual form (32-char hex, 36-char with
+        dashes, ``urn:uuid:...`` prefix, ``{...}`` braced
+        form) and rejects anything else with a clear
+        :class:`ValueError`.  The return value is always the
+        dashes-less 32-char hex form -- the on-disk shape every
+        backend stores.
+
+        Centralised at the ABC level so the contract documented
+        on :meth:`record` is enforced on every backend.  Without
+        this, the SQL backend's native ``Uuid`` column type
+        rejects malformed IDs at insert time (good), but Mongo
+        happily accepts arbitrary strings (bad), and SQL
+        dialects falling back to ``CHAR(32)`` accept anything
+        that fits in 32 chars (worse).  Catching the bad value
+        here makes the failure mode uniform across backends.
+        """
+        if event_id is None:
+            return uuid.uuid4().hex
+        try:
+            return uuid.UUID(event_id).hex
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"event_id must be a UUID hex string (32-char no-dashes "
+                f"or 36-char with-dashes form); got {event_id!r}"
+            ) from exc
 
     def record(
         self,

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -6287,16 +6287,26 @@ class DBAudit(DB):
     @staticmethod
     def _validate_details(details: Any) -> None:
         """Raise :class:`ValueError` if ``details`` is not
-        ``None`` and not JSON-serializable.
+        ``None`` and not strict-JSON-serializable.
 
         Caught at the ABC so a caller that passes a
         ``datetime`` / ``set`` / custom object surfaces the
         problem at insert time with a clear error rather than
         at SQL JSON-serialization time (or worse, at later
         read time on a Mongo backend that happily stored the
-        BSON-but-not-JSON value).  The default ``json.dumps``
-        encoder is sufficient: any value the rest of IVRE
-        emits to JSON via stdlib ``json`` will serialize here.
+        BSON-but-not-JSON value).
+
+        ``allow_nan=False`` makes :func:`json.dumps` reject
+        ``NaN`` / ``Infinity`` / ``-Infinity`` floats.  The
+        stdlib default (``allow_nan=True``) emits the literal
+        tokens ``NaN`` / ``Infinity`` / ``-Infinity``, which
+        are **not** part of RFC 8259 JSON: strict consumers
+        (any standards-conformant JSON parser, ``JSON`` /
+        ``JSONB`` column types on some SQL dialects, every
+        downstream non-Python consumer of the audit log) will
+        choke on them.  Rejecting them here keeps the
+        cross-backend storage shape strict-JSON-clean and the
+        Mongo / SQL writes interchangeable.
         """
         if details is None:
             return
@@ -6305,7 +6315,7 @@ class DBAudit(DB):
                 f"details must be a dict (or None), got " f"{type(details).__name__}"
             )
         try:
-            json.dumps(details)
+            json.dumps(details, allow_nan=False)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"details is not JSON-serializable: {exc}") from exc
 

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -8498,12 +8498,33 @@ class MongoDBAudit(MongoDB, DBAudit):
         self._validate_details(details)
         if event_id is None:
             event_id = uuid.uuid4().hex
+        # Normalise ``actor`` / ``resource`` to the canonical
+        # key sets at write time so the on-disk shape matches
+        # the caller-visible shape every :class:`DBAudit`
+        # backend returns.  The SQL backend always reassembles
+        # the full key set from its individual columns
+        # (``actor_user_email`` etc., defaulting to ``None``
+        # when nullable columns are unset); Mongo does the same
+        # normalisation up front so a partial caller-supplied
+        # dict turns into the same shape on disk and on the
+        # ``query()`` / ``record()`` boundary.  Forensics
+        # expects ``audit.events`` documents to look like they
+        # did when written, not like a query-layer projection.
+        actor = actor or {}
+        resource = resource or {}
         doc = {
             "event_id": event_id,
             "event_type": event_type,
             "created_at": datetime.datetime.now(tz=datetime.timezone.utc),
-            "actor": actor or {},
-            "resource": resource or {},
+            "actor": {
+                "user_email": actor.get("user_email"),
+                "api_key_hash": actor.get("api_key_hash"),
+                "remote_addr": actor.get("remote_addr"),
+            },
+            "resource": {
+                "route": resource.get("route"),
+                "method": resource.get("method"),
+            },
             "details": details or {},
             "outcome": outcome,
         }
@@ -8511,7 +8532,7 @@ class MongoDBAudit(MongoDB, DBAudit):
             self.db[self.columns[self.column_audit_events]].insert_one(doc)
         except PyMongoError as exc:
             raise AuditWriteError(
-                f"failed to record audit event {event_id} " f"({event_type}): {exc}"
+                f"failed to record audit event {event_id} ({event_type}): {exc}"
             ) from exc
         return event_id
 
@@ -8579,10 +8600,17 @@ class MongoDBAudit(MongoDB, DBAudit):
             since=since,
             until=until,
         )
-        col = self.db[self.columns[self.column_audit_events]]
-        if not flt:
-            return col.estimated_document_count()
-        return col.count_documents(flt)
+        # Always use ``count_documents`` -- including for the
+        # empty filter.  The :class:`MongoDBNotes.count` pattern
+        # uses ``estimated_document_count`` as a fast path, but
+        # that returns the collection's metadata count, which
+        # lags behind the live state during chunk migrations /
+        # segment writes.  The SQL backend's ``count(*)`` is
+        # exact, and the audit log's contract is "tell me
+        # exactly how many events I have" for compliance /
+        # forensics; an approximation would silently diverge
+        # across backends.
+        return self.db[self.columns[self.column_audit_events]].count_documents(flt)
 
     def purge_older_than(self, cutoff):
         col = self.db[self.columns[self.column_audit_events]]

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -30,6 +30,7 @@ import re
 import socket
 import struct
 import time
+import uuid
 from collections import OrderedDict
 from copy import deepcopy
 from secrets import token_urlsafe
@@ -58,7 +59,9 @@ from ivre import config, flow, passive, utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
 from ivre.db import (
     DB,
+    AuditWriteError,
     DBActive,
+    DBAudit,
     DBAuth,
     DBFlow,
     DBFlowMeta,
@@ -8418,6 +8421,201 @@ class MongoDBNotes(MongoDB, DBNotes):
 
     def count_notes(self, entity_type=None):
         return self.count({} if entity_type is None else {"entity_type": entity_type})
+
+
+class MongoDBAudit(MongoDB, DBAudit):
+    """MongoDB backend for the ``audit`` purpose.
+
+    Stores audit events in a single append-only collection
+    ``audit_events`` keyed by ``event_id`` (UUID v4 hex, 32
+    chars).  Three indexes back the expected query patterns:
+
+    * ``(event_type ASC, created_at DESC)`` -- "show me the
+      last N upload events".
+    * ``(actor.user_email ASC, created_at DESC)`` -- "show me
+      what alice did".  Sparse because cookie-less /
+      REMOTE_USER-less callers leave the field unset.
+    * ``(created_at DESC)`` -- generic time-window scan.
+
+    Insert failures (``PyMongoError``) are wrapped in
+    :class:`AuditWriteError` and re-raised: the audit log is
+    fail-loud by design, consistent with the ABC contract.
+
+    There is **no TTL index** on this collection -- retention
+    is operator-driven via :meth:`purge_older_than`.  Adding a
+    TTL is a deliberate operator choice (a future
+    ``WEB_AUDIT_TTL_SECONDS`` knob would create it
+    conditionally at startup); shipping without one keeps
+    compliance setups defaulting to indefinite retention.
+    """
+
+    column_audit_events = 0
+
+    indexes: list[list[tuple[list[IndexKey], dict[str, Any]]]] = [
+        # audit_events
+        [
+            (
+                [
+                    ("event_type", pymongo.ASCENDING),
+                    ("created_at", pymongo.DESCENDING),
+                ],
+                {},
+            ),
+            (
+                [
+                    ("actor.user_email", pymongo.ASCENDING),
+                    ("created_at", pymongo.DESCENDING),
+                ],
+                {"sparse": True},
+            ),
+            ([("created_at", pymongo.DESCENDING)], {}),
+            # ``event_id`` is operator-supplied or auto-
+            # generated UUID hex; uniqueness is best-effort
+            # (caller-supplied collisions are a programming
+            # error, not a security one) so the index is plain
+            # ``unique=True`` -- a duplicate insert fails loud.
+            ([("event_id", pymongo.ASCENDING)], {"unique": True}),
+        ],
+    ]
+
+    def __init__(self, url):
+        super().__init__(url)
+        self.columns = [
+            self.params.pop("colname_audit_events", "audit_events"),
+        ]
+
+    def record(
+        self,
+        event_type,
+        *,
+        actor=None,
+        resource=None,
+        details=None,
+        outcome=None,
+        event_id=None,
+    ):
+        self._validate_event_type(event_type)
+        self._validate_details(details)
+        if event_id is None:
+            event_id = uuid.uuid4().hex
+        doc = {
+            "event_id": event_id,
+            "event_type": event_type,
+            "created_at": datetime.datetime.now(tz=datetime.timezone.utc),
+            "actor": actor or {},
+            "resource": resource or {},
+            "details": details or {},
+            "outcome": outcome,
+        }
+        try:
+            self.db[self.columns[self.column_audit_events]].insert_one(doc)
+        except PyMongoError as exc:
+            raise AuditWriteError(
+                f"failed to record audit event {event_id} " f"({event_type}): {exc}"
+            ) from exc
+        return event_id
+
+    def _build_query_filter(
+        self,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+    ):
+        """Shared filter builder for :meth:`query` and
+        :meth:`count`.  Returns a Mongo find-filter dict; keys
+        absent when the corresponding kwarg is ``None``.
+        """
+        flt: dict[str, Any] = {}
+        if event_type is not None:
+            self._validate_event_type(event_type)
+            flt["event_type"] = event_type
+        if user_email is not None:
+            flt["actor.user_email"] = user_email
+        if since is not None or until is not None:
+            created_at: dict[str, Any] = {}
+            if since is not None:
+                created_at["$gte"] = since
+            if until is not None:
+                created_at["$lt"] = until
+            flt["created_at"] = created_at
+        return flt
+
+    def query(
+        self,
+        *,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+        limit=None,
+        skip=None,
+    ):
+        flt = self._build_query_filter(
+            event_type=event_type,
+            user_email=user_email,
+            since=since,
+            until=until,
+        )
+        cursor = self.db[self.columns[self.column_audit_events]].find(flt)
+        cursor = cursor.sort([("created_at", pymongo.DESCENDING)])
+        if skip is not None and skip > 0:
+            cursor = cursor.skip(skip)
+        if limit is not None and limit > 0:
+            cursor = cursor.limit(limit)
+        return [self._present_event(doc) for doc in cursor]
+
+    def count(
+        self,
+        *,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+    ):
+        flt = self._build_query_filter(
+            event_type=event_type,
+            user_email=user_email,
+            since=since,
+            until=until,
+        )
+        col = self.db[self.columns[self.column_audit_events]]
+        if not flt:
+            return col.estimated_document_count()
+        return col.count_documents(flt)
+
+    def purge_older_than(self, cutoff):
+        col = self.db[self.columns[self.column_audit_events]]
+        result = col.delete_many({"created_at": {"$lt": cutoff}})
+        return result.deleted_count
+
+    def get(self, spec, **kargs):
+        cursor = self.db[self.columns[self.column_audit_events]].find(spec)
+        sort = kargs.pop("sort", None)
+        if sort is not None:
+            cursor = cursor.sort(sort)
+        skip = kargs.pop("skip", None)
+        if skip is not None and skip > 0:
+            cursor = cursor.skip(skip)
+        limit = kargs.pop("limit", None)
+        if limit is not None and limit > 0:
+            cursor = cursor.limit(limit)
+        for doc in cursor:
+            yield self._present_event(doc)
+
+    @staticmethod
+    def _present_event(doc):
+        """Strip Mongo's internal ``_id`` from a stored event
+        document before handing it to a caller.  Mirrors the
+        :meth:`MongoDBNotes._present_note` projection helper
+        in spirit: the ABC's contract is the caller-visible
+        shape, not the on-disk shape.
+        """
+        if doc is None:
+            return None
+        out = dict(doc)
+        out.pop("_id", None)
+        return out
 
 
 load_plugins("ivre.plugins.db.mongo", globals())

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -30,7 +30,6 @@ import re
 import socket
 import struct
 import time
-import uuid
 from collections import OrderedDict
 from copy import deepcopy
 from secrets import token_urlsafe
@@ -8496,8 +8495,7 @@ class MongoDBAudit(MongoDB, DBAudit):
     ):
         self._validate_event_type(event_type)
         self._validate_details(details)
-        if event_id is None:
-            event_id = uuid.uuid4().hex
+        event_id = self._normalize_event_id(event_id)
         # Normalise ``actor`` / ``resource`` to the canonical
         # key sets at write time so the on-disk shape matches
         # the caller-visible shape every :class:`DBAudit`
@@ -8578,12 +8576,20 @@ class MongoDBAudit(MongoDB, DBAudit):
             since=since,
             until=until,
         )
-        cursor = self.db[self.columns[self.column_audit_events]].find(flt)
-        cursor = cursor.sort([("created_at", pymongo.DESCENDING)])
+        # Route through :meth:`MongoDB._get_cursor` so the audit
+        # query inherits the shared cursor plumbing every other
+        # purpose uses -- in particular the
+        # ``MONGODB_QUERY_TIMEOUT_MS`` cap via
+        # :meth:`set_limits`.  Bypassing it (an earlier draft
+        # called ``.find().sort().skip().limit()`` directly)
+        # let audit queries run unbounded even when an operator
+        # had set a deployment-wide query timeout.
+        cargs: dict[str, Any] = {"sort": [("created_at", pymongo.DESCENDING)]}
         if skip is not None and skip > 0:
-            cursor = cursor.skip(skip)
+            cargs["skip"] = skip
         if limit is not None and limit > 0:
-            cursor = cursor.limit(limit)
+            cargs["limit"] = limit
+        cursor = self._get_cursor(self.columns[self.column_audit_events], flt, **cargs)
         return [self._present_event(doc) for doc in cursor]
 
     def count(
@@ -8618,16 +8624,13 @@ class MongoDBAudit(MongoDB, DBAudit):
         return result.deleted_count
 
     def get(self, spec, **kargs):
-        cursor = self.db[self.columns[self.column_audit_events]].find(spec)
-        sort = kargs.pop("sort", None)
-        if sort is not None:
-            cursor = cursor.sort(sort)
-        skip = kargs.pop("skip", None)
-        if skip is not None and skip > 0:
-            cursor = cursor.skip(skip)
-        limit = kargs.pop("limit", None)
-        if limit is not None and limit > 0:
-            cursor = cursor.limit(limit)
+        # Low-level escape hatch: route through
+        # :meth:`MongoDB._get_cursor` so the standard
+        # ``fields=`` / ``projection=`` handling, the
+        # text-sort sugar, and the
+        # ``MONGODB_QUERY_TIMEOUT_MS`` cap all apply --
+        # matching :meth:`MongoDBNotes.get`.
+        cursor = self._get_cursor(self.columns[self.column_audit_events], spec, **kargs)
         for doc in cursor:
             yield self._present_event(doc)
 

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -8432,8 +8432,16 @@ class MongoDBAudit(MongoDB, DBAudit):
     * ``(event_type ASC, created_at DESC)`` -- "show me the
       last N upload events".
     * ``(actor.user_email ASC, created_at DESC)`` -- "show me
-      what alice did".  Sparse because cookie-less /
-      REMOTE_USER-less callers leave the field unset.
+      what alice did".  Restricted via a
+      ``partialFilterExpression`` to events whose
+      ``actor.user_email`` is a string so anonymous /
+      REMOTE_USER-less events (which :meth:`record` normalises
+      to ``actor.user_email = None`` at write time) do not
+      bloat the index with a giant NULL bucket.  A plain
+      ``sparse: True`` would not work here -- ``sparse``
+      excludes documents where the indexed field is *missing*,
+      not those where it is *present-but-null*, and write-time
+      normalisation always materialises the key.
     * ``(created_at DESC)`` -- generic time-window scan.
 
     Insert failures (``PyMongoError``) are wrapped in
@@ -8465,7 +8473,23 @@ class MongoDBAudit(MongoDB, DBAudit):
                     ("actor.user_email", pymongo.ASCENDING),
                     ("created_at", pymongo.DESCENDING),
                 ],
-                {"sparse": True},
+                # ``partialFilterExpression`` (not ``sparse``)
+                # because :meth:`record` always writes
+                # ``actor.user_email`` -- as a string for
+                # authenticated callers, as ``None`` for
+                # anonymous ones.  ``sparse: True`` only skips
+                # documents where the field is *missing*; it
+                # would still index every anonymous event under
+                # a single NULL bucket, which is exactly what
+                # we want to avoid for an audit collection that
+                # may carry millions of anonymous reads.
+                # ``{"$type": "string"}`` matches every real
+                # email and rejects ``None`` / missing.
+                {
+                    "partialFilterExpression": {
+                        "actor.user_email": {"$type": "string"},
+                    },
+                },
             ),
             ([("created_at", pymongo.DESCENDING)], {}),
             # ``event_id`` is operator-supplied or auto-

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -7114,10 +7114,14 @@ class SQLDBAudit(SQLDB, DBAudit):
         # under both PostgreSQL and DuckDB; the duckdb-engine
         # dialect returns ``rowcount=-1`` for every DELETE
         # otherwise (same workaround used in
-        # :meth:`SQLDBAuth.delete_api_key`).
+        # :meth:`SQLDBAuth.delete_api_key`).  Count rows in a
+        # streaming fashion via ``sum(1 for _ in ...)`` rather
+        # than materialising the ``RETURNING`` result into a
+        # list: for a large purge the difference is one O(N)
+        # int allocation we can avoid for free.
         stmt = stmt.returning(self.tables.events.id)
         with self.db.begin() as conn:
-            return len(list(conn.execute(stmt)))
+            return sum(1 for _ in conn.execute(stmt))
 
     def get(self, spec, **kargs):
         # Low-level escape hatch.  The audit log's primary API

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -59,6 +59,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased
 
 from ivre import config
@@ -7002,8 +7003,7 @@ class SQLDBAudit(SQLDB, DBAudit):
     ):
         self._validate_event_type(event_type)
         self._validate_details(details)
-        if event_id is None:
-            event_id = uuid.uuid4().hex
+        event_id = self._normalize_event_id(event_id)
         actor = actor or {}
         resource = resource or {}
         values = {
@@ -7021,16 +7021,22 @@ class SQLDBAudit(SQLDB, DBAudit):
         try:
             with self.db.begin() as conn:
                 conn.execute(insert(self.tables.events).values(**values))
-        except Exception as exc:
-            # SQLAlchemy raises ``SQLAlchemyError``; we widen
-            # to ``Exception`` so dialect-driver-specific
-            # failures (psycopg2's ``OperationalError``, the
-            # duckdb driver's catalog errors, ...) are also
-            # caught and re-raised loudly through the audit
-            # contract rather than leaking driver-specific
-            # types.
+        except SQLAlchemyError as exc:
+            # ``SQLAlchemyError`` is the SA 2.x umbrella for
+            # every DBAPI driver failure: psycopg2 /
+            # duckdb-engine / etc. raise their own exception
+            # classes, but SA wraps them in
+            # ``sqlalchemy.exc.DBAPIError`` (a SQLAlchemyError
+            # subclass) with the driver-level exception
+            # available via ``.orig``.  Catching the umbrella
+            # keeps the fail-loud contract for any backend
+            # failure while letting genuine programming bugs
+            # (``TypeError``, ``AttributeError``, ...)
+            # propagate unwrapped so they surface as the bugs
+            # they are rather than as opaque
+            # ``AuditWriteError`` instances.
             raise AuditWriteError(
-                f"failed to record audit event {event_id} " f"({event_type}): {exc}"
+                f"failed to record audit event {event_id} ({event_type}): {exc}"
             ) from exc
         return event_id
 

--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -27,6 +27,7 @@ import datetime
 import hashlib
 import json
 import re
+import uuid
 from collections import namedtuple
 from collections.abc import Iterator
 from secrets import token_urlsafe
@@ -64,10 +65,22 @@ from ivre import config
 from ivre import flow as ivre_flow
 from ivre import utils, xmlnmap
 from ivre.active.nmap import ALIASES_TABLE_ELEMS
-from ivre.db import DB, DBActive, DBAuth, DBFlow, DBNmap, DBPassive, DBRir, DBView
+from ivre.db import (
+    DB,
+    AuditWriteError,
+    DBActive,
+    DBAudit,
+    DBAuth,
+    DBFlow,
+    DBNmap,
+    DBPassive,
+    DBRir,
+    DBView,
+)
 from ivre.db.sql import tables as tables_module
 from ivre.db.sql.tables import (
     RIR_FTS_COLUMNS,
+    AuditEvent,
     AuthApiKey,
     AuthMagicLink,
     AuthRateLimit,
@@ -6912,3 +6925,207 @@ class SQLDBAuth(SQLDB, DBAuth):
             conn.execute(
                 insert(self.tables.rate_limit).values(key=key, created_at=_now_utc())
             )
+
+
+class SQLDBAudit(SQLDB, DBAudit):
+    """SQL-backend base for the ``audit`` purpose.
+
+    Mirrors :class:`MongoDBAudit`.  Stores append-only events in
+    the ``audit_events`` table (see :class:`AuditEvent` for the
+    schema + indexes).  Insert failures wrap
+    :class:`SQLAlchemyError` in :class:`AuditWriteError`, matching
+    the fail-loud contract.
+
+    No dialect-specific subclass is needed yet; the statements
+    are portable SQL.  The ``PostgresDBAudit`` /
+    ``DuckDBAudit`` registrations in :class:`DBAudit.backends`
+    resolve to this same class via the dialect-flavoured
+    ``PostgresDB`` / ``DuckDB`` SQLDB subclasses (the multiple-
+    inheritance pattern used by every other SQL purpose).
+    """
+
+    table_layout = namedtuple("audit_layout", ["events"])
+    tables = table_layout(AuditEvent)
+
+    SCHEMA_VERSION = 1
+
+    @staticmethod
+    def _row2event(row):
+        """Project an :class:`AuditEvent` row into the dict
+        shape :class:`MongoDBAudit` returns.
+
+        ``event_id`` is normalised from SQLAlchemy's hex-with-
+        dashes ``str`` form to the dashes-less 32-char hex the
+        ABC contract speaks.  ``actor`` / ``resource`` /
+        ``details`` are reassembled into the nested dicts the
+        Mongo backend stores natively.
+        """
+        if row is None:
+            return None
+        # ``event_id`` may arrive as ``uuid.UUID`` (on dialects
+        # where SQLAlchemy's Uuid type returns native objects
+        # despite ``as_uuid=False``) or as ``str`` (with or
+        # without dashes depending on the dialect).  Normalise
+        # to the dashes-less hex form so callers see the same
+        # shape across backends.
+        raw_event_id = row.event_id
+        if isinstance(raw_event_id, uuid.UUID):
+            event_id = raw_event_id.hex
+        else:
+            event_id = str(raw_event_id).replace("-", "")
+        return {
+            "event_id": event_id,
+            "event_type": row.event_type,
+            "created_at": row.created_at,
+            "actor": {
+                "user_email": row.actor_user_email,
+                "api_key_hash": row.actor_api_key_hash,
+                "remote_addr": row.actor_remote_addr,
+            },
+            "resource": {
+                "route": row.resource_route,
+                "method": row.resource_method,
+            },
+            "details": row.details or {},
+            "outcome": row.outcome,
+        }
+
+    def record(
+        self,
+        event_type,
+        *,
+        actor=None,
+        resource=None,
+        details=None,
+        outcome=None,
+        event_id=None,
+    ):
+        self._validate_event_type(event_type)
+        self._validate_details(details)
+        if event_id is None:
+            event_id = uuid.uuid4().hex
+        actor = actor or {}
+        resource = resource or {}
+        values = {
+            "event_id": event_id,
+            "event_type": event_type,
+            "created_at": _now_utc(),
+            "actor_user_email": actor.get("user_email"),
+            "actor_api_key_hash": actor.get("api_key_hash"),
+            "actor_remote_addr": actor.get("remote_addr"),
+            "resource_route": resource.get("route"),
+            "resource_method": resource.get("method"),
+            "details": details or {},
+            "outcome": outcome,
+        }
+        try:
+            with self.db.begin() as conn:
+                conn.execute(insert(self.tables.events).values(**values))
+        except Exception as exc:
+            # SQLAlchemy raises ``SQLAlchemyError``; we widen
+            # to ``Exception`` so dialect-driver-specific
+            # failures (psycopg2's ``OperationalError``, the
+            # duckdb driver's catalog errors, ...) are also
+            # caught and re-raised loudly through the audit
+            # contract rather than leaking driver-specific
+            # types.
+            raise AuditWriteError(
+                f"failed to record audit event {event_id} " f"({event_type}): {exc}"
+            ) from exc
+        return event_id
+
+    def _build_query_stmt(
+        self,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+    ):
+        """Shared WHERE-clause builder for :meth:`query` and
+        :meth:`count`.  Returns a list of SQLAlchemy clauses
+        ready for ``and_(*clauses)``.
+        """
+        clauses = []
+        if event_type is not None:
+            self._validate_event_type(event_type)
+            clauses.append(self.tables.events.event_type == event_type)
+        if user_email is not None:
+            clauses.append(self.tables.events.actor_user_email == user_email)
+        if since is not None:
+            clauses.append(self.tables.events.created_at >= since)
+        if until is not None:
+            clauses.append(self.tables.events.created_at < until)
+        return clauses
+
+    def query(
+        self,
+        *,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+        limit=None,
+        skip=None,
+    ):
+        clauses = self._build_query_stmt(
+            event_type=event_type,
+            user_email=user_email,
+            since=since,
+            until=until,
+        )
+        stmt = select(self.tables.events)
+        if clauses:
+            stmt = stmt.where(and_(*clauses))
+        stmt = stmt.order_by(desc(self.tables.events.created_at))
+        if skip is not None and skip > 0:
+            stmt = stmt.offset(skip)
+        if limit is not None and limit > 0:
+            stmt = stmt.limit(limit)
+        with self.db.connect() as conn:
+            return [self._row2event(row) for row in conn.execute(stmt)]
+
+    def count(
+        self,
+        *,
+        event_type=None,
+        user_email=None,
+        since=None,
+        until=None,
+    ):
+        clauses = self._build_query_stmt(
+            event_type=event_type,
+            user_email=user_email,
+            since=since,
+            until=until,
+        )
+        # ``func.count()`` not-callable is a pre-existing
+        # pylint false positive on this codebase's SQLAlchemy
+        # 2.x usage (see ``ivre/db/sql/__init__.py:1355`` etc.);
+        # mirror the existing pattern.
+        stmt = select(func.count()).select_from(self.tables.events)
+        if clauses:
+            stmt = stmt.where(and_(*clauses))
+        with self.db.connect() as conn:
+            return conn.execute(stmt).scalar() or 0
+
+    def purge_older_than(self, cutoff):
+        stmt = delete(self.tables.events).where(self.tables.events.created_at < cutoff)
+        # ``DELETE ... RETURNING`` for an accurate row count
+        # under both PostgreSQL and DuckDB; the duckdb-engine
+        # dialect returns ``rowcount=-1`` for every DELETE
+        # otherwise (same workaround used in
+        # :meth:`SQLDBAuth.delete_api_key`).
+        stmt = stmt.returning(self.tables.events.id)
+        with self.db.begin() as conn:
+            return len(list(conn.execute(stmt)))
+
+    def get(self, spec, **kargs):
+        # Low-level escape hatch.  The audit log's primary API
+        # is :meth:`query` / :meth:`count`; ``get`` is provided
+        # for consistency with the ABC.  ``spec`` is ignored
+        # (Mongo-native filter shape does not translate to
+        # SQL); SQL callers should use :meth:`query` directly.
+        del spec, kargs
+        raise NotImplementedError(
+            "SQLDBAudit.get is not supported; use query() instead"
+        )

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -71,6 +71,7 @@ from sqlalchemy.dialects import postgresql
 from ivre import utils
 from ivre.db.sql import NmapFilter, ViewFilter
 from ivre.db.sql.postgres import (
+    PostgresDBAudit,
     PostgresDBAuth,
     PostgresDBFlow,
     PostgresDBNmap,
@@ -1121,4 +1122,17 @@ class DuckDBAuth(DuckDBMixin, PostgresDBAuth):
     handled by :class:`SQLDBAuth`'s shared helpers
     (:meth:`SQLDBAuth.delete_api_key` counts via ``DELETE
     ... RETURNING`` instead).
+    """
+
+
+class DuckDBAudit(DuckDBMixin, PostgresDBAudit):
+    """DuckDB backend for the ``audit`` purpose.
+
+    Pure inheritance from :class:`PostgresDBAudit`.  DuckDB
+    has native ``UUID`` support, so the ``event_id`` column
+    behaves identically to PostgreSQL.  The
+    :meth:`SQLDBAudit.purge_older_than` ``DELETE ...
+    RETURNING`` path already works around the
+    ``duckdb-engine`` ``cursor.rowcount = -1`` quirk that
+    affects every other DELETE on this backend.
     """

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -2744,5 +2744,5 @@ class PostgresDBAudit(PostgresDB, SQLDBAudit):
     native ``uuid`` type (16-byte storage, type-safe at the DB
     layer with a server-side rejection of malformed UUIDs at
     insert time -- a defence-in-depth on top of
-    :meth:`DBAudit._validate_event_type`).
+    :meth:`DBAudit._normalize_event_id`).
     """

--- a/ivre/db/sql/postgres.py
+++ b/ivre/db/sql/postgres.py
@@ -64,6 +64,7 @@ from ivre.db.sql import (
     PassiveCSVFile,
     ScanCSVFile,
     SQLDBActive,
+    SQLDBAudit,
     SQLDBAuth,
     SQLDBFlow,
     SQLDBNmap,
@@ -2729,4 +2730,19 @@ class PostgresDBAuth(PostgresDB, SQLDBAuth):
     this initial PR.  Future column / index changes plug in
     via the established :meth:`SQLDB.migrate_schema`
     orchestrator the active / passive backends already use.
+    """
+
+
+class PostgresDBAudit(PostgresDB, SQLDBAudit):
+    """PostgreSQL backend for the ``audit`` purpose.
+
+    Pure inheritance over :class:`SQLDBAudit`: every helper
+    that class declares uses portable SQL (``DELETE ...
+    RETURNING`` for the purge sweep is supported natively on
+    PostgreSQL).  The ``event_id`` column uses
+    :class:`sqlalchemy.Uuid`, which compiles to PostgreSQL's
+    native ``uuid`` type (16-byte storage, type-safe at the DB
+    layer with a server-side rejection of malformed UUIDs at
+    insert time -- a defence-in-depth on top of
+    :meth:`DBAudit._validate_event_type`).
     """

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    Uuid,
     cast,
     column,
     func,
@@ -1125,4 +1126,92 @@ class AuthMagicLink(Base):
     __table_args__ = (
         UniqueConstraint("token_hash", name="auth_magic_link_idx_token_hash"),
         Index("auth_magic_link_idx_expires_at", "expires_at"),
+    )
+
+
+# ----- audit log -----------------------------------------------
+#
+# Field-length constants shared between :class:`AuditEvent`
+# columns.  ``_AUDIT_EVENT_TYPE_LEN`` accommodates every member
+# of :attr:`ivre.db.DBAudit.EVENT_TYPES`; ``_AUDIT_HASH_LEN``
+# matches :data:`_AUTH_HASH_LEN` so the SHA-256 hex of an API
+# key fits without truncation; ``_AUDIT_ROUTE_LEN`` covers the
+# longest Bottle route string IVRE ships
+# (``/<subdb:re:scans|view|passive|rir>/distinct/<field:path>``
+# is ~60 chars; 255 leaves generous headroom).
+_AUDIT_EVENT_TYPE_LEN = 32
+_AUDIT_HASH_LEN = 64
+_AUDIT_ROUTE_LEN = 255
+_AUDIT_METHOD_LEN = 8
+_AUDIT_REMOTE_ADDR_LEN = 45  # IPv6 textual form max
+
+_seq_audit_events_id = Sequence("seq_audit_events_id")
+
+
+class AuditEvent(Base):
+    """One append-only audit event.
+
+    Mirrors :class:`MongoDBAudit`'s ``audit_events`` collection.
+    ``event_id`` uses :class:`sqlalchemy.Uuid` (``as_uuid=False``)
+    so PostgreSQL and DuckDB get the native ``UUID`` column type
+    (16-byte storage, type-safe at the DB layer) while
+    SQL dialects without UUID support fall back to ``CHAR(32)``.
+    The ABC's caller-facing contract is the 32-char hex string,
+    consistent with the Mongo backend.
+
+    Three composite indexes match Mongo's query patterns:
+    ``(event_type, created_at DESC)`` for type-filtered scans,
+    ``(actor_user_email, created_at DESC)`` for per-user audit
+    trails, and a plain ``(created_at)`` for generic time
+    windows.  ``event_id`` is uniquely indexed; duplicate
+    inserts fail loud (matches the Mongo backend).
+
+    Retention is operator-driven; no TTL.
+    """
+
+    __tablename__ = "audit_events"
+    id = Column(
+        Integer,
+        _seq_audit_events_id,
+        server_default=_seq_audit_events_id.next_value(),
+        primary_key=True,
+    )
+    # ``as_uuid=False``: SQLAlchemy returns the value as a
+    # ``str`` (canonical hex-with-dashes form on the Python
+    # side; the backend dispatches to native UUID storage on
+    # dialects that support it).  The ABC normalises both
+    # representations to the dashes-less 32-char form on read.
+    event_id = Column(Uuid(as_uuid=False), nullable=False)
+    event_type = Column(String(_AUDIT_EVENT_TYPE_LEN), nullable=False)
+    created_at = Column(DateTime, nullable=False)
+    # Actor sub-fields: every one nullable because (a)
+    # anonymous / REMOTE_USER traffic has no user_email,
+    # (b) session-cookie callers carry no api_key_hash, and
+    # (c) non-HTTP callers (CLI / future MCP write tools)
+    # have no remote_addr.
+    actor_user_email = Column(String(_AUTH_EMAIL_LEN))
+    actor_api_key_hash = Column(String(_AUDIT_HASH_LEN))
+    actor_remote_addr = Column(String(_AUDIT_REMOTE_ADDR_LEN))
+    resource_route = Column(String(_AUDIT_ROUTE_LEN))
+    resource_method = Column(String(_AUDIT_METHOD_LEN))
+    # ``details`` is event-type-specific arbitrary JSON.  The
+    # ABC's :meth:`_validate_details` rejects non-JSON-
+    # serializable values at insert time so writes never blow
+    # up at SQL serialization.
+    details = Column(SQLJSONB)
+    # HTTP status code (or ``None`` for non-HTTP callers).
+    outcome = Column(Integer)
+    __table_args__ = (
+        UniqueConstraint("event_id", name="audit_events_idx_event_id"),
+        Index(
+            "audit_events_idx_type_created",
+            "event_type",
+            "created_at",
+        ),
+        Index(
+            "audit_events_idx_user_created",
+            "actor_user_email",
+            "created_at",
+        ),
+        Index("audit_events_idx_created", "created_at"),
     )

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -1160,11 +1160,19 @@ class AuditEvent(Base):
     consistent with the Mongo backend.
 
     Three composite indexes match Mongo's query patterns:
-    ``(event_type, created_at DESC)`` for type-filtered scans,
-    ``(actor_user_email, created_at DESC)`` for per-user audit
+    ``(event_type, created_at)`` for type-filtered scans,
+    ``(actor_user_email, created_at)`` for per-user audit
     trails, and a plain ``(created_at)`` for generic time
-    windows.  ``event_id`` is uniquely indexed; duplicate
-    inserts fail loud (matches the Mongo backend).
+    windows.  The SQLAlchemy ``Index(...)`` declarations below
+    do not encode a per-column sort order -- the Mongo
+    backend's matching indexes are ``DESC`` on ``created_at``,
+    but on SQL the analogous newest-first semantic is provided
+    by :meth:`SQLDBAudit.query` via ``ORDER BY created_at
+    DESC``, which both PostgreSQL and DuckDB can satisfy with
+    a plain b-tree index regardless of declared direction (the
+    planner reads it backwards as needed).  ``event_id`` is
+    uniquely indexed; duplicate inserts fail loud (matches the
+    Mongo backend).
 
     Retention is operator-driven; no TTL.
     """

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16465,7 +16465,7 @@ class DBAuditAbstractSurfaceTests(unittest.TestCase):
         from ivre.db import DB, DBAudit
 
         # Build a bare instance via ``object.__new__`` so we
-        # don't trip the :class:`DB` ``__init__`` (which
+        # don't trip the :class:`DB` ``__init__`` (which does
         # nothing for the ABC itself).
         instance = object.__new__(DBAudit)
         # ``DB.__init__`` is parameterless.
@@ -16526,11 +16526,24 @@ class MongoDBAuditIndexTests(unittest.TestCase):
             "missing event_id index",
         )
 
-    def test_audit_user_email_index_is_sparse(self) -> None:
-        # ``actor.user_email`` is nullable (anonymous /
-        # REMOTE_USER traffic), so the per-user composite must
-        # be sparse to avoid indexing every event with a NULL
-        # entry.
+    def test_audit_user_email_index_excludes_anonymous_events(self) -> None:
+        # ``actor.user_email`` is normalised to ``None`` at
+        # write time for anonymous / REMOTE_USER-less callers
+        # (see :meth:`MongoDBAudit.record`).  The per-user
+        # composite must therefore exclude those events via a
+        # ``partialFilterExpression`` rather than the obvious
+        # ``sparse: True`` flag: ``sparse`` only excludes
+        # documents where the indexed field is *missing*, but
+        # write-time normalisation always materialises the key
+        # (with a ``None`` value for anonymous events), so the
+        # sparse path would still index every anonymous event
+        # under a single NULL bucket.
+        #
+        # ``{"$type": "string"}`` matches every real email and
+        # rejects both ``None`` and missing entries -- pin the
+        # exact filter so a regression to ``sparse: True``
+        # (which silently no-ops under the new write-time
+        # normalisation contract) surfaces here.
         from ivre.db.mongo import MongoDBAudit
 
         block = MongoDBAudit.indexes[MongoDBAudit.column_audit_events]
@@ -16539,7 +16552,17 @@ class MongoDBAuditIndexTests(unittest.TestCase):
             for keys, opts in block
             if keys == [("actor.user_email", 1), ("created_at", -1)]
         )
-        self.assertTrue(user_idx.get("sparse"))
+        self.assertNotIn(
+            "sparse",
+            user_idx,
+            "actor.user_email index must not use sparse "
+            "(write-time normalisation defeats it); "
+            "use partialFilterExpression instead",
+        )
+        self.assertEqual(
+            user_idx.get("partialFilterExpression"),
+            {"actor.user_email": {"$type": "string"}},
+        )
 
     def test_audit_event_id_index_is_unique(self) -> None:
         from ivre.db.mongo import MongoDBAudit

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16444,6 +16444,30 @@ class DBAuditAbstractSurfaceTests(unittest.TestCase):
                     DBAudit._validate_details(bad)
                 self.assertIn("not JSON-serializable", str(ctx.exception))
 
+    def test_validate_details_rejects_non_finite_floats(self) -> None:
+        # ``json.dumps`` accepts ``NaN`` / ``Infinity`` /
+        # ``-Infinity`` by default (``allow_nan=True``) and
+        # emits the bare tokens ``NaN`` / ``Infinity`` /
+        # ``-Infinity`` -- which are NOT part of RFC 8259 JSON.
+        # The ABC's strict-JSON contract is what keeps the
+        # audit log interchangeable across Mongo / SQL / any
+        # standards-conformant downstream consumer; reject the
+        # non-finite floats at insert time rather than letting
+        # them slip through to a backend that may or may not
+        # accept the non-standard token.
+        from ivre.db import DBAudit
+
+        for bad in (
+            {"x": float("nan")},
+            {"x": float("inf")},
+            {"x": float("-inf")},
+            {"nested": {"y": float("nan")}},  # nested too
+        ):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    DBAudit._validate_details(bad)
+                self.assertIn("not JSON-serializable", str(ctx.exception))
+
     def test_audit_write_error_is_top_level_exception(self) -> None:
         # ``AuditWriteError`` is a top-level :class:`Exception`,
         # NOT a :class:`ValueError`.  The asymmetry with

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16328,13 +16328,13 @@ class MongoDBNotesIndexTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------
-# DBAuditTests / MongoDBAuditIndexTests / SQLDBAuditIndexTests
-# / SQLDBAuditLiveIntegrationTests -- backend-free pin tests
-# for the ``audit`` purpose (append-only audit log of uploads,
-# admin actions, and oversized queries).  Mirrors the
-# ``MongoDBNotesIndexTests`` block in spirit: ABC surface,
-# typed-exception class, Mongo schema + indexes, SQL schema +
-# indexes, and a DuckDB-driven integration block for
+# DBAuditAbstractSurfaceTests / MongoDBAuditIndexTests /
+# SQLDBAuditSchemaTests / SQLDBAuditLiveIntegrationTests --
+# backend-free pin tests for the ``audit`` purpose (append-only
+# audit log of uploads, admin actions, and oversized queries).
+# Mirrors the ``MongoDBNotesIndexTests`` block in spirit: ABC
+# surface, typed-exception class, Mongo schema + indexes, SQL
+# schema + indexes, and a DuckDB-driven integration block for
 # end-to-end behaviour of the SQL path.
 # ---------------------------------------------------------------------
 
@@ -16575,6 +16575,54 @@ class MongoDBAuditIndexTests(unittest.TestCase):
         src = inspect.getsource(MongoDBAudit.__init__)
         self.assertIn("colname_audit_events", src)
         self.assertIn('"audit_events"', src)
+
+    def test_audit_record_normalises_actor_and_resource_at_write_time(
+        self,
+    ) -> None:
+        # Cross-backend parity pin: ``MongoDBAudit.record`` must
+        # store ``actor`` / ``resource`` with the full canonical
+        # key set (defaulting missing fields to ``None``) so the
+        # on-disk shape matches what :meth:`SQLDBAudit._row2event`
+        # reassembles from per-column NULLs.  Without this, a
+        # call like ``record(actor={"user_email": "alice"})``
+        # would round-trip as ``{"user_email": "alice"}`` on
+        # Mongo but ``{"user_email": "alice", "api_key_hash":
+        # None, "remote_addr": None}`` on SQL.
+        from ivre.db.mongo import MongoDBAudit
+
+        events_col = mock.Mock()
+        backend = MongoDBAudit.__new__(MongoDBAudit)
+        backend.columns = ["audit_events"]
+        # ``MongoDBAudit.db`` is a property delegating to
+        # ``self._db.db``; stub the inner ``_db`` so the
+        # ``self.db[...]`` lookup returns our mocked
+        # ``audit_events`` collection.  Same pattern as
+        # ``test_set_note_swallows_audit_insert_failure``.
+        backend._db = mock.Mock()
+        backend._db.db = {"audit_events": events_col}
+        event_id = backend.record(
+            "upload",
+            actor={"user_email": "alice@example.org"},  # partial
+            # ``resource`` omitted entirely
+            details={"k": "v"},
+            outcome=200,
+        )
+        self.assertEqual(len(event_id), 32)
+        events_col.insert_one.assert_called_once()
+        doc = events_col.insert_one.call_args.args[0]
+        # ``actor`` has the full canonical key set with ``None``
+        # for fields the caller did not supply.
+        self.assertEqual(
+            doc["actor"],
+            {
+                "user_email": "alice@example.org",
+                "api_key_hash": None,
+                "remote_addr": None,
+            },
+        )
+        # ``resource`` likewise carries the full canonical key
+        # set even though the caller passed nothing.
+        self.assertEqual(doc["resource"], {"route": None, "method": None})
 
 
 # ``SQLDBAudit*`` tests need SQLAlchemy at import time

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16577,6 +16577,26 @@ class MongoDBAuditIndexTests(unittest.TestCase):
         self.assertIn('"audit_events"', src)
 
 
+# ``SQLDBAudit*`` tests need SQLAlchemy at import time
+# (``ivre.db.sql.tables`` triggers ``from sqlalchemy import ...``
+# at module load).  The CI "build (3.12)" job installs
+# ``.[elasticsearch,mcp]`` only -- neither extra pulls
+# SQLAlchemy -- so the test classes must be guarded behind an
+# ``ImportError`` guard.  Mirrors ``_HAVE_SQLDB_AUTH`` etc.
+try:
+    from ivre.db.sql.tables import (  # noqa: E402, F401
+        AuditEvent as _AuditEvent_for_tests,
+    )
+
+    _HAVE_SQLDB_AUDIT = True
+except ImportError:
+    _HAVE_SQLDB_AUDIT = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUDIT,
+    "SQLAlchemy is required for SQLDBAuditSchemaTests",
+)
 class SQLDBAuditSchemaTests(unittest.TestCase):
     """Pin the SQL ``audit_events`` table schema + indexes,
     matching the Mongo backend's logical shape.  Backend-free:
@@ -16683,6 +16703,22 @@ class SQLDBAuditSchemaTests(unittest.TestCase):
         self.assertTrue(issubclass(DuckDBAudit, SQLDBAudit))
 
 
+# ``SQLDBAuditLiveIntegrationTests`` additionally needs the
+# ``duckdb-engine`` SQLAlchemy dialect at runtime; the
+# ``[duckdb]`` optional extras pin that.  Mirrors
+# ``_HAVE_DUCKDB_ENGINE_FOR_AUTH`` for the auth tests.
+try:
+    import duckdb_engine as _duckdb_engine_for_audit_tests  # type: ignore[import-untyped]  # noqa: F401, E402
+
+    _HAVE_DUCKDB_ENGINE_FOR_AUDIT = True
+except ImportError:
+    _HAVE_DUCKDB_ENGINE_FOR_AUDIT = False
+
+
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUDIT and _HAVE_DUCKDB_ENGINE_FOR_AUDIT,
+    "duckdb-engine is required (install with the ``duckdb`` extras)",
+)
 class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
     """End-to-end tests against an in-memory DuckDB.  Mirrors
     :class:`SQLDBAuthLiveIntegrationTests`: builds the schema

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16624,6 +16624,100 @@ class MongoDBAuditIndexTests(unittest.TestCase):
         # set even though the caller passed nothing.
         self.assertEqual(doc["resource"], {"route": None, "method": None})
 
+    def test_audit_record_validates_caller_supplied_event_id(self) -> None:
+        # The docstring on :meth:`DBAudit.record` documents
+        # ``event_id`` as a 32-char UUID hex string.  Without
+        # validation, a caller passing ``"hello"`` reached the
+        # backend unchanged: Mongo stored the garbage; SQL's
+        # native UUID column rejected it at insert time
+        # (PostgreSQL / DuckDB) but ``CHAR(32)`` fallbacks let
+        # it through.  Cross-backend contract was inconsistent.
+        #
+        # :meth:`DBAudit._normalize_event_id` now validates
+        # caller-supplied IDs via ``uuid.UUID(...)`` and raises
+        # :class:`ValueError`.  Pin the rejection.
+        from ivre.db.mongo import MongoDBAudit
+
+        backend = MongoDBAudit.__new__(MongoDBAudit)
+        backend.columns = ["audit_events"]
+        backend._db = mock.Mock()
+        backend._db.db = {"audit_events": mock.Mock()}
+        for bad in (
+            "hello",
+            "not-a-uuid",
+            "0" * 31,  # 31 chars
+            "0" * 33,  # 33 chars
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",  # non-hex 32 chars
+            123,  # not a string
+        ):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    backend.record("upload", event_id=bad)
+                self.assertIn("event_id", str(ctx.exception))
+
+    def test_audit_record_normalises_dashed_event_id_to_hex(self) -> None:
+        # ``_normalize_event_id`` accepts every standard UUID
+        # textual form ``uuid.UUID()`` accepts -- including the
+        # 36-char with-dashes form an operator might paste from
+        # another system -- and returns the canonical 32-char
+        # no-dashes form.  This keeps the on-disk shape uniform
+        # across backends.
+        from ivre.db.mongo import MongoDBAudit
+
+        events_col = mock.Mock()
+        backend = MongoDBAudit.__new__(MongoDBAudit)
+        backend.columns = ["audit_events"]
+        backend._db = mock.Mock()
+        backend._db.db = {"audit_events": events_col}
+        dashed = "deadbeef-dead-4bad-9bad-deadbeefcafe"
+        returned = backend.record("upload", event_id=dashed)
+        self.assertEqual(returned, "deadbeefdead4bad9baddeadbeefcafe")
+        doc = events_col.insert_one.call_args.args[0]
+        self.assertEqual(doc["event_id"], "deadbeefdead4bad9baddeadbeefcafe")
+
+    def test_audit_query_routes_through_get_cursor(self) -> None:
+        # Pin that :meth:`MongoDBAudit.query` delegates to the
+        # shared :meth:`MongoDB._get_cursor` so audit reads
+        # inherit ``MONGODB_QUERY_TIMEOUT_MS`` enforcement, the
+        # ``fields=`` -> ``projection=`` conversion, and the
+        # ``("text", ...)`` sort sugar.  Earlier draft called
+        # ``.find().sort().skip().limit()`` directly and bypassed
+        # the timeout cap entirely.
+        from ivre.db.mongo import MongoDBAudit
+
+        backend = MongoDBAudit.__new__(MongoDBAudit)
+        backend.columns = ["audit_events"]
+        with mock.patch.object(backend, "_get_cursor", return_value=iter([])) as gc:
+            backend.query(event_type="upload", limit=10, skip=5)
+        gc.assert_called_once()
+        # First positional arg is the column name; the rest are
+        # keyword args (filter, sort, skip, limit).
+        args, kwargs = gc.call_args
+        self.assertEqual(args[0], "audit_events")
+        self.assertEqual(args[1], {"event_type": "upload"})
+        self.assertEqual(kwargs.get("sort"), [("created_at", -1)])
+        self.assertEqual(kwargs.get("skip"), 5)
+        self.assertEqual(kwargs.get("limit"), 10)
+
+    def test_audit_get_routes_through_get_cursor(self) -> None:
+        # Mirror of the previous test on the low-level
+        # :meth:`MongoDBAudit.get` escape hatch.  Routing
+        # through ``_get_cursor`` keeps the public ``get`` /
+        # ``query`` pair consistent with the rest of the Mongo
+        # purpose layer (notes, etc.).
+        from ivre.db.mongo import MongoDBAudit
+
+        backend = MongoDBAudit.__new__(MongoDBAudit)
+        backend.columns = ["audit_events"]
+        with mock.patch.object(backend, "_get_cursor", return_value=iter([])) as gc:
+            # ``get`` is a generator; force it to run.
+            list(backend.get({"event_type": "upload"}, sort=[("created_at", -1)]))
+        gc.assert_called_once()
+        args, kwargs = gc.call_args
+        self.assertEqual(args[0], "audit_events")
+        self.assertEqual(args[1], {"event_type": "upload"})
+        self.assertEqual(kwargs.get("sort"), [("created_at", -1)])
+
 
 # ``SQLDBAudit*`` tests need SQLAlchemy at import time
 # (``ivre.db.sql.tables`` triggers ``from sqlalchemy import ...``
@@ -16803,6 +16897,29 @@ class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
             event_id=my_id,
         )
         self.assertEqual(returned, my_id)
+
+    def test_record_accepts_dashed_uuid_and_normalises(self) -> None:
+        # The SQL path goes through the same
+        # :meth:`DBAudit._normalize_event_id` helper as the
+        # Mongo path; pin the dashed form is accepted and
+        # returned in the canonical no-dashes 32-char hex.
+        dashed = "deadbeef-dead-4bad-9bad-deadbeefcafe"
+        returned = self._audit.record("upload", event_id=dashed)
+        self.assertEqual(returned, "deadbeefdead4bad9baddeadbeefcafe")
+        events = self._audit.query()
+        self.assertEqual(events[0]["event_id"], "deadbeefdead4bad9baddeadbeefcafe")
+
+    def test_record_rejects_malformed_event_id(self) -> None:
+        # ``_normalize_event_id`` rejects every non-UUID
+        # string with a ``ValueError`` -- before the SQL
+        # native ``Uuid`` column has a chance to either accept
+        # or reject it, so the failure mode is uniform across
+        # backends.
+        for bad in ("hello", "0" * 31, "0" * 33, "zzzzzzzz" * 4):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    self._audit.record("upload", event_id=bad)
+                self.assertIn("event_id", str(ctx.exception))
 
     def test_record_rejects_duplicate_event_id(self) -> None:
         # Unique constraint on event_id: a duplicate insert

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -64,7 +64,7 @@ import sys
 import tempfile
 import unittest
 from ast import literal_eval
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import reduce
 from typing import Any
 from unittest import mock
@@ -16325,6 +16325,540 @@ class MongoDBNotesIndexTests(unittest.TestCase):
         # what we care about here.
         self.assertIsNotNone(notes)
         self.assertIsInstance(notes, DBNotes)
+
+
+# ---------------------------------------------------------------------
+# DBAuditTests / MongoDBAuditIndexTests / SQLDBAuditIndexTests
+# / SQLDBAuditLiveIntegrationTests -- backend-free pin tests
+# for the ``audit`` purpose (append-only audit log of uploads,
+# admin actions, and oversized queries).  Mirrors the
+# ``MongoDBNotesIndexTests`` block in spirit: ABC surface,
+# typed-exception class, Mongo schema + indexes, SQL schema +
+# indexes, and a DuckDB-driven integration block for
+# end-to-end behaviour of the SQL path.
+# ---------------------------------------------------------------------
+
+
+class DBAuditAbstractSurfaceTests(unittest.TestCase):
+    """Pin the :class:`DBAudit` ABC surface + the shared
+    :meth:`_validate_event_type` and :meth:`_validate_details`
+    helpers + the :class:`AuditWriteError` exception
+    contract.  Backend-agnostic; touches neither Mongo nor SQL.
+    """
+
+    def test_audit_in_metadb_db_types(self) -> None:
+        from ivre.db import DBAudit, MetaDB
+
+        self.assertIn("audit", MetaDB.db_types)
+        self.assertIs(MetaDB.db_types["audit"], DBAudit)
+
+    def test_audit_in_metadb_close_iteration(self) -> None:
+        # ``MetaDB.close()`` enumerates the purpose attributes it
+        # owns so the cached connection is released; missing the
+        # ``audit`` entry would leak the audit-store handle.
+        import inspect
+
+        from ivre.db import MetaDB
+
+        src = inspect.getsource(MetaDB.close)
+        self.assertIn('"audit"', src, "MetaDB.close() must iterate the audit attr")
+
+    def test_metadb_has_audit_property(self) -> None:
+        from ivre.db import DBAudit, MetaDB
+
+        m = MetaDB(
+            url="mongodb:///x",
+            urls={"audit": "mongodb:///x"},
+        )
+        audit = m.audit
+        self.assertIsNotNone(audit)
+        self.assertIsInstance(audit, DBAudit)
+
+    def test_event_types_tuple_pinned(self) -> None:
+        # The ABC's enum must include exactly the three v1
+        # categories.  A new category requires extending this
+        # tuple (and probably the consumers in PR 2+).
+        from ivre.db import DBAudit
+
+        self.assertEqual(
+            DBAudit.EVENT_TYPES,
+            ("upload", "admin_action", "oversize_query"),
+        )
+
+    def test_validate_event_type_accepts_each(self) -> None:
+        from ivre.db import DBAudit
+
+        for event_type in DBAudit.EVENT_TYPES:
+            with self.subTest(event_type=event_type):
+                DBAudit._validate_event_type(event_type)  # must not raise
+
+    def test_validate_event_type_rejects_unknown(self) -> None:
+        from ivre.db import DBAudit
+
+        for bad in ("bogus", "", "UPLOAD", "upload ", " upload", None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    DBAudit._validate_event_type(bad)  # type: ignore[arg-type]
+                self.assertIn("unknown event_type", str(ctx.exception))
+
+    def test_validate_details_accepts_none(self) -> None:
+        from ivre.db import DBAudit
+
+        DBAudit._validate_details(None)  # must not raise
+
+    def test_validate_details_accepts_json_serializable_dict(self) -> None:
+        from ivre.db import DBAudit
+
+        for shape in (
+            {},
+            {"k": "v"},
+            {"count": 42, "nested": {"a": [1, 2, 3]}},
+            {"timestamp": "2026-05-25T00:00:00Z"},  # ISO string, not datetime
+        ):
+            with self.subTest(shape=shape):
+                DBAudit._validate_details(shape)  # must not raise
+
+    def test_validate_details_rejects_non_dict(self) -> None:
+        from ivre.db import DBAudit
+
+        for bad in ([], (), "string", 42, True):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    DBAudit._validate_details(bad)  # type: ignore[arg-type]
+                self.assertIn("details must be a dict", str(ctx.exception))
+
+    def test_validate_details_rejects_non_json_serializable_values(self) -> None:
+        # ``datetime`` / ``set`` / arbitrary objects fail
+        # ``json.dumps``; catching at the ABC means the SQL
+        # JSON column never sees a value it cannot encode.
+        from ivre.db import DBAudit
+
+        for bad in (
+            {"x": {1, 2, 3}},  # set
+            {"x": datetime.now()},  # datetime not stringified
+            {"x": object()},  # arbitrary object
+            {"x": b"bytes"},  # bytes not JSON
+        ):
+            with self.subTest(bad_value=type(bad["x"]).__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    DBAudit._validate_details(bad)
+                self.assertIn("not JSON-serializable", str(ctx.exception))
+
+    def test_audit_write_error_is_top_level_exception(self) -> None:
+        # ``AuditWriteError`` is a top-level :class:`Exception`,
+        # NOT a :class:`ValueError`.  The asymmetry with
+        # ``DBNotes``'s ``NoteAlreadyExists`` /
+        # ``NoteConcurrencyError`` (which DO subclass
+        # ``ValueError``) is intentional: the audit log's
+        # contract is fail-loud, so the exception type must
+        # NOT be silently caught by an upstream
+        # ``except ValueError`` clause that was written to
+        # handle a notes-style typed error.
+        from ivre.db import AuditWriteError
+
+        self.assertTrue(issubclass(AuditWriteError, Exception))
+        self.assertFalse(issubclass(AuditWriteError, ValueError))
+
+    def test_dbaudit_abstract_methods_raise(self) -> None:
+        # Driving each ABC method directly (bypassing the
+        # concrete override) must raise ``NotImplementedError``.
+        from ivre.db import DB, DBAudit
+
+        # Build a bare instance via ``object.__new__`` so we
+        # don't trip the :class:`DB` ``__init__`` (which
+        # nothing for the ABC itself).
+        instance = object.__new__(DBAudit)
+        # ``DB.__init__`` is parameterless.
+        DB.__init__(instance)
+        for method_args in (
+            ("record", ("upload",), {}),
+            ("query", (), {}),
+            ("count", (), {}),
+            ("purge_older_than", (datetime.now(timezone.utc),), {}),
+            ("get", ({},), {}),
+        ):
+            method_name, args, kwargs = method_args
+            with self.subTest(method=method_name):
+                with self.assertRaises(NotImplementedError):
+                    getattr(instance, method_name)(*args, **kwargs)
+
+
+class MongoDBAuditIndexTests(unittest.TestCase):
+    """Backend-free pin tests for the Mongo schema of the
+    ``audit`` purpose.  Mirrors :class:`MongoDBNotesIndexTests`
+    in spirit: schema + indexes pinned at the class level
+    without a live connection.
+    """
+
+    def test_audit_column_registered(self) -> None:
+        from ivre.db.mongo import MongoDBAudit
+
+        # Single collection, at index 0.
+        self.assertEqual(MongoDBAudit.column_audit_events, 0)
+        self.assertEqual(len(MongoDBAudit.indexes), 1)
+
+    def test_audit_indexes_pinned(self) -> None:
+        # Pin the three composite indexes Mongo needs to back
+        # the expected query patterns + the unique
+        # ``event_id`` constraint.
+        from ivre.db.mongo import MongoDBAudit
+
+        block = MongoDBAudit.indexes[MongoDBAudit.column_audit_events]
+        index_specs = [keys for keys, _opts in block]
+        self.assertIn(
+            [("event_type", 1), ("created_at", -1)],
+            index_specs,
+            "missing (event_type, created_at DESC) index",
+        )
+        self.assertIn(
+            [("actor.user_email", 1), ("created_at", -1)],
+            index_specs,
+            "missing (actor.user_email, created_at DESC) index",
+        )
+        self.assertIn(
+            [("created_at", -1)],
+            index_specs,
+            "missing (created_at DESC) index",
+        )
+        self.assertIn(
+            [("event_id", 1)],
+            index_specs,
+            "missing event_id index",
+        )
+
+    def test_audit_user_email_index_is_sparse(self) -> None:
+        # ``actor.user_email`` is nullable (anonymous /
+        # REMOTE_USER traffic), so the per-user composite must
+        # be sparse to avoid indexing every event with a NULL
+        # entry.
+        from ivre.db.mongo import MongoDBAudit
+
+        block = MongoDBAudit.indexes[MongoDBAudit.column_audit_events]
+        user_idx = next(
+            opts
+            for keys, opts in block
+            if keys == [("actor.user_email", 1), ("created_at", -1)]
+        )
+        self.assertTrue(user_idx.get("sparse"))
+
+    def test_audit_event_id_index_is_unique(self) -> None:
+        from ivre.db.mongo import MongoDBAudit
+
+        block = MongoDBAudit.indexes[MongoDBAudit.column_audit_events]
+        event_id_idx = next(opts for keys, opts in block if keys == [("event_id", 1)])
+        self.assertTrue(event_id_idx.get("unique"))
+
+    def test_audit_no_ttl_index(self) -> None:
+        # Retention is operator-driven.  A TTL index would
+        # silently purge events on the trailing edge; the
+        # design explicitly forbids it.  Adding a future
+        # ``WEB_AUDIT_TTL_SECONDS`` knob would create the TTL
+        # conditionally at startup -- not hard-code it here.
+        from ivre.db.mongo import MongoDBAudit
+
+        block = MongoDBAudit.indexes[MongoDBAudit.column_audit_events]
+        for _keys, opts in block:
+            self.assertNotIn(
+                "expireAfterSeconds",
+                opts,
+                "audit_events must not carry a TTL index",
+            )
+
+    def test_audit_columns_pop_supports_override(self) -> None:
+        # Operators can override the collection name via the
+        # ``colname_audit_events`` URL parameter.  Pin the pop
+        # so a rename or default change surfaces here.
+        import inspect
+
+        from ivre.db.mongo import MongoDBAudit
+
+        src = inspect.getsource(MongoDBAudit.__init__)
+        self.assertIn("colname_audit_events", src)
+        self.assertIn('"audit_events"', src)
+
+
+class SQLDBAuditSchemaTests(unittest.TestCase):
+    """Pin the SQL ``audit_events`` table schema + indexes,
+    matching the Mongo backend's logical shape.  Backend-free:
+    only inspects the SQLAlchemy declarative metadata.
+    """
+
+    def test_audit_events_table_name(self) -> None:
+        from ivre.db.sql.tables import AuditEvent
+
+        self.assertEqual(AuditEvent.__tablename__, "audit_events")
+
+    def test_audit_events_columns(self) -> None:
+        # Pin every column the ABC's record() shape requires.
+        from ivre.db.sql.tables import AuditEvent
+
+        names = {c.name for c in AuditEvent.__table__.columns}
+        self.assertEqual(
+            names,
+            {
+                "id",
+                "event_id",
+                "event_type",
+                "created_at",
+                "actor_user_email",
+                "actor_api_key_hash",
+                "actor_remote_addr",
+                "resource_route",
+                "resource_method",
+                "details",
+                "outcome",
+            },
+        )
+
+    def test_audit_events_event_id_type_is_uuid(self) -> None:
+        # ``event_id`` uses ``sqlalchemy.Uuid``: native UUID on
+        # PostgreSQL / DuckDB, CHAR(32) fallback elsewhere.
+        # The native type buys type-safety at the DB layer
+        # (malformed UUIDs are rejected at insert time on PG).
+        from sqlalchemy import Uuid
+
+        from ivre.db.sql.tables import AuditEvent
+
+        col = AuditEvent.__table__.columns["event_id"]
+        self.assertIsInstance(col.type, Uuid)
+        self.assertFalse(col.nullable)
+
+    def test_audit_events_nullable_fields(self) -> None:
+        # Every actor sub-field is nullable (anonymous /
+        # REMOTE_USER / non-HTTP callers leave them empty).
+        # ``outcome`` and ``details`` also nullable.
+        from ivre.db.sql.tables import AuditEvent
+
+        for nullable_col in (
+            "actor_user_email",
+            "actor_api_key_hash",
+            "actor_remote_addr",
+            "resource_route",
+            "resource_method",
+            "details",
+            "outcome",
+        ):
+            with self.subTest(col=nullable_col):
+                col = AuditEvent.__table__.columns[nullable_col]
+                self.assertTrue(col.nullable, f"{nullable_col} must be nullable")
+
+    def test_audit_events_required_fields(self) -> None:
+        # ``event_id`` / ``event_type`` / ``created_at`` MUST
+        # be non-null on every row.
+        from ivre.db.sql.tables import AuditEvent
+
+        for required_col in ("event_id", "event_type", "created_at"):
+            with self.subTest(col=required_col):
+                col = AuditEvent.__table__.columns[required_col]
+                self.assertFalse(col.nullable, f"{required_col} must be NOT NULL")
+
+    def test_audit_events_indexes(self) -> None:
+        # Mirror Mongo's index pattern: (event_type, created_at),
+        # (actor_user_email, created_at), (created_at), and a
+        # unique constraint on event_id.
+        from ivre.db.sql.tables import AuditEvent
+
+        index_names = {idx.name for idx in AuditEvent.__table__.indexes}
+        self.assertIn("audit_events_idx_type_created", index_names)
+        self.assertIn("audit_events_idx_user_created", index_names)
+        self.assertIn("audit_events_idx_created", index_names)
+        constraint_names = {c.name for c in AuditEvent.__table__.constraints if c.name}
+        self.assertIn("audit_events_idx_event_id", constraint_names)
+
+    def test_sqldbaudit_table_layout_wires_events(self) -> None:
+        from ivre.db.sql import SQLDBAudit
+        from ivre.db.sql.tables import AuditEvent
+
+        self.assertIs(SQLDBAudit.tables.events, AuditEvent)
+
+    def test_postgres_and_duckdb_subclasses_registered(self) -> None:
+        # The dialect subclasses exist and inherit
+        # :class:`SQLDBAudit` so the multi-backend dispatch in
+        # :attr:`DBAudit.backends` resolves correctly.
+        from ivre.db.sql import SQLDBAudit
+        from ivre.db.sql.duckdb import DuckDBAudit
+        from ivre.db.sql.postgres import PostgresDBAudit
+
+        self.assertTrue(issubclass(PostgresDBAudit, SQLDBAudit))
+        self.assertTrue(issubclass(DuckDBAudit, SQLDBAudit))
+
+
+class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
+    """End-to-end tests against an in-memory DuckDB.  Mirrors
+    :class:`SQLDBAuthLiveIntegrationTests`: builds the schema
+    on a throwaway ``duckdb:///:memory:`` URL, exercises every
+    public method, asserts the round-trip shape and the
+    fail-loud contract.
+    """
+
+    def setUp(self) -> None:
+        from urllib.parse import urlparse
+
+        from ivre.db.sql.duckdb import DuckDBAudit
+        from ivre.db.sql.tables import AuditEvent, Base
+
+        self._audit = DuckDBAudit(urlparse("duckdb:///:memory:"))
+        Base.metadata.create_all(self._audit.db, tables=[AuditEvent.__table__])
+
+    def test_record_returns_event_id(self) -> None:
+        event_id = self._audit.record(
+            "upload",
+            actor={"user_email": "alice@example.org"},
+            resource={"route": "/scans", "method": "POST"},
+            details={"count": 1},
+            outcome=200,
+        )
+        self.assertIsInstance(event_id, str)
+        self.assertEqual(len(event_id), 32)  # hex, no dashes
+
+    def test_record_accepts_caller_supplied_event_id(self) -> None:
+        my_id = "deadbeef" * 4
+        returned = self._audit.record(
+            "admin_action",
+            actor={"user_email": "admin@example.org"},
+            event_id=my_id,
+        )
+        self.assertEqual(returned, my_id)
+
+    def test_record_rejects_duplicate_event_id(self) -> None:
+        # Unique constraint on event_id: a duplicate insert
+        # must raise :class:`AuditWriteError` (not a silent
+        # no-op and not a generic backend error).
+        from ivre.db import AuditWriteError
+
+        eid = self._audit.record("upload")
+        with self.assertRaises(AuditWriteError) as ctx:
+            self._audit.record("upload", event_id=eid)
+        # Message names the offending event_id so an operator
+        # can find the row via grep on the log.
+        self.assertIn(eid, str(ctx.exception))
+
+    def test_query_returns_events_newest_first(self) -> None:
+        import time
+
+        ids = []
+        for i in range(3):
+            ids.append(self._audit.record("upload", details={"i": i}))
+            time.sleep(0.01)  # ensure monotonic created_at
+        events = self._audit.query()
+        self.assertEqual(len(events), 3)
+        # Newest-first ordering: last inserted is first returned.
+        self.assertEqual([e["event_id"] for e in events], list(reversed(ids)))
+
+    def test_query_event_shape(self) -> None:
+        self._audit.record(
+            "upload",
+            actor={
+                "user_email": "alice@example.org",
+                "api_key_hash": "a" * 64,
+                "remote_addr": "192.0.2.1",
+            },
+            resource={"route": "/scans", "method": "POST"},
+            details={"key": "value"},
+            outcome=200,
+        )
+        events = self._audit.query()
+        ev = events[0]
+        self.assertEqual(
+            set(ev.keys()),
+            {
+                "event_id",
+                "event_type",
+                "created_at",
+                "actor",
+                "resource",
+                "details",
+                "outcome",
+            },
+        )
+        self.assertEqual(ev["actor"]["user_email"], "alice@example.org")
+        self.assertEqual(ev["actor"]["api_key_hash"], "a" * 64)
+        self.assertEqual(ev["actor"]["remote_addr"], "192.0.2.1")
+        self.assertEqual(ev["resource"]["route"], "/scans")
+        self.assertEqual(ev["resource"]["method"], "POST")
+        self.assertEqual(ev["details"], {"key": "value"})
+        self.assertEqual(ev["outcome"], 200)
+
+    def test_query_filters(self) -> None:
+        self._audit.record("upload", actor={"user_email": "alice@example.org"})
+        self._audit.record("admin_action", actor={"user_email": "admin@example.org"})
+        self._audit.record("upload", actor={"user_email": "bob@example.org"})
+
+        # by event_type
+        self.assertEqual(len(self._audit.query(event_type="upload")), 2)
+        self.assertEqual(len(self._audit.query(event_type="admin_action")), 1)
+        # by user_email
+        self.assertEqual(len(self._audit.query(user_email="alice@example.org")), 1)
+        self.assertEqual(len(self._audit.query(user_email="absent@example.org")), 0)
+        # combined
+        self.assertEqual(
+            len(self._audit.query(event_type="upload", user_email="alice@example.org")),
+            1,
+        )
+
+    def test_query_pagination(self) -> None:
+        for i in range(10):
+            self._audit.record("upload", details={"i": i})
+        first_page = self._audit.query(limit=3)
+        self.assertEqual(len(first_page), 3)
+        second_page = self._audit.query(limit=3, skip=3)
+        self.assertEqual(len(second_page), 3)
+        # No overlap between pages.
+        first_ids = {e["event_id"] for e in first_page}
+        second_ids = {e["event_id"] for e in second_page}
+        self.assertEqual(first_ids & second_ids, set())
+
+    def test_count_filters(self) -> None:
+        self._audit.record("upload")
+        self._audit.record("upload")
+        self._audit.record("admin_action")
+        self.assertEqual(self._audit.count(), 3)
+        self.assertEqual(self._audit.count(event_type="upload"), 2)
+        self.assertEqual(self._audit.count(event_type="admin_action"), 1)
+        self.assertEqual(self._audit.count(event_type="oversize_query"), 0)
+
+    def test_purge_older_than_returns_deleted_count(self) -> None:
+        # The DELETE ... RETURNING workaround for the
+        # duckdb-engine rowcount=-1 quirk must report the
+        # actual count.
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
+
+        for _ in range(5):
+            self._audit.record("upload")
+        # cutoff in the future -> deletes everything
+        deleted = self._audit.purge_older_than(
+            _dt.now(tz=_tz.utc) + timedelta(seconds=1)
+        )
+        self.assertEqual(deleted, 5)
+        self.assertEqual(self._audit.count(), 0)
+
+    def test_purge_older_than_respects_cutoff(self) -> None:
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
+
+        for _ in range(3):
+            self._audit.record("upload")
+        # cutoff in the past -> deletes nothing
+        deleted = self._audit.purge_older_than(
+            _dt.now(tz=_tz.utc) - timedelta(seconds=60)
+        )
+        self.assertEqual(deleted, 0)
+        self.assertEqual(self._audit.count(), 3)
+
+    def test_record_rejects_unknown_event_type(self) -> None:
+        with self.assertRaises(ValueError):
+            self._audit.record("bogus_type")
+
+    def test_record_rejects_non_serializable_details(self) -> None:
+        with self.assertRaises(ValueError):
+            self._audit.record("upload", details={"bad": {1, 2, 3}})
+
+    def test_get_raises_not_implemented(self) -> None:
+        # The Mongo-flavoured ``spec`` filter doesn't
+        # translate to SQL; SQL callers use :meth:`query`.
+        with self.assertRaises(NotImplementedError):
+            list(self._audit.get({}))
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Storage layer of a new ``audit`` purpose. Append-only audit log of three categories surfaced by the web layer:

* ``upload`` -- writes against ``post_nmap`` / ``post_flow`` / ``post_flow_cleanup``.
* ``admin_action`` -- mutations under ``/cgi/auth/admin/*``.
* ``oversize_query`` -- reads whose underlying result count exceeds the operator-set threshold (declared here; consumed by a future decorator in PR 2).

This PR ships the storage contract first so the schema is reviewable in isolation. The hook decorator, route plumbing, read API, CLI, MCP tools and UI all land in follow-up PRs mirroring the DBNotes series split (#1874 -> #1876 -> #1877 / #1878 / #1880).

Design highlights

- **Rich + structured schema** (per-event): ``event_id`` (UUID v4 hex, 32 chars), ``event_type`` (enum- enforced via :attr:`DBAudit.EVENT_TYPES`), ``created_at``, ``actor`` (``user_email`` / ``api_key_hash`` / ``remote_addr``), ``resource`` (``route`` / ``method``), ``details`` (free-form JSON-validated dict), ``outcome`` (HTTP status).
- **Fail-loud insert model**: backend write failures wrap the underlying ``PyMongoError`` / ``SQLAlchemyError`` in :class:`AuditWriteError` and re-raise. ``AuditWriteError`` is a top-level :class:`Exception` (NOT a :class:`ValueError`) so an upstream ``except ValueError`` clause written to handle notes-style typed errors cannot silently swallow it.
- **No TTL by default**: retention is operator-driven via :meth:`DBAudit.purge_older_than`; no automatic TTL index. Adding one is a deliberate operator choice on a future ``WEB_AUDIT_TTL_SECONDS`` knob.
- **Mongo + SQL parity from day one**: both backends ship in the same PR with the same logical indexes and the same caller-visible dict shape. Audit-as-security-feature deserves multi-backend support out of the gate.
- **Native UUID on SQL backends that support it**: the ``event_id`` column uses :class:`sqlalchemy.Uuid` so PostgreSQL and DuckDB get native ``UUID`` storage (16 bytes, type-safe at the DB layer); dialects without UUID fall back to ``CHAR(32)`` automatically.

Files

- ``ivre/config.py`` -- new ``DB_AUDIT`` knob with the ``DB_NOTES``-style fallback ``DB_AUDIT = DB`` when unset.
- ``ivre/db/__init__.py`` -- :class:`AuditWriteError`, :class:`DBAudit` ABC (with :attr:`EVENT_TYPES` tuple, :meth:`_validate_event_type` / :meth:`_validate_details` helpers, and the :meth:`record` / :meth:`query` / :meth:`count` / :meth:`purge_older_than` / :meth:`get` method surface); :class:`MetaDB.audit` lazy property; ``"audit"`` entry in :attr:`MetaDB.db_types` (alphabetical insertion between ``auth`` and ``notes``) and in :meth:`MetaDB.close`.
- ``ivre/db/mongo.py`` -- :class:`MongoDBAudit` with a single ``audit_events`` collection, four indexes ((event_type, created_at DESC), (actor.user_email, created_at DESC) [sparse], (created_at DESC), unique event_id), and a private ``_build_query_filter`` shared between :meth:`query` and :meth:`count`.
- ``ivre/db/sql/tables.py`` -- :class:`AuditEvent` declarative model with the matching composite indexes; ``event_id`` column uses :class:`sqlalchemy.Uuid` for native UUID on PG / DuckDB.
- ``ivre/db/sql/__init__.py`` -- :class:`SQLDBAudit` (the generic SQL backend) with the dialect-portable implementation; uses ``DELETE ... RETURNING`` for an accurate :meth:`purge_older_than` row count (workaround for the duckdb-engine ``cursor.rowcount = -1`` quirk). Wraps every ``SQLAlchemyError`` in :class:`AuditWriteError`.
- ``ivre/db/sql/postgres.py`` -- :class:`PostgresDBAudit` (pure inheritance over :class:`SQLDBAudit`).
- ``ivre/db/sql/duckdb.py`` -- :class:`DuckDBAudit` (:class:`DuckDBMixin` + :class:`PostgresDBAudit`).

Tests added (``tests/tests_no_backend.py``)

39 new test methods across four classes:

- :class:`DBAuditAbstractSurfaceTests` -- 12 tests pinning the ABC surface: ``MetaDB`` plumbing (db_types, ``close()`` iteration, lazy property), the :attr:`EVENT_TYPES` tuple, the ``_validate_*`` helpers (accept / reject paths for every shape), the :class:`AuditWriteError` exception-type contract, and the ``raise NotImplementedError`` discipline on every abstract method.
- :class:`MongoDBAuditIndexTests` -- 6 tests pinning the Mongo schema (column registration, the four index specs, sparse / unique flags, the no-TTL invariant, the ``colname_audit_events`` override hook).
- :class:`SQLDBAuditSchemaTests` -- 8 tests pinning the SQL schema (table name, column inventory, the ``Uuid`` type, nullable / NOT NULL discipline, indexes, and the ``PostgresDBAudit`` / ``DuckDBAudit`` subclass registration).
- :class:`SQLDBAuditLiveIntegrationTests` -- 13 end-to-end tests on an in-memory DuckDB: ``record`` returns the generated / caller-supplied event_id, rejects duplicates loudly, ``query`` returns newest-first with the full caller-facing shape, supports every filter combination and pagination, ``count`` honours the same filters, ``purge_older_than`` returns the accurate deleted count (workaround verified), and the typed validation guards fire on the SQL path too.

Validation

- ``DBAuditAbstractSurfaceTests`` + ``MongoDBAuditIndexTests``
  + ``SQLDBAuditSchemaTests`` + ``SQLDBAuditLiveIntegrationTests`` 39/39 green.
- Full no-backend suite: 780 passed (was 741 on master; +39 new tests), 1 deselected (the unrelated TZ-dependent ``test_utils``).
- ``pkg/runchecks`` clean (same pre-existing ``func.count`` pylint regressions in ``ivre/db/sql/`` as before, plus one new line at ``ivre/db/sql/__init__.py:7105`` for :meth:`SQLDBAudit.count` matching the same false-positive pattern documented inline).
- ``pkg/builddocs`` ran clean (CI-matching env: Python 3.13, ``[doc]`` extras only); no ``web/static/doc/`` changes.