### PR TITLE
fix(db/sql): generalise ensure_indexes() to every SQL purpose

### DIFF
--- a/ivre/db/sql/__init__.py
+++ b/ivre/db/sql/__init__.py
@@ -503,7 +503,86 @@ class SQLDB(DB):
         raise NotImplementedError()
 
     def ensure_indexes(self):
-        raise NotImplementedError()
+        """Idempotently create every table declared on this
+        backend and every :class:`Index` attached to those
+        tables, without touching the rows already present.
+
+        Operator-facing CLIs (``scancli`` / ``view`` /
+        ``passive`` / ``flowcli`` / ``auditcli`` / ...) all
+        expose an ``--ensure-indexes`` subcommand that calls
+        this method.  Before this generalisation the base
+        raised :class:`NotImplementedError`, so every SQL
+        deployment would crash with a traceback on those
+        subcommands even though the purposes themselves were
+        fully wired against PostgreSQL / DuckDB.
+
+        Why not :meth:`Index.create` with ``checkfirst=True``
+        and / or the SQLAlchemy
+        :class:`~sqlalchemy.engine.Inspector` ?
+
+        * The duckdb-engine dialect does not translate
+          ``checkfirst`` into ``CREATE INDEX IF NOT EXISTS``
+          semantics: a second invocation against the same
+          database raises ``CatalogException: Index with name
+          "..." already exists``.
+        * Its inspector explicitly does not reflect indexes
+          either -- it warns ``duckdb-engine doesn't yet
+          support reflection on indices`` and returns ``[]``,
+          so the inspector-based "create only what's missing"
+          trick degenerates into "always create, always crash
+          on rerun".
+
+        Wrapping each ``CREATE INDEX`` in its own transaction
+        and treating a :class:`SQLAlchemyError` whose message
+        contains ``"already exists"`` as the success path
+        gives portable idempotency without depending on either
+        backend's catalog semantics: PostgreSQL's
+        ``DuplicateObjectError`` and DuckDB's
+        ``CatalogException`` both surface through SQLAlchemy
+        2.x with that substring in :func:`str`.  Other
+        :class:`SQLAlchemyError` instances (permission denied,
+        dialect bug, ...) still propagate so a real schema
+        problem surfaces loudly.
+
+        :class:`~sqlalchemy.UniqueConstraint` declarations
+        attached to a :class:`~sqlalchemy.Table` (e.g.
+        ``audit_events_idx_event_id`` on :class:`AuditEvent`)
+        are created with the table itself rather than via
+        :class:`Index`, so they do not appear in
+        ``table.indexes`` and the loop below does not need to
+        special-case them: the
+        ``Table.create(checkfirst=True)`` line above creates
+        them as part of the ``CREATE TABLE`` statement on the
+        first call and short-circuits on every subsequent
+        call.
+        """
+        # First pass: ensure each table exists.  ``checkfirst``
+        # makes this a clean no-op when the table is already
+        # there -- both PostgreSQL and DuckDB honour it for
+        # ``CREATE TABLE`` (the dialect quirk is index-only).
+        with self.db.begin() as conn:
+            for table in self.tables:
+                table.__table__.create(bind=conn, checkfirst=True)
+        # Second pass: each index in its own transaction so a
+        # duplicate on one index does not poison the rest of
+        # the run.  A shared transaction would abort on the
+        # first ``CatalogException``, leaving subsequent
+        # indexes uncreated; the per-index loop guarantees
+        # that every missing index is eventually created
+        # regardless of how many already exist.
+        for table in self.tables:
+            for index in table.__table__.indexes:
+                try:
+                    with self.db.begin() as conn:
+                        index.create(bind=conn)
+                except SQLAlchemyError as exc:
+                    if "already exists" not in str(exc):
+                        raise
+                    utils.LOGGER.debug(
+                        "%s.ensure_indexes: %s already exists, skipping",
+                        type(self).__name__,
+                        index.name,
+                    )
 
     @staticmethod
     def query(*args, **kargs):
@@ -6950,73 +7029,11 @@ class SQLDBAudit(SQLDB, DBAudit):
 
     SCHEMA_VERSION = 1
 
-    def ensure_indexes(self):
-        """Idempotently create every index declared on
-        :class:`AuditEvent` (and the table itself if it is
-        somehow missing).
-
-        ``SQLDB.create()`` uses ``Table.create(checkfirst=True)``,
-        which short-circuits when the table already exists --
-        and that *also* skips index creation, so a deployment
-        whose ``audit_events`` table predates an index addition
-        would silently miss it.  Iterating the declared
-        ``Index`` objects and creating each one that is missing
-        closes that gap without dropping data, matching the
-        operator expectation that ``ivre auditcli
-        --ensure-indexes`` is a safe, repeatable maintenance
-        step.
-
-        The base :class:`SQLDB.ensure_indexes` raises
-        ``NotImplementedError``; overriding here keeps the
-        audit-specific maintenance command working on every SQL
-        audit backend (PostgreSQL + DuckDB) without forcing a
-        wider SQL-purpose maintenance refactor in this PR.
-
-        ``Index.create(bind=conn, checkfirst=True)`` cannot be
-        relied on across dialects: the duckdb-engine driver
-        does not translate ``checkfirst`` into ``CREATE INDEX
-        IF NOT EXISTS`` semantics (a second invocation raises
-        ``CatalogException: Index with name "..." already
-        exists``), and its inspector explicitly does not
-        reflect indexes (it warns ``duckdb-engine doesn't yet
-        support reflection on indices`` and returns ``[]``), so
-        the inspector-based "create only what's missing" trick
-        does not work either.  Wrapping each ``CREATE INDEX``
-        in its own transaction and treating a
-        ``ProgrammingError`` (PostgreSQL's
-        ``DuplicateObjectError`` and DuckDB's
-        ``CatalogException`` both surface here under
-        SQLAlchemy 2.x) as "already there, fine" gives
-        portable idempotency without depending on either
-        backend's catalog semantics.
-        """
-        table = self.tables.events.__table__
-        with self.db.begin() as conn:
-            table.create(bind=conn, checkfirst=True)
-        # ``UniqueConstraint`` -- declared on
-        # :class:`AuditEvent` as ``audit_events_idx_event_id``
-        # -- is created with the table itself rather than via
-        # :class:`Index`, so it does not appear in
-        # ``table.indexes``; no special-case needed here.
-        for index in table.indexes:
-            try:
-                with self.db.begin() as conn:
-                    index.create(bind=conn)
-            except SQLAlchemyError as exc:
-                # Both PostgreSQL's ``DuplicateObjectError``
-                # and DuckDB's ``CatalogException`` reach us
-                # through SQLAlchemy 2.x as ``DBAPIError``
-                # subclasses; treat any "already exists"
-                # variant as the success path.  Other
-                # ``SQLAlchemyError`` instances (permission
-                # denied, dialect bug, ...) are real failures
-                # and must propagate.
-                if "already exists" not in str(exc):
-                    raise
-                utils.LOGGER.debug(
-                    "audit ensure_indexes: %s already exists, skipping",
-                    index.name,
-                )
+    # ``ensure_indexes`` is inherited from :class:`SQLDB`; the
+    # base method walks ``self.tables`` and idempotently
+    # creates every table + every declared :class:`Index` in
+    # one shot, including ``audit_events`` and its three
+    # composite indexes.  No audit-specific override needed.
 
     @staticmethod
     def _row2event(row):

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -11092,6 +11092,71 @@ class SQLDBAuthLiveIntegrationTests(unittest.TestCase):
         # Sessions / api-keys / magic-links cascaded.
         self.assertEqual(self.db.list_api_keys("alice@example.com"), [])
 
+    def test_ensure_indexes_is_idempotent_across_multiple_tables(self) -> None:
+        # ``ivre authcli --ensure-indexes`` (and every other
+        # SQL purpose's equivalent verb) calls
+        # :meth:`db.<purpose>.ensure_indexes`; the base
+        # :class:`SQLDB.ensure_indexes` walks ``self.tables`` /
+        # ``table.__table__.indexes`` and creates each one
+        # idempotently across PostgreSQL and DuckDB.
+        #
+        # The auth purpose is the right surface to pin the
+        # cross-table contract on: it has five tables
+        # (``auth_user``, ``auth_session``, ``auth_api_key``,
+        # ``auth_rate_limit``, ``auth_magic_link``) and a dozen
+        # declared :class:`Index` blocks across them.  A
+        # single-table coverage (the audit purpose) would not
+        # exercise the outer ``for table in self.tables`` loop
+        # in :meth:`SQLDB.ensure_indexes`; this test does.
+        from sqlalchemy import delete
+
+        from ivre.db.sql.tables import Base
+
+        # First call: every table already exists (created by
+        # ``setUpClass`` via ``Base.metadata.create_all``);
+        # ``ensure_indexes`` should be a clean no-op on the
+        # data but still re-issue ``CREATE INDEX`` for each
+        # declared index without crashing on "already exists".
+        self.db.create_user(
+            "alice@example.com",
+            display_name="Alice",
+            is_active=True,
+        )
+        self.db.ensure_indexes()  # must not raise
+        self.assertIsNotNone(self.db.get_user_by_email("alice@example.com"))
+
+        # Drop every auth table and call ensure_indexes again:
+        # it must recreate every table *and* every declared
+        # index without dropping data from other tables.
+        # ``Base.metadata.drop_all(... tables=...)`` issues
+        # ``DROP TABLE IF EXISTS`` in dependency order;
+        # ``ensure_indexes`` is expected to reverse that
+        # ground-up.
+        Base.metadata.drop_all(self._engine, tables=self._auth_tables)
+        # Sanity check: tables are gone.
+        with self._engine.connect() as conn:
+            from sqlalchemy import inspect as sa_inspect
+
+            existing = set(sa_inspect(conn).get_table_names())
+            self.assertNotIn("auth_user", existing)
+
+        self.db.ensure_indexes()  # must not raise
+
+        # Schema is functional again: insert / fetch round-trip
+        # works on a freshly-provisioned auth surface.
+        self.db.create_user(
+            "bob@example.com",
+            display_name="Bob",
+            is_active=True,
+        )
+        self.assertIsNotNone(self.db.get_user_by_email("bob@example.com"))
+
+        # Clean up so the next test in the class starts from
+        # the same empty-but-existing state ``setUp`` builds.
+        with self._engine.begin() as conn:
+            for tbl in self._auth_tables:
+                conn.execute(delete(tbl))
+
 
 # ---------------------------------------------------------------------
 # PostgresDBAuthTests -- pin :class:`ivre.db.sql.postgres.PostgresDBAuth`.
@@ -17186,12 +17251,13 @@ class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
     def test_ensure_indexes_is_idempotent(self) -> None:
         # ``ivre auditcli --ensure-indexes`` calls
         # :meth:`db.audit.ensure_indexes`; the base
-        # :class:`SQLDB` raises ``NotImplementedError`` so the
-        # CLI would crash on PostgreSQL / DuckDB if the audit
-        # subclass did not override it.  Pin the override and
-        # the idempotency contract: it is safe to invoke
-        # repeatedly, both before and after the table exists,
-        # without dropping data.
+        # :class:`SQLDB.ensure_indexes` (which
+        # :class:`SQLDBAudit` inherits unchanged) creates every
+        # declared table and index idempotently across
+        # PostgreSQL and DuckDB.  Pin the idempotency contract
+        # specifically on the audit purpose: it is safe to
+        # invoke repeatedly, both before and after the table
+        # exists, without dropping rows.
         from ivre.db.sql.tables import AuditEvent, Base
 
         # First call: table already exists (created by setUp);


### PR DESCRIPTION
Round 7 of PR #1887 fixed ``ivre auditcli --ensure-indexes`` on PostgreSQL / DuckDB by overriding
``SQLDBAudit.ensure_indexes()``, but left the base ``SQLDB.ensure_indexes()`` raising
``NotImplementedError``.  Every other SQL purpose (scancli, view, passive, flowcli, ...) calling
``--ensure-indexes`` would crash the same way.

Lift the audit override into the base
=====================================

``SQLDB.ensure_indexes()`` now walks ``self.tables`` and:

* ``Table.create(bind=conn, checkfirst=True)`` per table, inside a single transaction (clean no-op when the table is already there; provisions the schema on a fresh DB).
* For each ``Index`` declared on the table, opens its own ``db.begin()`` and calls ``index.create(bind=conn)``, catching ``SQLAlchemyError`` whose message contains ``"already exists"` as the success path.

Per-index transactions matter: a shared transaction would abort on the first ``CatalogException`` and leave every subsequent index uncreated, so partial-index drift (a new index added in code but not yet present in the database) would never converge.  The per-index loop guarantees that every missing index is eventually created regardless of how many already exist.

Why not ``Index.create(checkfirst=True)`` or
``Inspector.get_indexes()`` ?

* The duckdb-engine dialect does not translate ``checkfirst`` into ``CREATE INDEX IF NOT EXISTS`` semantics: a second invocation against the same database raises ``CatalogException: Index with name "..." already exists``.
* Its inspector explicitly does not reflect indexes either -- it warns ``duckdb-engine doesn't yet support reflection on indices`` and returns ``[]``, so the inspector-based "create only what's missing" trick degenerates into "always create, always crash on rerun".

The try/``except SQLAlchemyError as exc`` shape, with a narrow ``if "already exists" not in str(exc)` filter, gives portable idempotency without depending on either backend's catalog quirks.  Other ``SQLAlchemyError`` instances (permission denied, dialect bug, ...) still propagate so a real schema problem surfaces loudly.

``UniqueConstraint`` declarations attached to a
``Table`` (e.g. ``audit_events_idx_event_id`` on
:class:`AuditEvent`) are created with the table itself rather than via :class:`Index`, so they do not appear in ``table.indexes`` and the loop does not need to
special-case them: the ``Table.create(checkfirst=True)`` line above handles them as part of ``CREATE TABLE`` and short-circuits on every subsequent call.

Drop the audit override
=======================

With the base method generalised, the
``SQLDBAudit.ensure_indexes`` override added in round 7 of PR #1887 is now dead weight: it does exactly what the base does (one table, three composite indexes, same fail-loud / fail-soft contract).  Remove it; the audit class inherits unchanged behaviour.

Regression tests
================

``SQLDBAuditLiveIntegrationTests::test_ensure_indexes_is_idempotent`` stays in place (single-table coverage) -- its docstring is updated to point at the base class rather than the removed override.

New ``SQLDBAuthLiveIntegrationTests::test_ensure_indexes_is_idempotent_across_multiple_tables`` pins the cross-table contract on the auth purpose, which has five tables (``auth_user``, ``auth_session``,
``auth_api_key``, ``auth_rate_limit``,
``auth_magic_link``) and over a dozen declared
``Index`` blocks across them.  Single-table coverage (the audit purpose alone) would not exercise the outer
``for table in self.tables`` loop; this new test does.

Both tests pin the same two-phase contract:

* First call against an existing schema -- no ``already exists`` crash, existing rows preserved.
* Second call after a full drop -- schema and every declared index are recreated; the surface becomes functional again from an empty database.

Failing either test means SQL operators will see a traceback on the corresponding ``<purpose>cli
--ensure-indexes`` invocation.

Validation
==========

* ``pkg/runchecks`` clean (black / flake8 / bandit / mypy / codespell / pylint 10.00/10 / isort / rstcheck / sphinx-lint / shellcheck).
* SQL no-backend suites: 54/54 pass across ``SQLDBAudit*`` / ``SQLDBAuth*`` / ``DuckDBAuthTests`` / ``PostgresDBAuthTests``.

Out of scope
============

* The Mongo / Elastic backends already have working ``ensure_indexes``; no changes there.
* ``create_indexes()`` is a Mongo-only method on ``SQLDB`` too and stays unimplemented (no caller exercises it through the SQL backends).

Follow-ups from PR #1887 still queued: web-UI audit surfaces (#1 in the post-#1887 backlog), partial-index optimization on ``audit_events_idx_user_created`` (#2), Sphinx docs for ``ivre auditcli`` + ``/cgi/audit/*`` (#5).