### PR TITLE
fix(db/sql): make audit_events_idx_user_created partial on PostgreSQL

### DIFF
--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -47,7 +47,9 @@ methods win the MRO lookup against ``PostgresDB*``'s defaults.
 # pylint: disable=singleton-comparison
 
 
+import contextlib
 import re
+from collections.abc import Iterable, Iterator
 from typing import Any, override
 
 from sqlalchemy import (
@@ -193,6 +195,74 @@ def _is_unsupported_on_duckdb(index: Any) -> bool:
 # in child tables are not visible to the read paths (which
 # always project from ``scan`` joined to children); a periodic
 # vacuum can be wired in later if needed.
+
+
+@contextlib.contextmanager
+def _duckdb_metadata_rewrites(tables: Iterable[Any]) -> Iterator[None]:
+    """Temporarily strip declarations DuckDB rejects at create
+    time from ``tables``, restoring them on exit.
+
+    Three eviction passes mirror the schema rewrites the DuckDB
+    backend has always needed at ``init()`` time:
+
+    * unsupported indexes (GIN, partial ``postgresql_where``,
+      INET / ARRAY keys) -- see
+      :func:`_is_unsupported_on_duckdb`;
+    * table-level ``ForeignKeyConstraint`` objects -- DuckDB
+      rejects ``ON DELETE CASCADE`` (see the comment block
+      above) and the implicit ``RESTRICT`` fallback would break
+      IVRE's scan-rooted delete paths;
+    * column-level ``ForeignKey`` objects (e.g. ``Flow.src`` /
+      ``Flow.dst``) -- same rationale, different SQLAlchemy
+      attachment site.
+
+    Snapshots are taken before the strip and the originals are
+    re-attached in a ``finally`` block so other engines sharing
+    the same :data:`~ivre.db.sql.tables.Base.metadata` in the
+    same Python process (e.g. a parallel test against
+    PostgreSQL) keep their canonical declarations.
+
+    Shared by :meth:`DuckDBMixin.init` (full-metadata rewrite
+    around the drop / create cycle) and
+    :meth:`DuckDBMixin.ensure_indexes` (per-purpose rewrite
+    around the ``Table.create(checkfirst=True)`` + index loop
+    in :meth:`SQLDB.ensure_indexes`).
+    """
+    saved_indexes: dict[Any, list[Any]] = {}
+    saved_table_fkcs: dict[Any, set[Any]] = {}
+    saved_column_fks: dict[Any, set[Any]] = {}
+    # Materialise the iterable so the ``finally`` block can
+    # iterate it a second time (callers may pass a generator).
+    tables_list = list(tables)
+    try:
+        for table in tables_list:
+            skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
+            if skipped:
+                saved_indexes[table] = skipped
+                for ix in skipped:
+                    table.indexes.discard(ix)
+            if table.foreign_key_constraints:
+                saved_table_fkcs[table] = set(table.foreign_key_constraints)
+                for fkc in list(table.foreign_key_constraints):
+                    table.constraints.discard(fkc)
+            for col in table.columns:
+                if col.foreign_keys:
+                    saved_column_fks[col] = set(col.foreign_keys)
+                    for fk in list(col.foreign_keys):
+                        col.foreign_keys.discard(fk)
+                        table.foreign_keys.discard(fk)
+        yield
+    finally:
+        for table, indexes in saved_indexes.items():
+            for ix in indexes:
+                table.indexes.add(ix)
+        for table, fkcs in saved_table_fkcs.items():
+            for fkc in fkcs:
+                table.append_constraint(fkc)
+        for col, fks in saved_column_fks.items():
+            for fk in fks:
+                col.foreign_keys.add(fk)
+                col.table.foreign_keys.add(fk)
 
 
 class DuckDBMixin:
@@ -468,35 +538,14 @@ class DuckDBMixin:
         materialise a fresh engine -- and therefore a fresh
         DuckDB session -- which the subsequent :meth:`create`
         runs against without the catalog conflict.
+
+        The strip / restore of unsupported indexes and FK
+        constraints is delegated to
+        :func:`_duckdb_metadata_rewrites`, which is shared
+        with :meth:`ensure_indexes` so both schema-provision
+        paths apply the same set of DuckDB rewrites.
         """
-        saved_indexes: dict[Any, list[Any]] = {}
-        saved_table_fkcs: dict[Any, set[Any]] = {}
-        saved_column_fks: dict[Any, set[Any]] = {}
-        try:
-            for table in Base.metadata.tables.values():
-                skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
-                if skipped:
-                    saved_indexes[table] = skipped
-                    for ix in skipped:
-                        table.indexes.discard(ix)
-                # Snapshot then strip table-level FK constraints
-                # (``ForeignKeyConstraint(...)``) -- DuckDB
-                # cannot enforce ``ON DELETE CASCADE`` and the
-                # implicit ``RESTRICT`` would break IVRE's
-                # scan-rooted delete paths (see top-of-module
-                # comment).
-                if table.foreign_key_constraints:
-                    saved_table_fkcs[table] = set(table.foreign_key_constraints)
-                    for fkc in list(table.foreign_key_constraints):
-                        table.constraints.discard(fkc)
-                # Same treatment for column-level ``ForeignKey``
-                # objects (e.g. ``Flow.src`` / ``Flow.dst``).
-                for col in table.columns:
-                    if col.foreign_keys:
-                        saved_column_fks[col] = set(col.foreign_keys)
-                        for fk in list(col.foreign_keys):
-                            col.foreign_keys.discard(fk)
-                            table.foreign_keys.discard(fk)
+        with _duckdb_metadata_rewrites(Base.metadata.tables.values()):
             self.drop()
             # Recycle the engine before ``create()``: see the
             # docstring above for the catalog-conflict
@@ -516,42 +565,38 @@ class DuckDBMixin:
             # indexes that subsequent ``searchtext()`` calls
             # rebuild via ``overwrite=1`` once data is in.
             self._create_fts_indexes()
-        finally:
-            for table, indexes in saved_indexes.items():
-                for ix in indexes:
-                    table.indexes.add(ix)
-            for table, fkcs in saved_table_fkcs.items():
-                for fkc in fkcs:
-                    table.append_constraint(fkc)
-            for col, fks in saved_column_fks.items():
-                for fk in fks:
-                    col.foreign_keys.add(fk)
-                    col.table.foreign_keys.add(fk)
 
     @override
     def ensure_indexes(self) -> None:  # type: ignore[misc]
         """DuckDB override of :meth:`SQLDB.ensure_indexes`.
 
-        The base implementation iterates
-        ``table.__table__.indexes`` and calls
-        :meth:`Index.create` on every entry.  After
-        :meth:`init` returns, the in-process
-        :data:`~ivre.db.sql.tables.Base.metadata` once again
-        carries every declaration -- including the few
-        :func:`_is_unsupported_on_duckdb` rejects at create
-        time (GIN, partial ``postgresql_where``, INET / ARRAY
-        keys).  Calling the unfiltered base loop would re-emit
-        their DDL against the DuckDB catalog and crash, for
-        example, ``audit_events_idx_user_created`` on
-        :class:`~ivre.db.sql.tables.AuditEvent`.
+        The base implementation does two passes over
+        ``self.tables``: ``Table.create(checkfirst=True)`` on
+        every table, then :meth:`Index.create` on every index
+        attached to it.  After :meth:`init` returns, the
+        in-process :data:`~ivre.db.sql.tables.Base.metadata`
+        once again carries every declaration -- including the
+        few DuckDB rejects at create time:
 
-        Mirror the strip / restore pattern :meth:`init` uses:
-        evict the unsupported indexes from each table's
-        ``indexes`` set for the duration of the base call, then
-        put them back so other engines sharing the same
-        metadata in the same Python process (e.g. a parallel
-        test against PostgreSQL) keep their canonical
-        declarations.
+        * unsupported indexes (GIN, partial
+          ``postgresql_where``, INET / ARRAY keys) flagged by
+          :func:`_is_unsupported_on_duckdb` -- the base loop
+          would re-emit, for example,
+          ``audit_events_idx_user_created`` on
+          :class:`~ivre.db.sql.tables.AuditEvent` and crash;
+        * ``ON DELETE CASCADE`` foreign keys on the ``nmap`` /
+          ``view`` / ``flow`` tables -- the base
+          ``Table.create`` pass would re-emit them and
+          DuckDB raises ``Parser Error: FOREIGN KEY
+          constraints cannot use CASCADE, ...``.
+
+        Both rewrites are applied by
+        :func:`_duckdb_metadata_rewrites`, shared with
+        :meth:`init`.  The scope is narrowed to the current
+        purpose's ``self.tables`` (vs ``init()``'s
+        ``Base.metadata.tables.values()``) because only those
+        tables are touched by the base
+        :meth:`SQLDB.ensure_indexes` loops.
         """
         # Local import: same rationale as :meth:`db` above --
         # break the ``ivre.db.sql`` <-> ``ivre.db.sql.duckdb``
@@ -559,20 +604,8 @@ class DuckDBMixin:
         # pylint: disable=import-outside-toplevel
         from ivre.db.sql import SQLDB
 
-        saved_indexes: dict[Any, list[Any]] = {}
-        try:
-            for table_cls in self.tables:
-                table = table_cls.__table__
-                skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
-                if skipped:
-                    saved_indexes[table] = skipped
-                    for ix in skipped:
-                        table.indexes.discard(ix)
+        with _duckdb_metadata_rewrites(t.__table__ for t in self.tables):
             SQLDB.ensure_indexes(self)
-        finally:
-            for table, indexes in saved_indexes.items():
-                for ix in indexes:
-                    table.indexes.add(ix)
 
 
 class _DuckDBActiveFilterMixin:

--- a/ivre/db/sql/duckdb.py
+++ b/ivre/db/sql/duckdb.py
@@ -528,6 +528,52 @@ class DuckDBMixin:
                     col.foreign_keys.add(fk)
                     col.table.foreign_keys.add(fk)
 
+    @override
+    def ensure_indexes(self) -> None:  # type: ignore[misc]
+        """DuckDB override of :meth:`SQLDB.ensure_indexes`.
+
+        The base implementation iterates
+        ``table.__table__.indexes`` and calls
+        :meth:`Index.create` on every entry.  After
+        :meth:`init` returns, the in-process
+        :data:`~ivre.db.sql.tables.Base.metadata` once again
+        carries every declaration -- including the few
+        :func:`_is_unsupported_on_duckdb` rejects at create
+        time (GIN, partial ``postgresql_where``, INET / ARRAY
+        keys).  Calling the unfiltered base loop would re-emit
+        their DDL against the DuckDB catalog and crash, for
+        example, ``audit_events_idx_user_created`` on
+        :class:`~ivre.db.sql.tables.AuditEvent`.
+
+        Mirror the strip / restore pattern :meth:`init` uses:
+        evict the unsupported indexes from each table's
+        ``indexes`` set for the duration of the base call, then
+        put them back so other engines sharing the same
+        metadata in the same Python process (e.g. a parallel
+        test against PostgreSQL) keep their canonical
+        declarations.
+        """
+        # Local import: same rationale as :meth:`db` above --
+        # break the ``ivre.db.sql`` <-> ``ivre.db.sql.duckdb``
+        # cycle at module-load time.
+        # pylint: disable=import-outside-toplevel
+        from ivre.db.sql import SQLDB
+
+        saved_indexes: dict[Any, list[Any]] = {}
+        try:
+            for table_cls in self.tables:
+                table = table_cls.__table__
+                skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
+                if skipped:
+                    saved_indexes[table] = skipped
+                    for ix in skipped:
+                        table.indexes.discard(ix)
+            SQLDB.ensure_indexes(self)
+        finally:
+            for table, indexes in saved_indexes.items():
+                for ix in indexes:
+                    table.indexes.add(ix)
+
 
 class _DuckDBActiveFilterMixin:
     """Mixin overriding :meth:`ActiveFilter._text_predicate` for

--- a/ivre/db/sql/tables.py
+++ b/ivre/db/sql/tables.py
@@ -40,6 +40,7 @@ from sqlalchemy import (
     column,
     func,
     literal_column,
+    text,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import declarative_base, declared_attr, mapped_column
@@ -1216,10 +1217,39 @@ class AuditEvent(Base):
             "event_type",
             "created_at",
         ),
+        # Partial index: the per-user trail lookup (``WHERE
+        # actor_user_email = ? ORDER BY created_at DESC``) never
+        # benefits from rows where ``actor_user_email IS NULL``,
+        # but anonymous / ``REMOTE_USER``-less traffic produces
+        # exactly those rows in bulk (every public ``GET /scans``
+        # that trips ``WEB_MAXRESULTS`` records an
+        # ``oversize_query`` event with a ``NULL`` actor).
+        # Restricting the index to non-NULL emails cuts the
+        # index size to the cardinality of the audited-actors
+        # set rather than every audit event ever recorded,
+        # without changing the query plan -- the planner picks
+        # the partial index whenever the filter is sargable
+        # against the predicate.
+        #
+        # ``postgresql_where`` is a PostgreSQL-only DDL option;
+        # the duckdb-engine dialect inherits from PostgreSQL's
+        # but DuckDB itself raises ``NotImplementedException:
+        # Creating partial indexes is not supported currently``.
+        # :func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb`
+        # already recognises ``postgresql_where`` and strips
+        # such indexes from each table's ``__table__.indexes``
+        # at ``init()`` time on the DuckDB backend, so the SQL
+        # mirrors the MongoDB backend's
+        # ``partialFilterExpression`` on PostgreSQL (the
+        # production target) and degrades to a sequential scan
+        # on DuckDB (dev / test only, where audit volumes are
+        # tiny by construction).  Same precedent as the
+        # :class:`Passive` table's partial-unique indexes.
         Index(
             "audit_events_idx_user_created",
             "actor_user_email",
             "created_at",
+            postgresql_where=text("actor_user_email IS NOT NULL"),
         ),
         Index("audit_events_idx_created", "created_at"),
     )

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -16979,6 +16979,87 @@ class SQLDBAuditSchemaTests(unittest.TestCase):
         constraint_names = {c.name for c in AuditEvent.__table__.constraints if c.name}
         self.assertIn("audit_events_idx_event_id", constraint_names)
 
+    def test_audit_events_user_index_is_partial_on_postgres(self) -> None:
+        # ``audit_events_idx_user_created`` must restrict to
+        # rows where ``actor_user_email IS NOT NULL`` on
+        # PostgreSQL.  Anonymous / ``REMOTE_USER``-less
+        # traffic produces ``NULL`` actor emails in bulk
+        # (every public ``GET /scans`` that trips
+        # ``WEB_MAXRESULTS`` records an ``oversize_query``
+        # event with a ``NULL`` actor); indexing them would
+        # bloat the b-tree without helping any query, since
+        # the per-user trail lookup
+        # (``WHERE actor_user_email = ?``) is never sargable
+        # against ``NULL``.
+        #
+        # Pin both:
+        #
+        # * the declarative shape (``postgresql_where=...``
+        #   present on the SQLAlchemy ``Index`` kwargs), so a
+        #   future refactor that drops the kwarg surfaces
+        #   here rather than silently regressing on
+        #   production-grade Postgres deployments;
+        # * the compiled DDL on the ``postgresql`` dialect,
+        #   so a SQLAlchemy upgrade that changes how the
+        #   kwarg is rendered (e.g. quoting / casing /
+        #   parenthesisation) surfaces here as well.
+        #
+        # Mirrors the MongoDB backend's
+        # ``partialFilterExpression`` on
+        # ``actor.user_email: {"$type": "string"}``.
+        from sqlalchemy.dialects import postgresql
+        from sqlalchemy.schema import CreateIndex
+
+        from ivre.db.sql.tables import AuditEvent
+
+        indexes_by_name = {ix.name: ix for ix in AuditEvent.__table__.indexes}
+        user_idx = indexes_by_name["audit_events_idx_user_created"]
+        self.assertIn("postgresql_where", user_idx.kwargs)
+        self.assertIsNotNone(user_idx.kwargs["postgresql_where"])
+
+        ddl = str(CreateIndex(user_idx).compile(dialect=postgresql.dialect()))
+        self.assertIn("audit_events_idx_user_created", ddl)
+        # Be tolerant of whitespace / case variations a future
+        # SQLAlchemy could introduce; only pin the meaningful
+        # tokens.
+        self.assertRegex(
+            ddl,
+            r"WHERE\s+actor_user_email\s+IS\s+NOT\s+NULL",
+        )
+
+    def test_audit_events_user_index_is_stripped_on_duckdb(self) -> None:
+        # ``_is_unsupported_on_duckdb`` (the DuckDB ``init()``
+        # filter) explicitly recognises ``postgresql_where``
+        # and evicts the index from the table's ``indexes``
+        # set, because DuckDB raises
+        # ``NotImplementedException: Creating partial indexes
+        # is not supported currently`` if the DDL reaches it.
+        #
+        # Pinning the recogniser here catches a future drop
+        # of the ``postgresql_where`` kwarg detector
+        # immediately rather than at the next ``ivre auditcli
+        # --init`` against a DuckDB file, where a partial
+        # index gets emitted unconditionally and the init
+        # crashes.
+        from ivre.db.sql.duckdb import _is_unsupported_on_duckdb
+        from ivre.db.sql.tables import AuditEvent
+
+        indexes_by_name = {ix.name: ix for ix in AuditEvent.__table__.indexes}
+        user_idx = indexes_by_name["audit_events_idx_user_created"]
+        self.assertTrue(_is_unsupported_on_duckdb(user_idx))
+
+        # The two other audit indexes are plain b-trees and
+        # must remain supported on DuckDB (per-event-type
+        # trail + generic time-window scan).
+        for plain_idx_name in (
+            "audit_events_idx_type_created",
+            "audit_events_idx_created",
+        ):
+            with self.subTest(idx=plain_idx_name):
+                self.assertFalse(
+                    _is_unsupported_on_duckdb(indexes_by_name[plain_idx_name])
+                )
+
     def test_sqldbaudit_table_layout_wires_events(self) -> None:
         from ivre.db.sql import SQLDBAudit
         from ivre.db.sql.tables import AuditEvent
@@ -17024,11 +17105,33 @@ class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
     def setUp(self) -> None:
         from urllib.parse import urlparse
 
-        from ivre.db.sql.duckdb import DuckDBAudit
+        from ivre.db.sql.duckdb import DuckDBAudit, _is_unsupported_on_duckdb
         from ivre.db.sql.tables import AuditEvent, Base
 
         self._audit = DuckDBAudit(urlparse("duckdb:///:memory:"))
-        Base.metadata.create_all(self._audit.db, tables=[AuditEvent.__table__])
+        # Mirror what :meth:`DuckDBMixin.init` does at the
+        # full-backend level: evict indexes DuckDB rejects
+        # at create-time (currently the ``postgresql_where``
+        # partial index ``audit_events_idx_user_created``)
+        # before ``create_all`` reaches the catalog.  Save +
+        # restore in ``tearDown`` so other tests sharing the
+        # same metadata see the original declarations.
+        table = AuditEvent.__table__
+        self._duckdb_skipped = [
+            ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)
+        ]
+        for ix in self._duckdb_skipped:
+            table.indexes.discard(ix)
+        Base.metadata.create_all(self._audit.db, tables=[table])
+
+    def tearDown(self) -> None:
+        # Restore the partial-index declaration so a Postgres-
+        # dialect compile / schema test running later in the
+        # same process sees the canonical metadata.
+        from ivre.db.sql.tables import AuditEvent
+
+        for ix in getattr(self, "_duckdb_skipped", ()):
+            AuditEvent.__table__.indexes.add(ix)
 
     def test_record_returns_event_id(self) -> None:
         event_id = self._audit.record(

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -17021,10 +17021,15 @@ class SQLDBAuditSchemaTests(unittest.TestCase):
         self.assertIn("audit_events_idx_user_created", ddl)
         # Be tolerant of whitespace / case variations a future
         # SQLAlchemy could introduce; only pin the meaningful
-        # tokens.
+        # tokens.  Lower-case the compiled DDL (and the regex
+        # tokens) so a release that emits ``where`` /
+        # ``is not null`` -- or any other casing -- still
+        # matches.  The ``\s+`` whitespace tolerance is
+        # preserved.
+        normalized_ddl = ddl.lower()
         self.assertRegex(
-            ddl,
-            r"WHERE\s+actor_user_email\s+IS\s+NOT\s+NULL",
+            normalized_ddl,
+            r"where\s+actor_user_email\s+is\s+not\s+null",
         )
 
     def test_audit_events_user_index_is_stripped_on_duckdb(self) -> None:

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -17397,6 +17397,74 @@ class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
         self.assertEqual(self._audit.count(), 1)
 
 
+@unittest.skipUnless(
+    _HAVE_SQLDB_AUDIT and _HAVE_DUCKDB_ENGINE_FOR_AUDIT,
+    "duckdb-engine is required (install with the ``duckdb`` extras)",
+)
+class DuckDBEnsureIndexesFkStripTests(unittest.TestCase):
+    """Regression for :meth:`DuckDBMixin.ensure_indexes`'s
+    foreign-key strip path.
+
+    Purposes carrying ``ondelete='CASCADE'`` foreign-key
+    constraints (``nmap`` / ``view`` -- see
+    :mod:`ivre.db.sql.tables`) reach DuckDB through
+    ``Table.create(checkfirst=True)`` on the first pass of
+    :meth:`SQLDB.ensure_indexes`.  DuckDB rejects ``CASCADE``
+    (``Parser Error: FOREIGN KEY constraints cannot use
+    CASCADE, SET NULL or SET DEFAULT``); the override must
+    strip the FK declarations for the duration of the call,
+    in lockstep with what :meth:`DuckDBMixin.init` does.
+
+    Pin both halves:
+
+    * the call against a fresh DuckDB does not raise,
+    * the metadata is restored on exit so PostgreSQL-flavoured
+      schema tests running later in the same process still see
+      the canonical ``ForeignKeyConstraint`` declarations.
+    """
+
+    def test_ensure_indexes_strips_cascade_fks_on_nmap(self) -> None:
+        from urllib.parse import urlparse
+
+        from ivre.db.sql.duckdb import DuckDBNmap
+        from ivre.db.sql.tables import N_Port
+
+        # Pre-flight: the cascade FKCs we expect to crash on
+        # must actually be declared, otherwise this test would
+        # pass trivially after a future refactor that removes
+        # them.
+        cascade_fkcs_before = [
+            fkc
+            for fkc in N_Port.__table__.foreign_key_constraints
+            if fkc.ondelete == "CASCADE"
+        ]
+        self.assertTrue(
+            cascade_fkcs_before,
+            "N_Port is expected to carry ON DELETE CASCADE FKs",
+        )
+
+        db = DuckDBNmap(urlparse("duckdb:///:memory:"))
+        # Must not raise.  Before the FK strip was wired into
+        # the override, this crashed in the base
+        # ``Table.create(checkfirst=True)`` pass.
+        db.ensure_indexes()
+
+        # Metadata restored.  Sibling tests (e.g. the audit
+        # schema tests above) rely on the canonical FK set
+        # being back on :class:`N_Port.__table__` after this
+        # class runs.
+        cascade_fkcs_after = [
+            fkc
+            for fkc in N_Port.__table__.foreign_key_constraints
+            if fkc.ondelete == "CASCADE"
+        ]
+        self.assertEqual(
+            len(cascade_fkcs_after),
+            len(cascade_fkcs_before),
+            "DuckDBMixin.ensure_indexes must restore stripped FKs",
+        )
+
+
 # ---------------------------------------------------------------------
 # DBAuditEventIdMongoSurfaceTests / DBAuditWebHookTests /
 # DBAuditWebRoutesTests / DBAuditMcpToolsTests /

--- a/tests/tests_no_backend.py
+++ b/tests/tests_no_backend.py
@@ -17113,25 +17113,28 @@ class SQLDBAuditLiveIntegrationTests(unittest.TestCase):
         # full-backend level: evict indexes DuckDB rejects
         # at create-time (currently the ``postgresql_where``
         # partial index ``audit_events_idx_user_created``)
-        # before ``create_all`` reaches the catalog.  Save +
-        # restore in ``tearDown`` so other tests sharing the
-        # same metadata see the original declarations.
+        # before ``create_all`` reaches the catalog, then put
+        # them back as soon as the table is materialised so
+        # the rest of the test runs against the same
+        # canonical metadata operators see after
+        # :meth:`DuckDBMixin.init` returns.  In particular,
+        # :meth:`test_ensure_indexes_is_idempotent` must
+        # exercise the post-init() state where the partial
+        # index is once again declared on the table -- that
+        # is the path the new
+        # :meth:`DuckDBMixin.ensure_indexes` override has to
+        # handle without crashing.  ``try`` / ``finally`` so
+        # an unexpected ``create_all`` failure still restores
+        # the metadata for tests later in the same process.
         table = AuditEvent.__table__
-        self._duckdb_skipped = [
-            ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)
-        ]
-        for ix in self._duckdb_skipped:
+        skipped = [ix for ix in table.indexes if _is_unsupported_on_duckdb(ix)]
+        for ix in skipped:
             table.indexes.discard(ix)
-        Base.metadata.create_all(self._audit.db, tables=[table])
-
-    def tearDown(self) -> None:
-        # Restore the partial-index declaration so a Postgres-
-        # dialect compile / schema test running later in the
-        # same process sees the canonical metadata.
-        from ivre.db.sql.tables import AuditEvent
-
-        for ix in getattr(self, "_duckdb_skipped", ()):
-            AuditEvent.__table__.indexes.add(ix)
+        try:
+            Base.metadata.create_all(self._audit.db, tables=[table])
+        finally:
+            for ix in skipped:
+                table.indexes.add(ix)
 
     def test_record_returns_event_id(self) -> None:
         event_id = self._audit.record(


### PR DESCRIPTION
Follow-up to the Copilot nit on PR #1885 (carried as item #2 of the post-#1887 backlog).  The MongoDB backend already restricts the per-user audit-trail index via
``partialFilterExpression={ "actor.user_email":
{ "$type": "string" } }``; the SQL side was a plain b-tree on (actor_user_email, created_at)``, which
indexes every anonymous / ``REMOTE_USER``-less event under the NULL`` key.

Anonymous traffic produces those NULL-actor rows in bulk: every public GET /scans`` that trips WEB_MAXRESULTS`` records an oversize_query`` event with a NULL actor. On a production-scale Postgres deployment the index can balloon by orders of magnitude over what the per-user trail lookup actually needs -- the WHERE
actor_user_email = ?`` predicate is never sargable against NULL anyway, so those rows are pure overhead.

The fix
=======

Add postgresql_where=text("actor_user_email IS NOT NULL")`` to the Index`` declaration in
:class:`AuditEvent`.  SQLAlchemy emits

  CREATE INDEX audit_events_idx_user_created
  ON audit_events (actor_user_email, created_at)
  WHERE actor_user_email IS NOT NULL

on PostgreSQL, matching the MongoDB
partialFilterExpression`` semantically: the index is restricted to the cardinality of the audited-actors set rather than every audit event ever recorded.

DuckDB handling
===============

DuckDB itself rejects partial indexes at create-time with NotImplementedException: Creating partial indexes is not supported currently``, and duckdb-engine``
inherits PostgreSQL's DDL compiler so the WHERE clause would still reach the catalog.  The existing
:func:`ivre.db.sql.duckdb._is_unsupported_on_duckdb` filter already recognises postgresql_where`` (in lockstep with the GIN / INET / ARRAY exclusions) and evicts the index from each table's __table__.indexes`` set at init()`` time, so the partial declaration degrades cleanly to "no index on (actor_user_email, created_at)" on DuckDB rather than crashing the init.

The DuckDB degradation is acceptable: this backend is the dev / test target where audit volumes are tiny by construction (a developer runs at most thousands of audited events, where a sequential scan over
audit_events`` finishes in microseconds).  Same
precedent as the partial unique indexes on the
:class:`Passive` table.

Test fixture update
===================

``SQLDBAuditLiveIntegrationTests`` builds the schema directly via Base.metadata.create_all(...,
tables=[AuditEvent.__table__])`` to keep the fixture small.  That code path bypasses the full
:meth:`DuckDBMixin.init` flow, so the partial-index declaration would reach the DuckDB catalog and crash every test in the class.  Mirror the eviction in the fixture's setUp`` (save the unsupported indexes via _is_unsupported_on_duckdb``, discard them from the table's indexes`` set before create_all``) and
restore them in tearDown`` so a Postgres-dialect
compile / schema test running later in the same process still sees the canonical metadata.

Regression tests
================

New pins in SQLDBAuditSchemaTests``:

* ``test_audit_events_user_index_is_partial_on_postgres`` -- two-layer pin against silent regressions:

  1. The declarative shape: postgresql_where`` is present on the SQLAlchemy Index`` kwargs and non-None.  Catches a refactor that drops the kwarg.
  2. The compiled DDL on the postgresql`` dialect: the emitted CREATE INDEX ... WHERE actor_user_email IS NOT NULL`` clause is present.  Catches a SQLAlchemy upgrade that changes how postgresql_where`` is rendered.

  The DDL match is whitespace / case tolerant
  (\s+``) so a future SQLAlchemy quoting tweak does
  not trip the test gratuitously; only the meaningful
  tokens are pinned.

* ``test_audit_events_user_index_is_stripped_on_duckdb`` -- _is_unsupported_on_duckdb returns True`` for the partial index and False`` for the two other audit indexes (which must remain functional on DuckDB).  Catches a refactor that drops the postgresql_where`` recogniser in the DuckDB predicate, which would otherwise surface as a runtime crash on the next ivre auditcli --init`` against a DuckDB file.

Validation
==========

* ``pkg/runchecks`` clean (black / flake8 / bandit / mypy / codespell / pylint 10.00/10 / isort / rstcheck / sphinx-lint / shellcheck).
* Audit no-backend suites: 108/108 pass across the full DBAudit / SQLDBAudit / DBAuditWeb* / DBAuditCli* / AuditMcpTools / PostNmapAuditDetails class set.
* SQL no-backend regression: schema tests + live integration on DuckDB are clean; the partial index is emitted as expected on the PostgreSQL DDL compile path and stripped cleanly on the DuckDB catalog path.

Out of scope
============

* MongoDB audit_events`` indexes already carry the equivalent partialFilterExpression`` (see :class:`MongoDBAudit.indexes`); no Mongo change.
* No schema migration: this PR follows directly on the initial audit landing (#1885 / #1887), so existing deployments are expected to re-run ivre auditcli --init`` once.  The :meth:`SQLDB.ensure_indexes` generalisation in commit 03fa11d1 makes the index swap idempotent for operators who prefer to drop + recreate the index without dropping the table.