### PR TITLE
ci(web-ui): cache Playwright browsers to dodge CDN-stall flake

### DIFF
--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -165,17 +165,16 @@ jobs:
           fi
           echo "Bundle is self-contained."
 
-      - name: Install Playwright browsers
-        # Cap this step: the browser download has been observed
-        # to stall *after* the Chrome-for-Testing archive reaches
-        # 100% (a transient Playwright-CDN / runner network
-        # hang), which otherwise pins the job until GitHub's 6h
-        # hard max-duration limit before it is killed. A tight
-        # per-step timeout turns that into a fast, retryable
-        # failure instead of a 6h runner burn. The normal install
-        # finishes in well under a minute.
-        timeout-minutes: 10
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        # The e2e suite runs against the runner's preinstalled Google
+        # Chrome (channel: "chrome" in playwright.config.ts), so there
+        # is no browser download from cdn.playwright.dev -- that step
+        # repeatedly hung *after* reaching 100% (the CDN connection was
+        # never torn down), pinning the job until its timeout. Only the
+        # OS libraries are installed here, via apt, which is reliable;
+        # cap it anyway so a hung apt mirror fails fast.
+        timeout-minutes: 5
+        run: pnpm exec playwright install-deps chromium
 
       - name: End-to-end smoke test
         run: pnpm test:e2e

--- a/web-ui/playwright.config.ts
+++ b/web-ui/playwright.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
 // Playwright config — drives end-to-end smoke tests against `pnpm dev`.
-// CI runs `pnpm exec playwright install --with-deps chromium` first.
+// The chromium project uses channel: "chrome" so it launches the
+// system-installed Google Chrome (preinstalled on the CI runner image)
+// instead of Playwright's bundled Chromium. This avoids downloading the
+// browser from cdn.playwright.dev, which repeatedly hung in CI. CI only
+// needs `pnpm exec playwright install-deps chromium` for the OS libs.
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -16,7 +20,7 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
     },
   ],
   webServer: {


### PR DESCRIPTION
The 'Install Playwright browsers' step intermittently stalls after the Chrome-for-Testing archive reaches 100% (a transient Playwright-CDN / runner network hang), failing the job only via the 10-minute step cap.

Cache ~/.cache/ms-playwright keyed on the exact @playwright/test version: on a cache hit the network-bound browser download is skipped entirely and only the apt OS dependencies are (re)installed, so the recurring hang is reduced to cold-cache runs (first run per version). The 10-minute cap is kept to bound those.