### PR TITLE
doc(web-api): fix inline-literal warning in two route docstrings

### DIFF
--- a/ivre/web/app.py
+++ b/ivre/web/app.py
@@ -828,8 +828,9 @@ def get_flow():
                        ``config.WEB_GRAPH_LIMIT`` (1000)
          - ``skip``    pagination offset; defaults to ``0``
          - ``mode``    ``default`` / ``flow_map`` / ``talk_map``
-         - ``count``   ``true`` returns ``{clients, servers,
-                       flows}`` instead of the graph
+         - ``count``   ``true`` returns
+                       ``{clients, servers, flows}`` instead of
+                       the graph
          - ``orderby`` ``src`` / ``dst`` / ``flow`` (or unset)
          - ``timeline`` ``true`` embeds ``data.meta.times`` per edge
          - ``before`` / ``after``  ``"YYYY-MM-DD HH:MM"`` time bounds
@@ -2177,8 +2178,8 @@ def get_note_revisions(entity_type: str, entity_key: str):
 
     :param str entity_type: entity type
     :param str entity_key: caller-facing entity key
-    :status 200: JSON array of ``{revision, body, created_at,
-        created_by}`` entries
+    :status 200: JSON array of
+        ``{revision, body, created_at, created_by}`` entries
     :status 400: invalid entity_type / entity_key
     :status 404: ``notes`` module is not exposed by
         ``WEB_MODULES``

--- a/web/static/doc/dev/web-api.html
+++ b/web/static/doc/dev/web-api.html
@@ -370,7 +370,8 @@ node or edge instead of a graph.</p>
 <li><p><code class="docutils literal notranslate"><span class="pre">skip</span></code>    pagination offset; defaults to <code class="docutils literal notranslate"><span class="pre">0</span></code></p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">mode</span></code>    <code class="docutils literal notranslate"><span class="pre">default</span></code> / <code class="docutils literal notranslate"><span class="pre">flow_map</span></code> / <code class="docutils literal notranslate"><span class="pre">talk_map</span></code></p></li>
 <li><dl class="simple">
-<dt><code class="docutils literal notranslate"><span class="pre">count</span></code>   <code class="docutils literal notranslate"><span class="pre">true</span></code> returns <a href="#id1"><span class="problematic" id="id2">``</span></a>{clients, servers,</dt><dd><p>flows}`` instead of the graph</p>
+<dt><code class="docutils literal notranslate"><span class="pre">count</span></code>   <code class="docutils literal notranslate"><span class="pre">true</span></code> returns</dt><dd><p><code class="docutils literal notranslate"><span class="pre">{clients,</span> <span class="pre">servers,</span> <span class="pre">flows}</span></code> instead of
+the graph</p>
 </dd>
 </dl>
 </li>
@@ -952,8 +953,8 @@ create-only collision</p></li>
 </dd>
 <dt class="field-even">Status Codes<span class="colon">:</span></dt>
 <dd class="field-even"><ul class="simple">
-<li><p><span><a class="reference external" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200">200 OK</a></span> – JSON array of <code class="docutils literal notranslate"><span class="pre">{revision,</span> <span class="pre">body,</span> <span class="pre">created_at,</span>
-<span class="pre">created_by}</span></code> entries</p></li>
+<li><p><span><a class="reference external" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200">200 OK</a></span> – JSON array of
+<code class="docutils literal notranslate"><span class="pre">{revision,</span> <span class="pre">body,</span> <span class="pre">created_at,</span> <span class="pre">created_by}</span></code> entries</p></li>
 <li><p><span><a class="reference external" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/400">400 Bad Request</a></span> – invalid entity_type / entity_key</p></li>
 <li><p><span><a class="reference external" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/404">404 Not Found</a></span> – <code class="docutils literal notranslate"><span class="pre">notes</span></code> module is not exposed by
 <code class="docutils literal notranslate"><span class="pre">WEB_MODULES</span></code></p></li>


### PR DESCRIPTION
The Sphinx build emitted 'doc/dev/web-api.rst:145: WARNING: Inline literal start-string without end-string' on every run. Two route docstrings (get_flow, get_note_revisions) split a double-backtick inline literal across a line break -- {clients, servers,\nflows} and {revision, body, created_at,\ncreated_by} -- which the autobottle-rendered field bodies could not parse.

Reword both so each inline literal stays on a single physical line (breaking before the literal instead). Regenerate web/static/doc/. 'pkg/builddocs' now reports 'La compilation a réussi.' with no warnings; 'pkg/runchecks' (incl. rstcheck / sphinx-lint) clean.